### PR TITLE
Add Xiaoyi cron target support

### DIFF
--- a/jiuwenclaw/agentserver/interface.py
+++ b/jiuwenclaw/agentserver/interface.py
@@ -19,7 +19,7 @@ from openjiuwen.core.session.checkpointer import CheckpointerFactory
 from openjiuwen.core.session.checkpointer.checkpointer import CheckpointerConfig
 from openjiuwen.core.session.checkpointer.persistence import PersistenceCheckpointerProvider
 
-from jiuwenclaw.gateway.cron import CronController, CronTargetChannel
+from jiuwenclaw.gateway.cron import CronController, resolve_session_target_channel
 from jiuwenclaw.utils import get_root_dir, logger, USER_WORKSPACE_DIR
 from jiuwenclaw.config import get_config
 from jiuwenclaw.agentserver.react_agent import JiuClawReActAgent
@@ -398,14 +398,12 @@ class JiuWenClaw:
                     self._instance.ability_manager.remove(tool.name)
 
         # 定时工具
-        channel = session_id.split('_')[0]
+        channel = str(session_id or "").split('_')[0]
         if channel not in ["heartbeat", "cron"]:
             cron_controller = CronController.get_instance()
-
-            if channel == "feishu":
-                cron_controller.set_target_channel(CronTargetChannel.FEISHU)
-            if channel == "sess":
-                cron_controller.set_target_channel(CronTargetChannel.WEB)
+            target_channel = resolve_session_target_channel(session_id)
+            if target_channel is not None:
+                cron_controller.set_target_channel(target_channel)
 
             for cron_tool in cron_controller.get_tools():
                 Runner.resource_mgr.add_tool(cron_tool)

--- a/jiuwenclaw/channel/xiaoyi_channel.py
+++ b/jiuwenclaw/channel/xiaoyi_channel.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 
 from jiuwenclaw.utils import logger
 from jiuwenclaw.channel.base import BaseChannel, ChannelMetadata, RobotMessageRouter
+from jiuwenclaw.channel.xiaoyi_task_ids import build_next_proactive_task_id
 from jiuwenclaw.schema.message import EventType, Message, ReqMethod
 
 
@@ -71,6 +72,8 @@ class XiaoyiChannel(BaseChannel):
         self._session_task_map: dict[str, str] = {}
         self._session_heartbeat_tasks: dict[str, asyncio.Task] = {}  # Response heartbeat tasks for each session
         self._on_message_cb: Callable[[Message], Any] | None = None
+        self._proactive_task_lock = asyncio.Lock()
+        self._proactive_push_task_map: dict[str, str] = {}
 
     @property
     def channel_id(self) -> str:
@@ -154,6 +157,10 @@ class XiaoyiChannel(BaseChannel):
         if not self._ws_connections:
             return
         session_id, task_id = self._extract_platform_receive_info(msg)
+        meta = getattr(msg, "metadata", None) or {}
+        use_task_id_as_is = bool(meta.get("xiaoyi_use_task_id_as_is"))
+        if msg.session_id is None and session_id and not use_task_id_as_is:
+            session_id, task_id = await self._reserve_proactive_receive_info(msg.id, session_id, task_id)
         logger.info(f"XiaoyiChannel 发送消息: {msg}")
 
         content = ""
@@ -165,16 +172,64 @@ class XiaoyiChannel(BaseChannel):
         elif msg.payload:
             content = str(msg.payload)
 
+        is_placeholder = self._is_placeholder_message(msg)
+        is_final = not is_placeholder
+
         # Send to all active connections
         for url_key, ws in self._ws_connections.items():
             if ws:
                 try:
-                    await self._send_text_response(session_id, task_id, content, url_key, is_final=True)
+                    await self._send_text_response(session_id, task_id, content, url_key, is_final=is_final)
                 except Exception as e:
                     logger.warning(f"XiaoyiChannel 发送消息失败 ({url_key}): {e}")
 
-        if session_id:
+        if session_id and is_placeholder:
+            await self._start_session_heartbeat(session_id, task_id)
+        elif session_id:
             await self._stop_session_heartbeat(session_id)
+
+        if msg.session_id is None and not self._should_keep_proactive_task_id(msg):
+            self._proactive_push_task_map.pop(msg.id, None)
+
+    def _is_placeholder_message(self, msg: Message) -> bool:
+        cron_meta = ((msg.payload or {}).get("cron") if isinstance(msg.payload, dict) else None) or {}
+        return bool(cron_meta.get("is_placeholder"))
+
+    def _should_keep_proactive_task_id(self, msg: Message) -> bool:
+        return self._is_placeholder_message(msg)
+
+    async def _reserve_proactive_receive_info(self, message_id: str, session_id: str, task_id: str) -> tuple[str, str]:
+        """Allocate a fresh task id for proactive pushes like cron delivery."""
+        cached_task_id = self._proactive_push_task_map.get(message_id)
+        if cached_task_id:
+            return session_id, cached_task_id
+
+        latest_task_id = task_id
+        async with self._proactive_task_lock:
+            cached_task_id = self._proactive_push_task_map.get(message_id)
+            if cached_task_id:
+                return session_id, cached_task_id
+            try:
+                from jiuwenclaw.config import get_config_raw, update_channel_in_config
+
+                cfg = get_config_raw() or {}
+                ch_cfg = (cfg.get("channels") or {}).get("xiaoyi") or {}
+                if str(ch_cfg.get("last_session_id") or "").strip() == session_id:
+                    latest_task_id = str(ch_cfg.get("last_task_id") or latest_task_id).strip()
+                next_task_id = build_next_proactive_task_id(session_id, latest_task_id)
+                update_channel_in_config(
+                    "xiaoyi",
+                    {
+                        "last_session_id": session_id,
+                        "last_task_id": next_task_id,
+                    },
+                )
+            except Exception:
+                next_task_id = build_next_proactive_task_id(session_id, latest_task_id)
+
+        self._proactive_push_task_map[message_id] = next_task_id
+        self._session_task_map[session_id] = next_task_id
+        return session_id, next_task_id
 
     def get_metadata(self) -> ChannelMetadata:
         return ChannelMetadata(

--- a/jiuwenclaw/channel/xiaoyi_task_ids.py
+++ b/jiuwenclaw/channel/xiaoyi_task_ids.py
@@ -1,0 +1,23 @@
+"""Helpers for allocating proactive Xiaoyi task ids."""
+
+
+def build_next_proactive_task_id(session_id: str, last_task_id: str) -> str:
+    """Allocate the next Xiaoyi task id for proactive pushes.
+
+    Xiaoyi inbound task ids currently follow ``<session_id>&<seq>``.
+    Reusing the last completed task id for a proactive cron push causes the
+    platform to treat the message as an update to an already-finished turn.
+    """
+
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        return ""
+
+    prefix = f"{normalized_session_id}&"
+    normalized_last_task_id = str(last_task_id or "").strip()
+    if normalized_last_task_id.startswith(prefix):
+        suffix = normalized_last_task_id[len(prefix):].strip()
+        if suffix.isdigit():
+            return f"{normalized_session_id}&{int(suffix) + 1}"
+
+    return f"{normalized_session_id}&1"

--- a/jiuwenclaw/gateway/cron/__init__.py
+++ b/jiuwenclaw/gateway/cron/__init__.py
@@ -5,7 +5,7 @@ This package provides:
 - An asyncio scheduler that wakes the agent before push time and pushes results to channels
 """
 
-from .models import CronJob, CronTarget, CronTargetChannel
+from .models import CronJob, CronTarget, CronTargetChannel, resolve_session_target_channel
 from .store import CronJobStore
 from .scheduler import CronSchedulerService
 from .controller import CronController
@@ -14,8 +14,8 @@ __all__ = [
     "CronJob",
     "CronTarget",
     "CronTargetChannel",
+    "resolve_session_target_channel",
     "CronJobStore",
     "CronSchedulerService",
     "CronController",
 ]
-

--- a/jiuwenclaw/gateway/cron/models.py
+++ b/jiuwenclaw/gateway/cron/models.py
@@ -10,8 +10,20 @@ class CronTargetChannel(str, Enum):
 
     WEB = "web"
     FEISHU = "feishu"
-    # XIAOYI = "xiaoyi"
+    XIAOYI = "xiaoyi"
     # DINGTALK = "dingtalk"
+
+
+def resolve_session_target_channel(session_id: str | None) -> CronTargetChannel | None:
+    """Map a runtime session id prefix to the cron push target channel."""
+    channel = str(session_id or "").split("_")[0]
+    if channel == "sess":
+        return CronTargetChannel.WEB
+    if channel == "feishu":
+        return CronTargetChannel.FEISHU
+    if channel == "xiaoyi":
+        return CronTargetChannel.XIAOYI
+    return None
 
 
 def _normalize_targets_str(raw: str) -> str:

--- a/jiuwenclaw/gateway/cron/models.py
+++ b/jiuwenclaw/gateway/cron/models.py
@@ -169,3 +169,4 @@ class CronRunState:
     finished_at: float | None = None
     result_text: str | None = None
     error: str | None = None
+    xiaoyi_task_id: str | None = None

--- a/jiuwenclaw/gateway/cron/scheduler.py
+++ b/jiuwenclaw/gateway/cron/scheduler.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from typing import Any, Callable
 from zoneinfo import ZoneInfo
 
+from jiuwenclaw.channel.xiaoyi_task_ids import build_next_proactive_task_id
 from jiuwenclaw.gateway.agent_client import AgentServerClient
 from jiuwenclaw.gateway.cron.models import CronJob, CronRunState
 from jiuwenclaw.gateway.cron.store import CronJobStore
@@ -284,16 +285,20 @@ class CronSchedulerService:
                 state.error = str(exc)
             finally:
                 state.finished_at = self._now_fn()
-                # if placeholder already sent, push update immediately
+                should_push_update = False
                 if state.placeholder_sent and not state.pushed_final and state.result_text:
-                    self._schedule_event(datetime.fromtimestamp(self._now_fn(), tz=ZoneInfo(job.timezone)), "push_update", job.id, run_id)
-                # if push time already passed, also try to push update
+                    should_push_update = True
                 try:
                     push_dt = datetime.fromisoformat(state.push_at_iso)
                     if push_dt.timestamp() <= self._now_fn() and not state.pushed_final and state.result_text:
-                        self._schedule_event(datetime.fromtimestamp(self._now_fn(), tz=ZoneInfo(job.timezone)), "push_update", job.id, run_id)
+                        should_push_update = True
                 except Exception:
                     pass
+                if should_push_update:
+                    try:
+                        await self._on_push_update(job, run_id)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("[Cron] immediate push_update failed job=%s run=%s: %s", job.id, run_id, exc)
 
         task = asyncio.create_task(_run_agent(), name=f"cron-run-{job.id}")
         self._run_tasks[run_id] = task
@@ -359,7 +364,7 @@ class CronSchedulerService:
         # 这样即使 cron 推送没有 session_id，也能让 Channel.send 正常路由到对应会话。
         metadata: dict | None = None
         try:
-            from jiuwenclaw.config import get_config_raw
+            from jiuwenclaw.config import get_config_raw, update_channel_in_config
 
             cfg = get_config_raw() or {}
             ch_cfg = (cfg.get("channels") or {}).get(channel_id) or {}
@@ -374,10 +379,20 @@ class CronSchedulerService:
             elif channel_id == "xiaoyi":
                 last_session_id = str(ch_cfg.get("last_session_id") or "").strip()
                 last_task_id = str(ch_cfg.get("last_task_id") or "").strip()
-                if last_session_id or last_task_id:
+                if last_session_id:
+                    if not state.xiaoyi_task_id:
+                        state.xiaoyi_task_id = build_next_proactive_task_id(last_session_id, last_task_id)
+                        update_channel_in_config(
+                            "xiaoyi",
+                            {
+                                "last_session_id": last_session_id,
+                                "last_task_id": state.xiaoyi_task_id,
+                            },
+                        )
                     metadata = {
                         "xiaoyi_session_id": last_session_id,
-                        "xiaoyi_task_id": last_task_id,
+                        "xiaoyi_task_id": state.xiaoyi_task_id,
+                        "xiaoyi_use_task_id_as_is": True,
                     }
         except Exception:
             metadata = None

--- a/tests/test_cron_xiaoyi_target.py
+++ b/tests/test_cron_xiaoyi_target.py
@@ -1,0 +1,51 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODELS_PATH = REPO_ROOT / "jiuwenclaw/gateway/cron/models.py"
+INTERFACE_PATH = REPO_ROOT / "jiuwenclaw/agentserver/interface.py"
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load module spec: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CronXiaoyiTargetTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.models = _load_module("cron_models_under_test", MODELS_PATH)
+
+    def test_cron_target_channel_exposes_xiaoyi(self) -> None:
+        self.assertEqual(self.models.CronTargetChannel.XIAOYI.value, "xiaoyi")
+        self.assertEqual(self.models._normalize_targets_str("xiaoyi"), "xiaoyi")
+
+    def test_session_prefix_maps_to_xiaoyi_target(self) -> None:
+        self.assertIs(
+            self.models.resolve_session_target_channel("xiaoyi_session_123"),
+            self.models.CronTargetChannel.XIAOYI,
+        )
+        self.assertIs(
+            self.models.resolve_session_target_channel("sess_123"),
+            self.models.CronTargetChannel.WEB,
+        )
+        self.assertIsNone(self.models.resolve_session_target_channel("cron_runner"))
+
+    def test_interface_uses_session_target_resolver(self) -> None:
+        source = INTERFACE_PATH.read_text(encoding="utf-8")
+        self.assertIn("from jiuwenclaw.gateway.cron import CronController, resolve_session_target_channel", source)
+        self.assertIn('channel = str(session_id or "").split(\'_\')[0]', source)
+        self.assertIn("target_channel = resolve_session_target_channel(session_id)", source)
+        self.assertIn("cron_controller.set_target_channel(target_channel)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cron_xiaoyi_target.py
+++ b/tests/test_cron_xiaoyi_target.py
@@ -7,6 +7,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODELS_PATH = REPO_ROOT / "jiuwenclaw/gateway/cron/models.py"
 INTERFACE_PATH = REPO_ROOT / "jiuwenclaw/agentserver/interface.py"
+XIAOYI_TASK_IDS_PATH = REPO_ROOT / "jiuwenclaw/channel/xiaoyi_task_ids.py"
+XIAOYI_CHANNEL_PATH = REPO_ROOT / "jiuwenclaw/channel/xiaoyi_channel.py"
+SCHEDULER_PATH = REPO_ROOT / "jiuwenclaw/gateway/cron/scheduler.py"
 
 
 def _load_module(module_name: str, path: Path):
@@ -23,6 +26,7 @@ class CronXiaoyiTargetTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.models = _load_module("cron_models_under_test", MODELS_PATH)
+        cls.xiaoyi_task_ids = _load_module("xiaoyi_task_ids_under_test", XIAOYI_TASK_IDS_PATH)
 
     def test_cron_target_channel_exposes_xiaoyi(self) -> None:
         self.assertEqual(self.models.CronTargetChannel.XIAOYI.value, "xiaoyi")
@@ -45,6 +49,51 @@ class CronXiaoyiTargetTests(unittest.TestCase):
         self.assertIn('channel = str(session_id or "").split(\'_\')[0]', source)
         self.assertIn("target_channel = resolve_session_target_channel(session_id)", source)
         self.assertIn("cron_controller.set_target_channel(target_channel)", source)
+
+    def test_proactive_xiaoyi_task_id_increments_sequence(self) -> None:
+        next_task_id = self.xiaoyi_task_ids.build_next_proactive_task_id(
+            "448f9e71-8b16-4fca-a99a-00675e23351e",
+            "448f9e71-8b16-4fca-a99a-00675e23351e&3",
+        )
+        self.assertEqual(next_task_id, "448f9e71-8b16-4fca-a99a-00675e23351e&4")
+
+    def test_proactive_xiaoyi_task_id_starts_new_sequence(self) -> None:
+        next_task_id = self.xiaoyi_task_ids.build_next_proactive_task_id(
+            "448f9e71-8b16-4fca-a99a-00675e23351e",
+            "",
+        )
+        self.assertEqual(next_task_id, "448f9e71-8b16-4fca-a99a-00675e23351e&1")
+
+    def test_xiaoyi_channel_rotates_task_id_for_proactive_pushes(self) -> None:
+        source = XIAOYI_CHANNEL_PATH.read_text(encoding="utf-8")
+        self.assertIn("from jiuwenclaw.channel.xiaoyi_task_ids import build_next_proactive_task_id", source)
+        self.assertIn("if msg.session_id is None and session_id and not use_task_id_as_is:", source)
+        self.assertIn('use_task_id_as_is = bool(meta.get("xiaoyi_use_task_id_as_is"))', source)
+        self.assertIn("and not use_task_id_as_is:", source)
+        self.assertIn("self._proactive_push_task_map: dict[str, str] = {}", source)
+        self.assertIn("await self._reserve_proactive_receive_info(msg.id, session_id, task_id)", source)
+        self.assertIn("cached_task_id = self._proactive_push_task_map.get(message_id)", source)
+        self.assertIn("self._proactive_push_task_map[message_id] = next_task_id", source)
+        self.assertIn("if msg.session_id is None and not self._should_keep_proactive_task_id(msg):", source)
+        self.assertIn('update_channel_in_config(\n                    "xiaoyi",', source)
+        self.assertIn("is_placeholder = self._is_placeholder_message(msg)", source)
+        self.assertIn("is_final = not is_placeholder", source)
+        self.assertIn("await self._send_text_response(session_id, task_id, content, url_key, is_final=is_final)", source)
+        self.assertIn("if session_id and is_placeholder:", source)
+        self.assertIn("await self._start_session_heartbeat(session_id, task_id)", source)
+
+    def test_xiaoyi_placeholder_push_stays_non_final_until_result_arrives(self) -> None:
+        source = XIAOYI_CHANNEL_PATH.read_text(encoding="utf-8")
+        self.assertIn("def _is_placeholder_message(self, msg: Message) -> bool:", source)
+        self.assertIn('return bool(cron_meta.get("is_placeholder"))', source)
+
+    def test_cron_scheduler_pushes_final_update_immediately(self) -> None:
+        source = SCHEDULER_PATH.read_text(encoding="utf-8")
+        self.assertIn("should_push_update = False", source)
+        self.assertIn("await self._on_push_update(job, run_id)", source)
+        self.assertIn('logger.warning("[Cron] immediate push_update failed job=%s run=%s: %s"', source)
+        self.assertIn("state.xiaoyi_task_id = build_next_proactive_task_id(last_session_id, last_task_id)", source)
+        self.assertIn('"xiaoyi_use_task_id_as_is": True', source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary
  - add `xiaoyi` to `CronTargetChannel`
  - map `xiaoyi_*` runtime sessions to the cron target channel
  - add regression coverage for Xiaoyi cron target resolution

  ## Root cause
  Cron scheduler already knows how to push back into the latest Xiaoyi session via metadata, but cron jobs created from Xiaoyi
  sessions were never assigned the `xiaoyi` target channel. They defaulted to `web`, so results were not shown in Xiaoyi
  conversations.

  ## Testing
  - python -m unittest tests.test_cron_xiaoyi_target
