### PR TITLE
fix(model-validate): retry with larger max_tokens for thinking models

### DIFF
--- a/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
@@ -875,10 +875,10 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                 response = await _probe(1)
             except Exception as first_exc:  # noqa: BLE001
                 logger.info(
-                    "[cli config.validate_model] max_tokens=1 failed, retrying with 16: %s",
+                    "[cli config.validate_model] max_tokens=1 failed, retrying with 256: %s",
                     first_exc,
                 )
-                response = await _probe(16)
+                response = await _probe(256)
         except Exception as exc:  # noqa: BLE001
             logger.warning("[cli config.validate_model] LLM probe failed: %s", exc)
             await channel.send_response(
@@ -896,6 +896,18 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             content = response.get("content", "")
         else:
             content = str(response)
+
+        if not (isinstance(content, str) and content.strip()):
+            try:
+                response = await _probe(256)
+                if hasattr(response, "content"):
+                    content = response.content
+                elif isinstance(response, dict):
+                    content = response.get("content", "")
+                else:
+                    content = str(response)
+            except Exception:  # noqa: BLE001
+                pass
 
         if not (isinstance(content, str) and content.strip()):
             await channel.send_response(

--- a/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
+++ b/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
@@ -869,7 +869,7 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
         if max_tokens_bounds is None:
             max_tokens_bounds = {
                 "infimum_max_tokens": 1,
-                "supremum_max_tokens": 16,
+                "supremum_max_tokens": 256,
             }
 
         if isinstance(max_tokens_bounds, dict):
@@ -971,6 +971,22 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
         has_valid_response = (isinstance(content, str) and content.strip()) or (
                 isinstance(reasoning_content, str) and reasoning_content.strip()
         )
+        if not has_valid_response:
+            try:
+                resp = await test_invoke(supremum_max_tokens)
+                if hasattr(resp, "content"):
+                    content = resp.content
+                elif isinstance(resp, dict):
+                    content = resp.get("content", "")
+                else:
+                    content = str(resp)
+                reasoning_content = getattr(resp, "reasoning_content", None) if hasattr(resp, "reasoning_content") else None
+                has_valid_response = (isinstance(content, str) and content.strip()) or (
+                    isinstance(reasoning_content, str) and reasoning_content.strip()
+                )
+            except Exception:  # noqa: BLE001
+                pass
+
         if not has_valid_response:
             await channel.send_response(
                 ws, req_id, ok=False,


### PR DESCRIPTION
## 关联 Issue

Closes #24

## 问题

模型连接测试（config.validate_model）对 thinking model（如 `vertex_ai/gemini-3.5-flash`）误报失败。

Thinking model 在 `max_tokens` 较小时，所有 token 都用于 reasoning，`content` 为空：
- `max_tokens=1`: content=None, completion_tokens=0
- `max_tokens=16`: content=None, reasoning_tokens=13, text_tokens=0
- `max_tokens=256`: content='Hello!...', reasoning_tokens=186, text_tokens=9 ✅

原代码有两个问题：
1. `supremum_max_tokens=16` 对 thinking model 来说太小
2. 重试仅在异常时触发，"成功返回但 content 为空"不触发重试

## 改动

**`app_web_handlers.py`（Web 版）**：
- `supremum_max_tokens` 从 16 → 256
- 在 `has_valid_response` 为 false 时，用 `supremum_max_tokens` 重试一次

**`tui_connect.py`（TUI 版）**：
- 异常重试的 `max_tokens` 从 16 → 256
- 在 content 为空时，用 256 重试一次

## 测试

已通过 `openjiuwen` SDK 的 `Model` 类端到端验证：
```
max_tokens=1:   content='',                              valid=False
max_tokens=256: content='Hello! How can I help you today?', valid=True
```