### PR TITLE
fix(gateway): split think tags from chat content

### DIFF
--- a/jiuwenswarm/common/think_tags.py
+++ b/jiuwenswarm/common/think_tags.py
@@ -1,0 +1,133 @@
+"""Utilities for splitting MiniMax-style ``<think>`` content blocks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+ThinkPartKind = Literal["text", "reasoning"]
+
+
+@dataclass(frozen=True)
+class ThinkTagPart:
+    kind: ThinkPartKind
+    content: str
+
+
+def _trailing_prefix_len(text: str, marker: str) -> int:
+    """Return the suffix length that may be the start of ``marker``."""
+    lower_text = text.lower()
+    marker = marker.lower()
+    max_len = min(len(lower_text), len(marker) - 1)
+    for size in range(max_len, 0, -1):
+        if marker.startswith(lower_text[-size:]):
+            return size
+    return 0
+
+
+class ThinkTagStreamParser:
+    """Incrementally split ``<think>...</think>`` blocks from visible text.
+
+    Some OpenAI-compatible providers, notably MiniMax-M2.7, encode model
+    reasoning inside the regular content stream. This parser keeps partial tags
+    buffered across chunks so raw tag fragments are not leaked to users.
+    """
+
+    _OPEN_PREFIX = "<think"
+    _CLOSE_TAG = "</think>"
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._in_reasoning = False
+
+    @property
+    def has_pending(self) -> bool:
+        return bool(self._buffer or self._in_reasoning)
+
+    def feed(self, text: str) -> list[ThinkTagPart]:
+        if not text:
+            return []
+        self._buffer += text
+        return self._drain(complete=False)
+
+    def flush(self) -> list[ThinkTagPart]:
+        return self._drain(complete=True)
+
+    def _find_open_tag(self, lower: str) -> int:
+        start = 0
+        while True:
+            idx = lower.find(self._OPEN_PREFIX, start)
+            if idx < 0:
+                return -1
+            next_idx = idx + len(self._OPEN_PREFIX)
+            if next_idx >= len(lower) or lower[next_idx].isspace() or lower[next_idx] == ">":
+                return idx
+            start = idx + 1
+
+    def _drain(self, *, complete: bool) -> list[ThinkTagPart]:
+        parts: list[ThinkTagPart] = []
+
+        while self._buffer:
+            lower = self._buffer.lower()
+            if self._in_reasoning:
+                close_idx = lower.find(self._CLOSE_TAG)
+                if close_idx < 0:
+                    hold = 0 if complete else _trailing_prefix_len(self._buffer, self._CLOSE_TAG)
+                    emit_len = len(self._buffer) - hold
+                    if emit_len > 0:
+                        parts.append(ThinkTagPart("reasoning", self._buffer[:emit_len]))
+                        self._buffer = self._buffer[emit_len:]
+                    break
+
+                if close_idx > 0:
+                    parts.append(ThinkTagPart("reasoning", self._buffer[:close_idx]))
+                self._buffer = self._buffer[close_idx + len(self._CLOSE_TAG):]
+                self._in_reasoning = False
+                continue
+
+            open_idx = self._find_open_tag(lower)
+            orphan_close_idx = lower.find(self._CLOSE_TAG)
+            if orphan_close_idx >= 0 and (open_idx < 0 or orphan_close_idx < open_idx):
+                if orphan_close_idx > 0:
+                    parts.append(ThinkTagPart("reasoning", self._buffer[:orphan_close_idx]))
+                self._buffer = self._buffer[orphan_close_idx + len(self._CLOSE_TAG):]
+                self._in_reasoning = False
+                continue
+
+            if open_idx < 0:
+                hold = 0 if complete else _trailing_prefix_len(self._buffer, self._OPEN_PREFIX)
+                emit_len = len(self._buffer) - hold
+                if emit_len > 0:
+                    parts.append(ThinkTagPart("text", self._buffer[:emit_len]))
+                    self._buffer = self._buffer[emit_len:]
+                break
+
+            if open_idx > 0:
+                parts.append(ThinkTagPart("text", self._buffer[:open_idx]))
+                self._buffer = self._buffer[open_idx:]
+                lower = self._buffer.lower()
+
+            tag_end = self._buffer.find(">")
+            if tag_end < 0:
+                if complete:
+                    self._buffer = ""
+                break
+            self._buffer = self._buffer[tag_end + 1:]
+            self._in_reasoning = True
+
+        if complete and self._buffer:
+            parts.append(ThinkTagPart("reasoning" if self._in_reasoning else "text", self._buffer))
+            self._buffer = ""
+            self._in_reasoning = False
+
+        return [part for part in parts if part.content]
+
+
+def split_think_tags(text: str) -> list[ThinkTagPart]:
+    parser = ThinkTagStreamParser()
+    return [*parser.feed(text), *parser.flush()]
+
+
+def strip_think_tags(text: str) -> str:
+    return "".join(part.content for part in split_think_tags(text) if part.kind == "text")

--- a/jiuwenswarm/gateway/im_pipeline/im_outbound.py
+++ b/jiuwenswarm/gateway/im_pipeline/im_outbound.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 _SKIP_EVENT_TYPES = frozenset({
     "chat.delta",
+    "chat.reasoning",
     "chat.tool_call",
     "chat.tool_result",
     "todo.updated",

--- a/jiuwenswarm/gateway/message_handler/message_handler.py
+++ b/jiuwenswarm/gateway/message_handler/message_handler.py
@@ -15,13 +15,15 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict
-from jiuwenswarm.gateway.channel_manager.base import ChannelType
+
 from jiuwenswarm.common.e2a.constants import E2A_WIRE_INTERNAL_METADATA_KEYS
-from jiuwenswarm.gateway.routing.session_map import SessionMap
+from jiuwenswarm.common.think_tags import ThinkTagPart, ThinkTagStreamParser
+from jiuwenswarm.gateway.channel_manager.base import ChannelType
 from jiuwenswarm.gateway.message_handler.command_parser.slash_command import (
     ParsedControlAction,
     parse_channel_control_text,
 )
+from jiuwenswarm.gateway.routing.session_map import SessionMap
 from jiuwenswarm.extensions.hook_event import GatewayHookEvents
 from jiuwenswarm.extensions.hooks_context import GatewayChatHookContext
 
@@ -128,6 +130,7 @@ class MessageHandler(ABC):
         self._stream_metadata: dict[str, dict[str, Any] | None] = {}  # request_id -> request metadata
         self._stream_modes: dict[str, str] = {}  # request_id -> mode
         self._stream_emits_processing_status: dict[str, bool] = {}  # request_id -> emits chat.processing_status
+        self._think_tag_parsers: dict[str, ThinkTagStreamParser] = {}
         self._pending_evolution_approval: dict[str, str] = {}  # session_id -> approval_request_id
         self._queued_supplement_input: dict[str, dict[str, Any]] = {}  # session_id -> queued supplement payload
         self._session_last_user_query: dict[str, str] = {}
@@ -1168,6 +1171,11 @@ class MessageHandler(ABC):
 
     async def publish_robot_messages(self, msg: "Message") -> None:
         """将 Agent 响应放入 robot_messages 队列."""
+        for split_msg in self._split_think_tag_message(msg):
+            await self._enqueue_robot_message(split_msg)
+
+    async def _enqueue_robot_message(self, msg: "Message") -> None:
+        """Queue a robot message after outbound pipeline processing."""
         # Outbound Pipeline（数字分身出站路由）— 在入队前运行
         if self._outbound_pipeline is not None:
             try:
@@ -1176,9 +1184,144 @@ class MessageHandler(ABC):
                 logger.exception("Outbound pipeline error, message queued without routing")
         await self._robot_messages.put(msg)
 
+    @staticmethod
+    def _think_tag_parser_key(msg: "Message") -> str:
+        return "\x1f".join((str(msg.channel_id or ""), str(msg.session_id or ""), str(msg.id or "")))
+
+    @staticmethod
+    def _message_event_type(msg: "Message"):
+        from jiuwenswarm.common.schema.message import EventType
+
+        if msg.event_type is not None:
+            return msg.event_type
+        payload = msg.payload if isinstance(msg.payload, dict) else {}
+        event_type_raw = payload.get("event_type")
+        if isinstance(event_type_raw, str):
+            try:
+                return EventType(event_type_raw)
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _message_from_think_part(
+        msg: "Message",
+        part: ThinkTagPart,
+        *,
+        text_event_type,
+    ) -> "Message":
+        from jiuwenswarm.common.schema.message import EventType
+
+        if part.kind == "reasoning":
+            event_type = EventType.CHAT_REASONING
+            payload = {
+                "event_type": event_type.value,
+                "content": part.content,
+                "source_chunk_type": "llm_reasoning",
+            }
+            if msg.session_id:
+                payload["session_id"] = msg.session_id
+        else:
+            event_type = text_event_type
+            payload = dict(msg.payload or {})
+            payload["event_type"] = event_type.value
+            payload["content"] = part.content
+        return replace(msg, type="event", payload=payload, event_type=event_type)
+
+    def _split_think_tag_message(self, msg: "Message") -> list["Message"]:
+        """Split MiniMax-style ``<think>`` blocks out of visible chat text."""
+        from jiuwenswarm.common.schema.message import EventType
+
+        event_type = self._message_event_type(msg)
+        payload = msg.payload if isinstance(msg.payload, dict) else {}
+        source_chunk_type = str(payload.get("source_chunk_type") or "").strip().lower()
+
+        if event_type in (EventType.CHAT_ERROR, EventType.CHAT_PROCESSING_STATUS):
+            if event_type == EventType.CHAT_ERROR or payload.get("is_processing") is False:
+                self._think_tag_parsers.pop(self._think_tag_parser_key(msg), None)
+            return [msg]
+
+        if (
+            event_type not in (EventType.CHAT_DELTA, EventType.CHAT_FINAL)
+            or source_chunk_type == "llm_reasoning"
+        ):
+            return [msg]
+
+        content = payload.get("content")
+        if not isinstance(content, str) or not content:
+            if event_type == EventType.CHAT_FINAL:
+                parser = self._think_tag_parsers.pop(self._think_tag_parser_key(msg), None)
+                if parser is not None:
+                    flushed = [
+                        self._message_from_think_part(msg, part, text_event_type=EventType.CHAT_DELTA)
+                        for part in parser.flush()
+                        if part.content
+                    ]
+                    return [*flushed, msg]
+            return [msg]
+
+        key = self._think_tag_parser_key(msg)
+        parser = self._think_tag_parsers.get(key)
+        if parser is None and "<" not in content:
+            return [msg]
+        if parser is None:
+            parser = ThinkTagStreamParser()
+            self._think_tag_parsers[key] = parser
+
+        parts = parser.feed(content)
+        if event_type == EventType.CHAT_FINAL:
+            parts.extend(parser.flush())
+            self._think_tag_parsers.pop(key, None)
+        elif not parser.has_pending:
+            self._think_tag_parsers.pop(key, None)
+
+        if not parts:
+            return []
+
+        return [
+            self._message_from_think_part(msg, part, text_event_type=event_type)
+            for part in parts
+            if part.content
+        ]
+
+    async def _flush_think_tag_parser(
+        self,
+        *,
+        request_id: str,
+        channel_id: str,
+        session_id: str | None,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        from jiuwenswarm.common.schema.message import EventType, Message
+
+        key = "\x1f".join((str(channel_id or ""), str(session_id or ""), str(request_id or "")))
+        parser = self._think_tag_parsers.pop(key, None)
+        if parser is None:
+            return
+        parts = parser.flush()
+        if not parts:
+            return
+        base_msg = Message(
+            id=request_id,
+            type="event",
+            channel_id=channel_id,
+            session_id=session_id,
+            params={},
+            timestamp=time.time(),
+            ok=True,
+            payload={},
+            event_type=EventType.CHAT_DELTA,
+            metadata=metadata,
+        )
+        for part in parts:
+            await self._enqueue_robot_message(
+                self._message_from_think_part(base_msg, part, text_event_type=EventType.CHAT_DELTA)
+            )
+
     def publish_robot_messages_nowait(self, msg: "Message") -> None:
         """将 Agent 响应放入 robot_messages 队列（同步）."""
-        self._robot_messages.put_nowait(msg)
+        for split_msg in self._split_think_tag_message(msg):
+            self._robot_messages.put_nowait(split_msg)
 
     async def consume_robot_messages(self, timeout: float | None = None) -> "Message | None":
         """消费一条 robot_messages；timeout 为 None 则阻塞，否则超时返回 None."""
@@ -1595,6 +1738,12 @@ class MessageHandler(ABC):
             logger.debug(
                 "[MessageHandler] 忽略 server_push 终止 chunk: request_id=%s",
                 chunk.request_id,
+            )
+            await self._flush_think_tag_parser(
+                request_id=rid,
+                channel_id=chunk.channel_id,
+                session_id=session_id,
+                metadata=bus_metadata,
             )
             return
 
@@ -2507,6 +2656,12 @@ class MessageHandler(ABC):
                     "[MessageHandler] Stream chunk 已写入 robot_messages: request_id=%s event_type=%s",
                     chunk.request_id, out.event_type,
                 )
+            await self._flush_think_tag_parser(
+                request_id=rid,
+                channel_id=channel_id,
+                session_id=session_id,
+                metadata=request_metadata,
+            )
             logger.info(
                 "[MessageHandler] Stream 正常完成: request_id=%s",
                 rid,
@@ -2528,6 +2683,7 @@ class MessageHandler(ABC):
             self._stream_metadata.pop(rid, None)
             self._stream_emits_processing_status.pop(rid, None)
             self._stream_modes.pop(rid, None)
+            self._think_tag_parsers.pop("\x1f".join((channel_id, str(session_id or ""), rid)), None)
             if session_id is not None and session_id not in self._stream_sessions.values():
                 # Fallback cleanup when stream exits unexpectedly without evolution end signal.
                 self._clear_session_evolution_in_progress(session_id)

--- a/tests/unit_tests/gateway/test_message_handler_think_tags.py
+++ b/tests/unit_tests/gateway/test_message_handler_think_tags.py
@@ -1,0 +1,88 @@
+import pytest
+
+from jiuwenswarm.common.schema.message import EventType, Message
+
+pytest.importorskip("openjiuwen")
+
+from jiuwenswarm.gateway.message_handler.message_handler import MessageHandler
+
+
+class _FakeAgentClient:
+    pass
+
+
+def _new_handler() -> MessageHandler:
+    MessageHandler._instance = None
+    return MessageHandler(_FakeAgentClient())
+
+
+def _chat_msg(content: str, *, request_id: str = "req-1", event_type: EventType = EventType.CHAT_DELTA) -> Message:
+    return Message(
+        id=request_id,
+        type="event",
+        channel_id="web",
+        session_id="sess-1",
+        params={},
+        timestamp=1.0,
+        ok=True,
+        payload={"event_type": event_type.value, "content": content},
+        event_type=event_type,
+    )
+
+
+async def _drain(handler: MessageHandler) -> list[Message]:
+    out = []
+    while True:
+        msg = await handler.consume_robot_messages(timeout=0)
+        if msg is None:
+            return out
+        out.append(msg)
+
+
+@pytest.mark.asyncio
+async def test_publish_robot_messages_splits_complete_think_block():
+    handler = _new_handler()
+
+    await handler.publish_robot_messages(
+        _chat_msg("<think>hidden</think>visible", event_type=EventType.CHAT_FINAL)
+    )
+
+    out = await _drain(handler)
+    assert [(msg.event_type, msg.payload.get("content")) for msg in out] == [
+        (EventType.CHAT_REASONING, "hidden"),
+        (EventType.CHAT_FINAL, "visible"),
+    ]
+    assert out[0].payload.get("source_chunk_type") == "llm_reasoning"
+
+
+@pytest.mark.asyncio
+async def test_publish_robot_messages_splits_streamed_partial_think_tags():
+    handler = _new_handler()
+
+    await handler.publish_robot_messages(_chat_msg("answer <thi"))
+    await handler.publish_robot_messages(_chat_msg("nk>hidden</thi"))
+    await handler.publish_robot_messages(_chat_msg("nk> visible"))
+
+    out = await _drain(handler)
+    assert [(msg.event_type, msg.payload.get("content")) for msg in out] == [
+        (EventType.CHAT_DELTA, "answer "),
+        (EventType.CHAT_REASONING, "hidden"),
+        (EventType.CHAT_DELTA, " visible"),
+    ]
+    assert all("<think" not in str(msg.payload.get("content", "")).lower() for msg in out)
+    assert all("</think>" not in str(msg.payload.get("content", "")).lower() for msg in out)
+
+
+@pytest.mark.asyncio
+async def test_publish_robot_messages_flushes_pending_text_before_empty_final():
+    handler = _new_handler()
+
+    await handler.publish_robot_messages(_chat_msg("answer <"))
+    await handler.publish_robot_messages(_chat_msg("", event_type=EventType.CHAT_FINAL))
+
+    out = await _drain(handler)
+    assert [(msg.event_type, msg.payload.get("content")) for msg in out] == [
+        (EventType.CHAT_DELTA, "answer "),
+        (EventType.CHAT_DELTA, "<"),
+        (EventType.CHAT_FINAL, ""),
+    ]

--- a/tests/unit_tests/test_think_tags.py
+++ b/tests/unit_tests/test_think_tags.py
@@ -1,0 +1,53 @@
+from jiuwenswarm.common.think_tags import ThinkTagStreamParser, split_think_tags, strip_think_tags
+
+
+def test_split_think_tags_separates_reasoning_from_visible_text():
+    parts = split_think_tags("before <think>hidden</think> after")
+
+    assert [(part.kind, part.content) for part in parts] == [
+        ("text", "before "),
+        ("reasoning", "hidden"),
+        ("text", " after"),
+    ]
+    assert strip_think_tags("before <think>hidden</think> after") == "before  after"
+
+
+def test_stream_parser_keeps_partial_tags_out_of_visible_text():
+    parser = ThinkTagStreamParser()
+
+    parts = []
+    parts.extend(parser.feed("answer <thi"))
+    parts.extend(parser.feed("nk>secret</thi"))
+    parts.extend(parser.feed("nk> done"))
+    parts.extend(parser.flush())
+
+    assert [(part.kind, part.content) for part in parts] == [
+        ("text", "answer "),
+        ("reasoning", "secret"),
+        ("text", " done"),
+    ]
+
+
+def test_stream_parser_treats_unclosed_think_as_reasoning_on_flush():
+    parser = ThinkTagStreamParser()
+
+    parts = [*parser.feed("<think>hidden"), *parser.flush()]
+
+    assert [(part.kind, part.content) for part in parts] == [("reasoning", "hidden")]
+
+
+def test_stream_parser_handles_orphan_closing_think_tag():
+    parts = split_think_tags("hidden</think>answer")
+
+    assert [(part.kind, part.content) for part in parts] == [
+        ("reasoning", "hidden"),
+        ("text", "answer"),
+    ]
+
+
+def test_stream_parser_does_not_treat_thinking_as_think_tag():
+    parts = split_think_tags("plain <thinking>visible</thinking> text")
+
+    assert [(part.kind, part.content) for part in parts] == [
+        ("text", "plain <thinking>visible</thinking> text")
+    ]


### PR DESCRIPTION
This change splits provider-emitted <think>...</think> blocks from normal chat content.

- Converts think-tag content into chat.reasoning events
- Keeps visible chat.delta/chat.final content clean
- Handles streamed partial think tags across chunks
- Adds unit tests for parser and gateway publishing path