### PR TITLE
fix: align backend predefined_members key with frontend canonical format

### DIFF
--- a/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
+++ b/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
@@ -594,7 +594,7 @@ def _flatten_modes_team_for_config_panel(raw: dict[str, Any]) -> dict[str, str]:
                     "prompt_hint": str(member.get("prompt_hint") or ""),
                     "agent_key": agent_key,
                 })
-        flat[f"{team_prefix}predefined_members"] = json.dumps(members_out, ensure_ascii=False)
+        flat[f"team_predefined_members_{team_idx}"] = json.dumps(members_out, ensure_ascii=False)
 
     for agent_idx, (agent_key, spec) in enumerate(agent_specs.items()):
         if agent_idx >= 10:


### PR DESCRIPTION
The backend `_flatten_modes_team_for_config_panel` emitted predefined_members as
`team_{idx}_predefined_members`, but the frontend's primary lookup key is
`team_predefined_members_{idx}` (with a fallback to the old format from
commit a5280ad4).

Fix the backend to emit the canonical `team_predefined_members_{idx}` format,
removing the dependency on the frontend fallback for this field.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
