### PR TITLE
feat(web): 支持 Web 图片附件与多模态对话

### DIFF
--- a/jiuwenswarm/channels/web/frontend/src/App.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/App.tsx
@@ -42,7 +42,7 @@ import {
 import { useWebSocket } from './hooks';
 import { webRequest } from './services/webClient';
 import { useTeamPanelState } from './features/teamPanelState';
-import { AgentMode, UserAnswer, ModelEntry } from './types';
+import { AgentMode, MediaItem, UserAnswer, ModelEntry } from './types';
 import { useSessionStore, useChatStore, useTodoStore, useHarnessStore } from './stores';
 import { useTranslation } from 'react-i18next';
 import {
@@ -437,9 +437,9 @@ function AppContent() {
     }
     // 同步获取多模型列表
     try {
-      const resp = await request<{ models: ModelEntry[]; active_model: string }>('models.list');
+      const resp = await request<{ models: ModelEntry[]; active_model: string; vision_model?: ModelEntry | null }>('models.list');
       if (resp?.models) {
-        setAvailableModels(resp.models, resp.active_model);
+        setAvailableModels(resp.models, resp.active_model, resp.vision_model ?? null);
       }
     } catch (error) {
       console.warn('Failed to fetch models list:', error);
@@ -531,9 +531,9 @@ function AppContent() {
 
   const handleModelsRefresh = useCallback(async () => {
     try {
-      const resp = await request<{ models: ModelEntry[]; active_model: string }>('models.list');
+      const resp = await request<{ models: ModelEntry[]; active_model: string; vision_model?: ModelEntry | null }>('models.list');
       if (resp?.models) {
-        setAvailableModels(resp.models, resp.active_model);
+        setAvailableModels(resp.models, resp.active_model, resp.vision_model ?? null);
       }
     } catch (error) {
       console.warn('Failed to refresh models list:', error);
@@ -1095,11 +1095,11 @@ for (let i = payload.team.length; i < 10; i++) {
     void switchMode(sessionId, mode);
   }, [sessionId, switchMode]);
 
-  const handleSendMessage = useCallback((content: string) => {
+  const handleSendMessage = useCallback((content: string, mediaItems?: MediaItem[]) => {
     const currentSessionId = sessionIdRef.current;
     if (!currentSessionId || currentSessionId === 'new') return;
     disposeInFlightHistoryHandles();
-    void sendMessage(content, currentSessionId);
+    void sendMessage(content, currentSessionId, mediaItems);
   }, [disposeInFlightHistoryHandles, sendMessage]);
 
   useEffect(() => {

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/ChatPanel.css
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/ChatPanel.css
@@ -45,6 +45,13 @@
   border-color: var(--danger) !important;
 }
 
+.chat-input-container--dragging {
+  border-color: var(--accent);
+  box-shadow:
+    var(--chat-composer-shadow),
+    0 0 0 2px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
 .chat-active-team-group {
   width: calc(100% - 48px);
   margin: 0 auto -1px;
@@ -511,6 +518,52 @@
   opacity: 1;
 }
 
+.chat-input-media-strip {
+  display: flex;
+  gap: 8px;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 0 18px 8px;
+}
+
+.chat-input-media-thumb {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--secondary);
+}
+
+.chat-input-media-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.chat-input-media-remove {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 0;
+  border-radius: var(--radius-full);
+  background: rgba(0, 0, 0, 0.68);
+  color: white;
+  cursor: pointer;
+}
+
+.chat-input-media-remove:hover {
+  background: rgba(0, 0, 0, 0.82);
+}
+
 /* Action buttons */
 .chat-input-actions {
   display: flex;
@@ -592,6 +645,39 @@
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
+.chat-model-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: min(260px, 46cqi);
+}
+
+.chat-model-inline__name {
+  min-width: 0;
+  max-width: min(140px, 28cqi);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted-strong);
+  font-size: 11px;
+  line-height: 16px;
+  padding: 0 2px;
+}
+
+.chat-model-inline__warning {
+  max-width: min(128px, 24cqi);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--warning, #a16207);
+  background: color-mix(in srgb, var(--warning, #ca8a04) 12%, transparent);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  line-height: 18px;
+  padding: 0 6px;
+}
+
 .chat-input-btn--send {
   width: 32px;
   height: 32px;
@@ -648,6 +734,10 @@
 
   .chat-model-selector {
     max-width: 72px;
+  }
+
+  .chat-model-inline__warning {
+    display: none;
   }
 }
 

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/InputArea.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/InputArea.tsx
@@ -1,23 +1,52 @@
-import { useState, useRef, useCallback, KeyboardEvent, useEffect } from 'react';
+import { useState, useRef, useCallback, KeyboardEvent, useEffect, ClipboardEvent, DragEvent, ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Square } from 'lucide-react';
+import { ImagePlus, Square, X } from 'lucide-react';
 import { useSpeechRecognition } from '../../hooks';
 
 // import { stopAllTts } from '../../utils';
 import { useChatStore, useSessionStore } from '../../stores';
-import { AgentMode } from '../../types';
+import { AgentMode, MediaItem } from '../../types';
 import clsx from 'clsx';
 import { getEvolutionPillLabel } from './evolution-status';
 import sendIcon from '../../assets/send.svg';
 import sendActiveIcon from '../../assets/send_active.svg';
 
 interface InputAreaProps {
-  onSubmit: (content: string) => void;
+  onSubmit: (content: string, mediaItems?: MediaItem[]) => void;
   onInterrupt: (newInput?: string) => void;
   onCancel: () => void;
   onSwitchMode: (mode: AgentMode) => void;
   isProcessing: boolean;
   onNewSession: () => Promise<void>;
+}
+
+const ACCEPTED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_IMAGE_COUNT = 8;
+
+function fileToMediaItem(file: File): Promise<MediaItem | null> {
+  if (!ACCEPTED_IMAGE_TYPES.has(file.type) || file.size > MAX_IMAGE_BYTES) {
+    return Promise.resolve(null);
+  }
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      const base64Data = result.includes(',') ? result.split(',')[1] : '';
+      if (!base64Data) {
+        resolve(null);
+        return;
+      }
+      resolve({
+        type: 'image',
+        mimeType: file.type,
+        filename: file.name || `image-${Date.now()}`,
+        base64Data,
+      });
+    };
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(file);
+  });
 }
 
 function ClusterIcon({ className }: { className?: string }) {
@@ -43,7 +72,10 @@ export function InputArea({
   const [isModeMenuOpen, setIsModeMenuOpen] = useState(false);
   const [showModeSwitchModal, setShowModeSwitchModal] = useState(false);
   const [pendingMode, setPendingMode] = useState<AgentMode | null>(null);
+  const [mediaItems, setMediaItems] = useState<MediaItem[]>([]);
+  const [isDraggingImage, setIsDraggingImage] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const modeMenuRef = useRef<HTMLDivElement>(null);
   const autoSendTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isComposingRef = useRef(false);
@@ -112,6 +144,8 @@ export function InputArea({
     },
   });
 
+  const imageInputDisabled = isListening || (isInterruptible && !isTeamMode);
+
   useEffect(() => {
     if (!isListening && pendingVoiceText) {
       const finalText = (inputValue + pendingVoiceText).trim();
@@ -144,6 +178,18 @@ export function InputArea({
     };
   }, []);
 
+  const appendImageFiles = useCallback(async (files: FileList | File[]) => {
+    const imageFiles = Array.from(files).filter((file) => ACCEPTED_IMAGE_TYPES.has(file.type));
+    if (!imageFiles.length) return;
+    const remainingSlots = Math.max(0, MAX_IMAGE_COUNT - mediaItems.length);
+    if (!remainingSlots) return;
+    const nextItems = (await Promise.all(imageFiles.slice(0, remainingSlots).map(fileToMediaItem)))
+      .filter((item): item is MediaItem => Boolean(item));
+    if (nextItems.length) {
+      setMediaItems((prev) => [...prev, ...nextItems].slice(0, MAX_IMAGE_COUNT));
+    }
+  }, [mediaItems.length]);
+
   useEffect(() => {
     if (!isModeMenuOpen) return;
 
@@ -162,35 +208,38 @@ export function InputArea({
 
   const handleSubmit = useCallback(() => {
     const trimmed = (inputValue + pendingVoiceText).trim();
-    if (!trimmed) return;
+    if (!trimmed && mediaItems.length === 0) return;
+    if (isInterruptible && !isTeamMode && mediaItems.length > 0) return;
 
     if (isListening) {
       stopListening();
     }
 
     if (isTeamMode) {
-      onSubmit(trimmed);
+      onSubmit(trimmed, mediaItems);
     } else if (isInterruptible) {
-      if (isAgentMode) {
+      if (isAgentMode && mediaItems.length === 0) {
         addToTaskQueue(trimmed);
       } else {
         onInterrupt(trimmed);
       }
     } else {
-      onSubmit(trimmed);
+      onSubmit(trimmed, mediaItems);
     }
     setInputValue('');
     setPendingVoiceText('');
+    setMediaItems([]);
 
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-  }, [inputValue, pendingVoiceText, isInterruptible, isListening, onSubmit, onInterrupt, stopListening, isAgentMode, isTeamMode, addToTaskQueue, setInputValue]);
+  }, [inputValue, pendingVoiceText, mediaItems, isInterruptible, isListening, onSubmit, onInterrupt, stopListening, isAgentMode, isTeamMode, addToTaskQueue, setInputValue]);
 
   const trimmedDraft = (inputValue + pendingVoiceText).trim();
-  const hasDraft = trimmedDraft.length > 0 || isListening;
+  const hasDraft = trimmedDraft.length > 0 || mediaItems.length > 0 || isListening;
+  const isImageInterruptBlocked = isInterruptible && !isTeamMode && mediaItems.length > 0;
   const showStop = isProcessing && !isPaused && !hasDraft;
-  const canSubmit = hasDraft || showStop;
+  const canSubmit = (hasDraft && !isImageInterruptBlocked) || showStop;
 
   const handleSendButtonClick = useCallback(() => {
     if (showStop) {
@@ -217,6 +266,49 @@ export function InputArea({
       textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 200)}px`;
     }
   }, []);
+
+  const handleFileInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (files) {
+      void appendImageFiles(files);
+    }
+    event.target.value = '';
+  }, [appendImageFiles]);
+
+  const handlePaste = useCallback((event: ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(event.clipboardData.items);
+    const files = items
+      .filter((item) => item.kind === 'file' && ACCEPTED_IMAGE_TYPES.has(item.type))
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => Boolean(file));
+    if (files.length) {
+      event.preventDefault();
+      void appendImageFiles(files);
+    }
+  }, [appendImageFiles]);
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    const hasImage = Array.from(event.dataTransfer.items).some(
+      (item) => item.kind === 'file' && ACCEPTED_IMAGE_TYPES.has(item.type)
+    );
+    if (!hasImage) return;
+    event.preventDefault();
+    setIsDraggingImage(true);
+  }, []);
+
+  const handleDragLeave = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      setIsDraggingImage(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback((event: DragEvent<HTMLDivElement>) => {
+    setIsDraggingImage(false);
+    const files = Array.from(event.dataTransfer.files).filter((file) => ACCEPTED_IMAGE_TYPES.has(file.type));
+    if (!files.length) return;
+    event.preventDefault();
+    void appendImageFiles(files);
+  }, [appendImageFiles]);
 
   // const handleVoiceStart = useCallback(() => {
   //   if (isListening) return;
@@ -274,6 +366,7 @@ export function InputArea({
     if (isListening || (isInterruptible && !isTeamMode)) return;
     setInputValue('');
     setPendingVoiceText('');
+    setMediaItems([]);
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
@@ -329,7 +422,11 @@ export function InputArea({
         'chat-input-container',
         isModeMenuOpen && 'chat-input-container--menu-open',
         isListening && 'chat-input-container--recording',
+        isDraggingImage && 'chat-input-container--dragging',
       )}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
     >
       {isListening && (
         <div className="chat-input-recording-bar">
@@ -375,6 +472,7 @@ export function InputArea({
         onCompositionStart={() => { isComposingRef.current = true; }}
         onCompositionEnd={() => { isComposingRef.current = false; }}
         onInput={handleInput}
+        onPaste={handlePaste}
         placeholder={
           isListening
             ? t('chat.placeholderVoice')
@@ -394,6 +492,27 @@ export function InputArea({
         rows={1}
         data-testid="chat-input"
       />
+
+      {mediaItems.length > 0 && (
+        <div className="chat-input-media-strip">
+          {mediaItems.map((item, index) => (
+            <div className="chat-input-media-thumb" key={`${item.filename}-${index}`}>
+              <img
+                src={`data:${item.mimeType};base64,${item.base64Data}`}
+                alt={item.filename}
+              />
+              <button
+                type="button"
+                className="chat-input-media-remove"
+                onClick={() => setMediaItems((prev) => prev.filter((_, i) => i !== index))}
+                title={t('chat.removeImage')}
+              >
+                <X size={12} strokeWidth={2} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
 
       <div className="chat-input-toolbar">
         <div className="chat-input-toolbar-left">
@@ -466,6 +585,27 @@ export function InputArea({
         </div>
 
         <div className="chat-input-actions">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            multiple
+            className="hidden"
+            onChange={handleFileInputChange}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={imageInputDisabled}
+            className={cx(
+              'chat-input-btn',
+              imageInputDisabled && 'chat-input-btn--disabled',
+            )}
+            title={imageInputDisabled ? t('chat.addImageDisabled') : t('chat.addImage')}
+          >
+            <ImagePlus className="chat-input-btn-icon" strokeWidth={1.8} />
+          </button>
+
           <button
             type="button"
             onClick={handleNewSession}
@@ -505,7 +645,7 @@ export function InputArea({
             </button>
           )} */}
 
-          <ModelSelector />
+          <ModelSelector hasMedia={mediaItems.length > 0} />
 
           <button
             type="button"
@@ -561,37 +701,52 @@ export function InputArea({
   );
 }
 
-function ModelSelector() {
+function ModelSelector({ hasMedia }: { hasMedia: boolean }) {
   const { chatAvailableModels, selectedModelName, setSelectedModelName } = useSessionStore();
   const { t } = useTranslation();
+  const hasVisionModel = chatAvailableModels.some((m) => m.model_capability === 'vision');
 
   if (chatAvailableModels.length === 0) return null;
 
   if (chatAvailableModels.length === 1) {
     return (
-      <span
-        className="text-xs text-text-muted px-2 truncate max-w-[200px]"
-        title={chatAvailableModels[0].model_name}
-      >
-        {chatAvailableModels[0].alias || chatAvailableModels[0].model_name}
+      <span className="chat-model-inline">
+        <span
+          className="chat-model-inline__name"
+          title={chatAvailableModels[0].model_name}
+        >
+          {chatAvailableModels[0].alias || chatAvailableModels[0].model_name}
+        </span>
+        {hasMedia && !hasVisionModel && (
+          <span className="chat-model-inline__warning" title={t('chat.modelSelector.noVisionTooltip')}>
+            {t('chat.modelSelector.noVision')}
+          </span>
+        )}
       </span>
     );
   }
 
   return (
-    <select
-      value={selectedModelName ?? ''}
-      onChange={(e) => setSelectedModelName(e.target.value)}
-      title={t('chat.modelSelector.tooltip')}
-      className="chat-model-selector"
-      data-testid="chat-model-selector"
-    >
-      {chatAvailableModels.map((m, idx) => (
-        <option key={`${m.model_name}-${idx}`} value={m.alias || m.model_name}>
-          {m.alias ? `${m.alias} (${m.model_name})` : m.model_name}
-        </option>
-      ))}
-    </select>
+    <span className="chat-model-inline">
+      <select
+        value={selectedModelName ?? ''}
+        onChange={(e) => setSelectedModelName(e.target.value)}
+        title={t('chat.modelSelector.tooltip')}
+        className="chat-model-selector"
+        data-testid="chat-model-selector"
+      >
+        {chatAvailableModels.map((m, idx) => (
+          <option key={`${m.model_name}-${idx}`} value={m.alias || m.model_name}>
+            {m.alias ? `${m.alias} (${m.model_name})` : m.model_name}
+          </option>
+        ))}
+      </select>
+      {hasMedia && !hasVisionModel && (
+        <span className="chat-model-inline__warning" title={t('chat.modelSelector.noVisionTooltip')}>
+          {t('chat.modelSelector.noVision')}
+        </span>
+      )}
+    </span>
   );
 }
 

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/index.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/index.tsx
@@ -9,7 +9,7 @@ import { ArrowRight, LoaderCircle, Share2, Sparkles } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { useChatStore, useSessionStore, useTodoStore } from '../../stores';
-import { AgentMode, Message, UserAnswer } from '../../types';
+import { AgentMode, MediaItem, Message, UserAnswer } from '../../types';
 import { MessageList } from './MessageList';
 import { ContextCompressionLines } from './MessageItem';
 import { InputArea } from './InputArea';
@@ -30,7 +30,7 @@ export interface ChatHistoryPagerProps {
 }
 
 interface ChatPanelProps {
-  onSendMessage: (content: string) => void;
+  onSendMessage: (content: string, mediaItems?: MediaItem[]) => void;
   onInterrupt: (newInput?: string) => void;
   onCancel: () => void;
   onSwitchMode: (mode: AgentMode) => void;
@@ -301,9 +301,9 @@ export function ChatPanel({
   }, [historyPager, messages.length]);
 
   // 包装发送消息函数，添加滚动逻辑
-  const handleSendMessage = useCallback((content: string) => {
+  const handleSendMessage = useCallback((content: string, mediaItems?: MediaItem[]) => {
     setIsSending(true);
-    onSendMessage(content);
+    onSendMessage(content, mediaItems);
   }, [onSendMessage]);
 
   // 当发送消息时强制滚动到底部

--- a/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
+++ b/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
@@ -262,7 +262,7 @@ interface UseWebSocketReturn {
     params?: Record<string, unknown>,
     options?: WebRequestOptions
   ) => Promise<T>;
-  sendMessage: (content: string, sessionId: string) => Promise<void>;
+  sendMessage: (content: string, sessionId: string, mediaItems?: MediaItem[]) => Promise<void>;
   sendStructuredChatContent: (content: unknown, sessionId: string) => Promise<void>;
   interrupt: (
     sessionId: string,
@@ -714,8 +714,9 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
 
   // 发送聊天消息
   const sendMessage = useCallback(
-    async (content: string, sessionId: string) => {
-      if (!content.trim()) return;
+    async (content: string, sessionId: string, mediaItems: MediaItem[] = []) => {
+      const hasMedia = mediaItems.length > 0;
+      if (!content.trim() && !hasMedia) return;
 
       const currentMode = useSessionStore.getState().mode;
       const unsupportedEvolutionMode = unsupportedEvolutionModeMessage(content, currentMode);
@@ -752,6 +753,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
         id: `user-${Date.now()}`,
         role: 'user',
         content,
+        mediaItems,
         timestamp: new Date().toISOString(),
       });
 
@@ -776,6 +778,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
         await request('chat.send', {
           session_id: sessionId,
           content,
+          ...(hasMedia ? { media_items: mediaItems } : {}),
           mode: currentMode,
           ...(selectedModel ? { model_name: selectedModel } : {}),
         });

--- a/jiuwenswarm/channels/web/frontend/src/i18n/locales/en.json
+++ b/jiuwenswarm/channels/web/frontend/src/i18n/locales/en.json
@@ -229,11 +229,16 @@
     "waitingTasks": "Waiting tasks",
     "waitingTasksCount": "Waiting tasks ({{count}})",
     "removeTask": "Remove task",
+    "addImage": "Add image",
+    "addImageDisabled": "Cannot add images while processing or recording",
+    "removeImage": "Remove image",
     "holdToSpeak": "Hold to speak",
     "send": "Send (Enter)",
     "stop": "Stop",
     "modelSelector": {
-      "tooltip": "Switch the model used for chat"
+      "tooltip": "Switch the model used for chat",
+      "noVision": "No vision model",
+      "noVisionTooltip": "models.vision is not configured. Images will be sent, but chat cannot switch to a dedicated vision model."
     },
     "newSessionDisabled": "Cannot create session while processing or recording",
     "modeSwitchTitle": "Switch Mode",

--- a/jiuwenswarm/channels/web/frontend/src/i18n/locales/zh.json
+++ b/jiuwenswarm/channels/web/frontend/src/i18n/locales/zh.json
@@ -229,11 +229,16 @@
     "waitingTasks": "等待任务",
     "waitingTasksCount": "等待任务 ({{count}})",
     "removeTask": "移除任务",
+    "addImage": "添加图片",
+    "addImageDisabled": "处理中或录音中不可添加图片",
+    "removeImage": "移除图片",
     "holdToSpeak": "按住说话",
     "send": "发送 (Enter)",
     "stop": "停止",
     "modelSelector": {
-      "tooltip": "切换对话使用的模型"
+      "tooltip": "切换对话使用的模型",
+      "noVision": "未配置视觉模型",
+      "noVisionTooltip": "当前配置缺少 models.vision，图片会随消息发送，但不会切换到专用视觉模型"
     },
     "newSessionDisabled": "处理中或录音中不可新建",
     "modeSwitchTitle": "切换模式",

--- a/jiuwenswarm/channels/web/frontend/src/stores/sessionStore.ts
+++ b/jiuwenswarm/channels/web/frontend/src/stores/sessionStore.ts
@@ -262,7 +262,7 @@ interface SessionState {
   setTeamMemberExecutionEvents: (events: TeamMemberExecutionEvent[]) => void;
   addTeamMemberExecutionEvent: (event: TeamMemberExecutionEvent) => void;
   setTeamHistoryMessages: (messages: Message[]) => void;
-  setAvailableModels: (models: ModelEntry[], activeModel?: string) => void;
+  setAvailableModels: (models: ModelEntry[], activeModel?: string, visionModel?: ModelEntry | null) => void;
   setSelectedModelName: (name: string) => void;
 }
 
@@ -625,18 +625,26 @@ export const useSessionStore = create<SessionState>((set) => ({
   setTeamHistoryMessages: (messages) => {
     set({ teamHistoryMessages: messages });
   },
-  setAvailableModels: (models, activeModel) => {
+  setAvailableModels: (models, activeModel, visionModel = null) => {
     set(() => {
       const chatModels = models.filter((m) => m.is_default !== false);
+      const nextChatModels = visionModel
+        ? [
+            ...chatModels,
+            ...(chatModels.some((m) => (m.alias || m.model_name) === (visionModel.alias || visionModel.model_name))
+              ? []
+              : [{ ...visionModel, model_capability: 'vision' as const, is_default: true }]),
+          ]
+        : chatModels;
       // 优先使用后端返回的 activeModel（默认模型），其次取第一个；有别名时存别名
-      const matchedModel = activeModel ? chatModels.find((m) => m.model_name === activeModel) : null;
+      const matchedModel = activeModel ? nextChatModels.find((m) => m.model_name === activeModel) : null;
       const selected = matchedModel
         ? (matchedModel.alias || matchedModel.model_name)
-        : (chatModels[0] ? (chatModels[0].alias || chatModels[0].model_name) : null);
+        : (nextChatModels[0] ? (nextChatModels[0].alias || nextChatModels[0].model_name) : null);
       if (selected) {
         try { localStorage.setItem(MODEL_STORAGE_KEY, selected); } catch { /* noop */ }
       }
-      return { availableModels: models, chatAvailableModels: chatModels, selectedModelName: selected };
+      return { availableModels: models, chatAvailableModels: nextChatModels, selectedModelName: selected };
     });
   },
   setSelectedModelName: (name) => {

--- a/jiuwenswarm/channels/web/frontend/src/types/index.ts
+++ b/jiuwenswarm/channels/web/frontend/src/types/index.ts
@@ -35,6 +35,7 @@ export interface ModelEntry {
   api_base: string;
   api_key: string;
   model_provider: string;
+  model_capability?: 'default' | 'vision';
   timeout?: number;
   temperature?: number;
   reasoning_level?: string;

--- a/jiuwenswarm/gateway/app_gateway.py
+++ b/jiuwenswarm/gateway/app_gateway.py
@@ -46,6 +46,7 @@ from jiuwenswarm.common.utils import (
     prepare_workspace,
     reset_free_search_runtime_flags,
 )
+from jiuwenswarm.gateway.media_attachments import normalize_chat_media_attachments
 
 # Ensure workspace initialized
 _workspace_dir = get_user_workspace_dir()
@@ -93,6 +94,8 @@ def _normalize_gateway_message(msg):
 
     req_method = getattr(msg, "req_method", None) or ReqMethod.CHAT_SEND
     params = dict(msg.params or {})
+    if req_method == ReqMethod.CHAT_SEND:
+        normalize_chat_media_attachments(params, getattr(msg, "session_id", None))
     if "query" not in params and "content" in params:
         params["query"] = params["content"]
     if req_method == ReqMethod.CHAT_RESUME:

--- a/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
+++ b/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
@@ -1269,6 +1269,36 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
 
     # ── models.* handlers ────────────────────────────────────────
 
+    def _configured_vision_model(config: dict[str, Any]) -> dict[str, Any] | None:
+        models_config = config.get("models")
+        if not isinstance(models_config, dict):
+            return None
+        vision_config = models_config.get("vision")
+        if not isinstance(vision_config, dict):
+            return None
+        mcc = vision_config.get("model_client_config")
+        if not isinstance(mcc, dict):
+            return None
+        model_name = str(mcc.get("model_name") or "").strip()
+        api_base = str(mcc.get("api_base") or "").strip()
+        api_key = str(mcc.get("api_key") or "").strip()
+        if not model_name or not api_base or not api_key:
+            return None
+        mco = vision_config.get("model_config_obj")
+        if not isinstance(mco, dict):
+            mco = {}
+        return {
+            "model_name": model_name,
+            "api_base": api_base,
+            "api_key": api_key,
+            "model_provider": mcc.get("client_provider", ""),
+            "temperature": mco.get("temperature", 0.95),
+            "reasoning_level": "off" if mco.get("reasoning_level") is False else mco.get("reasoning_level", ""),
+            "is_default": True,
+            "alias": vision_config.get("alias") or "Vision",
+            "model_capability": "vision",
+        }
+
     async def _models_list(ws, req_id, params, session_id):
         """返回已配置的所有默认模型列表（与 config.get 一致，返回解密后的完整值）。
 
@@ -1312,6 +1342,7 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
             await channel.send_response(ws, req_id, ok=True, payload={
                 "models": result,
                 "active_model": active_model,
+                "vision_model": _configured_vision_model(config),
             })
         except Exception as exc:  # noqa: BLE001
             logger.warning("[models.list] %s", exc)

--- a/jiuwenswarm/gateway/media_attachments.py
+++ b/jiuwenswarm/gateway/media_attachments.py
@@ -1,0 +1,151 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Helpers for normalizing browser-uploaded media attachments."""
+
+from __future__ import annotations
+
+import base64
+import re
+from pathlib import Path
+from typing import Any
+
+from jiuwenswarm.common.utils import get_agent_sessions_dir
+
+_SAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_SESSION_ID_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+_SUPPORTED_IMAGE_MIME_TYPES = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+}
+_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+_MAX_IMAGE_COUNT = 8
+
+
+def normalize_chat_media_attachments(params: dict[str, Any], session_id: str | None) -> None:
+    """Validate browser media_items, persist images, and enrich the chat params.
+
+    The frontend sends images as base64 for cross-platform browser compatibility.
+    The agent side already has vision tools that accept local image paths, so the
+    gateway stores images under the current session and appends those paths to the
+    prompt metadata instead of requiring every agent path to understand raw base64.
+    """
+
+    raw_items = params.get("media_items")
+    if not isinstance(raw_items, list) or not raw_items:
+        return
+
+    stored: list[dict[str, Any]] = []
+    for index, item in enumerate(raw_items[:_MAX_IMAGE_COUNT]):
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") != "image":
+            continue
+        stored_item = _store_image_item(item, session_id=session_id, index=index)
+        if stored_item:
+            stored.append(stored_item)
+
+    if not stored:
+        params.pop("media_items", None)
+        return
+
+    params["media_items"] = stored
+    files = params.get("files")
+    if not isinstance(files, dict):
+        files = {}
+    files["uploaded_images"] = [
+        {
+            "filename": item.get("filename"),
+            "path": item.get("path"),
+            "mime_type": item.get("mime_type"),
+            "size_bytes": item.get("size_bytes"),
+        }
+        for item in stored
+    ]
+    params["files"] = files
+
+    original_content = params.get("content")
+    content_text = (
+        original_content.strip()
+        if isinstance(original_content, str)
+        else str(original_content or "").strip()
+    )
+    content = _append_image_instruction(content_text, stored)
+    params["content"] = content
+    params["query"] = content
+
+
+def _store_image_item(item: dict[str, Any], *, session_id: str | None, index: int) -> dict[str, Any] | None:
+    mime_type = str(item.get("mimeType") or item.get("mime_type") or "").lower().strip()
+    suffix = _SUPPORTED_IMAGE_MIME_TYPES.get(mime_type)
+    if suffix is None:
+        return None
+
+    raw_base64 = item.get("base64Data") or item.get("base64_data")
+    if not isinstance(raw_base64, str) or not raw_base64.strip():
+        return None
+    try:
+        data = base64.b64decode(raw_base64, validate=True)
+    except ValueError:
+        return None
+    if not data or len(data) > _MAX_IMAGE_BYTES:
+        return None
+
+    safe_session_id = _safe_session_id(session_id)
+    upload_dir = get_agent_sessions_dir() / safe_session_id / "uploads"
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = _safe_filename(
+        str(item.get("filename") or f"image-{index + 1}{suffix}"),
+        fallback=f"image-{index + 1}{suffix}",
+    )
+    if Path(filename).suffix.lower() not in set(_SUPPORTED_IMAGE_MIME_TYPES.values()):
+        filename = f"{filename}{suffix}"
+    path = _unique_path(upload_dir / filename)
+    path.write_bytes(data)
+
+    return {
+        "type": "image",
+        "filename": path.name,
+        "mime_type": mime_type,
+        "path": str(path),
+        "size_bytes": len(data),
+    }
+
+
+def _append_image_instruction(content: str, items: list[dict[str, Any]]) -> str:
+    lines = [
+        content or "请分析我上传的图片。",
+        "",
+        "用户随消息上传了以下图片，"
+        "请在需要理解图片内容时调用 visual_question_answering 工具读取这些本地路径：",
+    ]
+    for index, item in enumerate(items, start=1):
+        lines.append(f"{index}. {item.get('filename')}: {item.get('path')}")
+    return "\n".join(lines).strip()
+
+
+def _safe_session_id(session_id: str | None) -> str:
+    text = str(session_id or "default").strip() or "default"
+    return _SESSION_ID_RE.sub("_", text)[:120]
+
+
+def _safe_filename(filename: str, *, fallback: str) -> str:
+    name = Path(filename).name.strip()
+    if not name or name in {".", ".."}:
+        name = fallback
+    return _SAFE_FILENAME_RE.sub("_", name)[:180]
+
+
+def _unique_path(path: Path) -> Path:
+    if not path.exists():
+        return path
+    stem = path.stem
+    suffix = path.suffix
+    for idx in range(1, 1000):
+        candidate = path.with_name(f"{stem}-{idx}{suffix}")
+        if not candidate.exists():
+            return candidate
+    return path.with_name(f"{stem}-overflow{suffix}")

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -2087,8 +2087,66 @@ class JiuWenSwarmDeepAdapter:
         )
         return Model(model_client_config=ModelClientConfig(**mcc_fields), model_config=m_config)
 
+    @staticmethod
+    def _requires_temperature_one(mcc: dict[str, Any]) -> bool:
+        model_name = str(mcc.get("model_name") or "").strip().lower()
+        api_base = str(mcc.get("api_base") or "").strip().lower()
+        return model_name.startswith("kimi-") or "moonshot.cn" in api_base
+
+    @classmethod
+    def _normalize_selectable_model_config(
+        cls,
+        mcc: dict[str, Any],
+        mco: dict[str, Any],
+    ) -> dict[str, Any]:
+        normalized = dict(mco)
+        if cls._requires_temperature_one(mcc):
+            normalized["temperature"] = 1
+            normalized["top_p"] = 0.95
+        return normalized
+
+    def _register_model_cache_entry(
+        self,
+        entry: dict[str, Any],
+        name_counter: dict[str, int],
+        fallback_alias: str = "",
+    ) -> None:
+        """Register one model entry into the request-selectable model cache."""
+        mcc = entry.get("model_client_config") or {}
+        if not mcc.get("model_name"):
+            return
+        model_name = mcc["model_name"]
+        idx = name_counter.get(model_name, 0)
+        name_counter[model_name] = idx + 1
+        cache_key = f"{model_name}#{idx}"
+        try:
+            self._model_cache[cache_key] = self._build_model_from_entry(
+                mcc,
+                self._normalize_selectable_model_config(
+                    mcc,
+                    entry.get("model_config_obj") or {},
+                ),
+            )
+        except Exception as exc:
+            logger.warning(
+                "[JiuWenSwarmDeepAdapter] 跳过无效模型条目 %s: %s",
+                model_name, exc,
+            )
+            return
+        if model_name not in self._model_name_to_keys:
+            self._model_name_to_keys[model_name] = []
+        self._model_name_to_keys[model_name].append(cache_key)
+
+        # 同时用纯 model_name 作为 key 指向 is_default=true 的条目
+        if entry.get("is_default") is True:
+            self._model_cache[model_name] = self._model_cache[cache_key]
+
+        alias = entry.get("alias") or fallback_alias
+        if alias and alias != model_name and alias not in self._model_cache:
+            self._model_cache[alias] = self._model_cache[cache_key]
+
     def _build_model_cache_from_defaults(self, config: dict) -> None:
-        """从 models.defaults 列表构建模型缓存。
+        """从 models.defaults 和可选择的多模态模型构建模型缓存。
 
         key 使用 {model_name}#{index} 格式以支持同名模型共存。
         同时记录 _model_name_to_keys 映射以便按 model_name 查找。
@@ -2097,35 +2155,11 @@ class JiuWenSwarmDeepAdapter:
         name_counter: dict[str, int] = {}
 
         for entry in get_default_models(config):
-            mcc = entry.get("model_client_config") or {}
-            if not mcc.get("model_name"):
-                continue
-            model_name = mcc["model_name"]
-            idx = name_counter.get(model_name, 0)
-            name_counter[model_name] = idx + 1
-            cache_key = f"{model_name}#{idx}"
-            try:
-                self._model_cache[cache_key] = self._build_model_from_entry(
-                    mcc,
-                    entry.get("model_config_obj") or {},
-                )
-            except Exception as exc:
-                logger.warning(
-                    "[JiuWenSwarmDeepAdapter] 跳过无效模型条目 %s: %s",
-                    model_name, exc,
-                )
-                continue
-            if model_name not in self._model_name_to_keys:
-                self._model_name_to_keys[model_name] = []
-            self._model_name_to_keys[model_name].append(cache_key)
+            self._register_model_cache_entry(entry, name_counter)
 
-            # 同时用纯 model_name 作为 key 指向 is_default=true 的条目
-            if entry.get("is_default") is True:
-                self._model_cache[model_name] = self._model_cache[cache_key]
-
-            alias = entry.get("alias", "")
-            if alias and alias != model_name and alias not in self._model_cache:
-                self._model_cache[alias] = self._model_cache[cache_key]
+        vision_entry = (config.get("models") or {}).get("vision")
+        if isinstance(vision_entry, dict):
+            self._register_model_cache_entry(vision_entry, name_counter, fallback_alias="Vision")
 
     def _build_model_cache_legacy(self, config: dict) -> None:
         """回退到旧格式（models.default / react 段）构建单条目缓存。"""

--- a/tests/unit_tests/agentserver/test_agentserver_modes.py
+++ b/tests/unit_tests/agentserver/test_agentserver_modes.py
@@ -161,6 +161,54 @@ def test_team_config_loader_defaults_teammate_mode_to_build_mode():
     assert spec["teammate_mode"] == "build_mode"
 
 
+def test_deep_adapter_can_select_configured_vision_model_by_alias():
+    from jiuwenswarm.server.runtime.agent_adapter.interface_deep import JiuWenSwarmDeepAdapter
+
+    adapter = JiuWenSwarmDeepAdapter()
+    adapter._create_model(  # pylint: disable=protected-access
+        {
+            "models": {
+                "defaults": [
+                    {
+                        "model_client_config": {
+                            "api_base": "https://default.example/v1",
+                            "api_key": "default-key",
+                            "model_name": "deepseek-chat",
+                            "client_provider": "OpenAI",
+                            "verify_ssl": False,
+                        },
+                        "model_config_obj": {"temperature": 0.1},
+                        "is_default": True,
+                    }
+                ],
+                "vision": {
+                    "model_client_config": {
+                        "api_base": "https://api.moonshot.cn/v1",
+                        "api_key": "vision-key",
+                        "model_name": "kimi-k2.6",
+                        "client_provider": "OpenAI",
+                        "verify_ssl": False,
+                    },
+                    "model_config_obj": {"temperature": 0.2},
+                },
+            }
+        }
+    )
+
+    request = AgentRequest(
+        request_id="req-vision",
+        channel_id="web",
+        params={"model_name": "Vision"},
+    )
+
+    resolved = adapter._resolve_model_for_request(request)  # pylint: disable=protected-access
+
+    assert resolved.model_config.model_name == "kimi-k2.6"
+    assert resolved.model_client_config.api_base == "https://api.moonshot.cn/v1"
+    assert resolved.model_config.temperature == 1
+    assert resolved.model_config.top_p == 0.95
+
+
 def test_resolve_request_project_dir_uses_metadata_project_dir_for_control_requests():
     request = AgentRequest(
         request_id="req-control",

--- a/tests/unit_tests/gateway/test_media_attachments.py
+++ b/tests/unit_tests/gateway/test_media_attachments.py
@@ -1,0 +1,65 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from __future__ import annotations
+
+import base64
+
+from jiuwenswarm.gateway.media_attachments import normalize_chat_media_attachments
+
+
+def test_normalize_chat_media_attachments_persists_images(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.media_attachments.get_agent_sessions_dir",
+        lambda: tmp_path / "sessions",
+    )
+    image_bytes = b"\x89PNG\r\n\x1a\nfake"
+    params = {
+        "content": "这是什么？",
+        "media_items": [
+            {
+                "type": "image",
+                "mimeType": "image/png",
+                "filename": "../screen shot.png",
+                "base64Data": base64.b64encode(image_bytes).decode("ascii"),
+            }
+        ],
+    }
+
+    normalize_chat_media_attachments(params, "sess-win-mac")
+
+    content = params.get("content")
+    media_items = params.get("media_items")
+    files = params.get("files")
+    uploaded_images = files.get("uploaded_images") if isinstance(files, dict) else None
+
+    assert isinstance(content, str)
+    assert isinstance(media_items, list)
+    assert isinstance(uploaded_images, list)
+    assert params.get("query") == content
+    assert "visual_question_answering" in content
+    assert media_items[0].get("filename") == "screen_shot.png"
+    stored_path = tmp_path / "sessions" / "sess-win-mac" / "uploads" / "screen_shot.png"
+    assert stored_path.read_bytes() == image_bytes
+    assert uploaded_images[0].get("path") == str(stored_path)
+
+
+def test_normalize_chat_media_attachments_drops_invalid_images(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.media_attachments.get_agent_sessions_dir",
+        lambda: tmp_path / "sessions",
+    )
+    params = {
+        "content": "hello",
+        "media_items": [
+            {
+                "type": "image",
+                "mimeType": "image/png",
+                "filename": "bad.png",
+                "base64Data": "not-base64",
+            }
+        ],
+    }
+
+    normalize_chat_media_attachments(params, "sess-1")
+
+    assert params == {"content": "hello"}


### PR DESCRIPTION
## 关联 Issue

响应并解决：#36

## 变更说明

本 PR 为 JiuwenSwarm Web 端增加图片附件能力，支持多模态对话交互。

主要变更包括：

- Web 输入框支持图片上传、粘贴、拖拽添加
- 输入框中展示图片缩略图预览
- 支持发送前删除已选择的图片
- `chat.send` 消息体携带图片附件信息
- Gateway 侧持久化 base64 图片附件，并转发给后端会话
- 聊天记录中展示用户发送的图片附件
- Web 端支持选择配置里的 `models.vision` 模型
- 后端将 `models.vision` 注册为可选择的 `Vision` 模型
- 兼容 Kimi/Moonshot vision 模型参数限制，自动设置 `temperature=1`、`top_p=0.95`
- 增加图片附件与 Vision 模型选择相关单元测试

## 验证情况

已完成本地验证：

- 图片上传成功
- 图片粘贴成功
- 图片拖拽成功
- 图片缩略图预览正常
- 删除图片附件正常
- 真实发送图片消息成功
- 切换 `Vision (kimi-k2.6)` 后可正常完成图片理解
- 使用两张测试图片完成真实图片解析验证

## 测试命令

```bash
UV_PROJECT_ENVIRONMENT=.venv311 uv run --python /opt/homebrew/bin/python3.11 python -m pytest tests/unit_tests/gateway/test_media_attachments.py tests/unit_tests/test_app_web_handlers.py tests/unit_tests/agentserver/test_agentserver_modes.py::test_deep_adapter_can_select_configured_vision_model_by_alias -q
```

结果：

```text
10 passed, 1 warning
```

前端构建：

```bash
cd jiuwenswarm/channels/web/frontend
npm run build
```

结果：构建通过。

## 测试截图

已按建议使用新的 Prompt 重新完成两张图片的真实链路验证。

新 Prompt：

> 请先仔细观察所提供的图片，并准确理解其内容，再以清晰、有条理的方式，将图中的信息完整地阐述出来。

验证结果：两张测试图片均可通过 Web 图片附件 + Vision 模型成功解析。

重新验证截图已补充在 PR 评论中。
