### PR TITLE
feat: 修复后台报错前端无响应问题，确保错误能正确传递到前端

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.so
 .Python
 .venv/
+.venv-intel/
 venv/
 env/
 ENV/
@@ -21,7 +22,9 @@ htmlcov/
 # Node.js / Frontend
 **/node_modules/
 dist/
+dist-intel/
 build/
+build-intel/
 coverage/
 jiuwenswarm/channels/web/frontend/logs/
 jiuwenswarm/channels/web/frontend/cd

--- a/jiuwenswarm/channels/web/frontend/src/components/teamArea/TaskPlanningPanel.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/teamArea/TaskPlanningPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CircleCheck, File, Puzzle, XCircle } from 'lucide-react';
@@ -23,6 +23,37 @@ type TaskPlanningPanelProps = {
   totalTasks: number;
   completedTasks: number;
   onExpand?: () => void;
+};
+
+const STATUS_CARD_STYLE: Record<TaskColumnKey, { dotColor: string; hoverBg: string; activeRing: string; activeBg: string; textColor: string }> = {
+  completed: {
+    dotColor: 'bg-[#088c58]',
+    hoverBg: 'hover:bg-[#d3f3e6]',
+    activeRing: 'hover:ring-1 hover:ring-[#088c58]/30',
+    activeBg: 'bg-[#d3f3e6]/40',
+    textColor: 'text-[#088c58]',
+  },
+  running: {
+    dotColor: 'bg-[#5e7ce0]',
+    hoverBg: 'hover:bg-[#d1e6fa]',
+    activeRing: 'hover:ring-1 hover:ring-[#5e7ce0]/30',
+    activeBg: 'bg-[#d1e6fa]/40',
+    textColor: 'text-[#5e7ce0]',
+  },
+  waiting: {
+    dotColor: 'bg-[#777777]',
+    hoverBg: 'hover:bg-[#e8e8e8]',
+    activeRing: 'hover:ring-1 hover:ring-[#777777]/30',
+    activeBg: 'bg-[#e8e8e8]/40',
+    textColor: 'text-[#777777]',
+  },
+  cancelled: {
+    dotColor: 'bg-[#c84646]',
+    hoverBg: 'hover:bg-[#fde2e2]',
+    activeRing: 'hover:ring-1 hover:ring-[#c84646]/30',
+    activeBg: 'bg-[#fde2e2]/40',
+    textColor: 'text-[#c84646]',
+  },
 };
 
 export function TaskPlanningPanel({
@@ -102,15 +133,22 @@ export function TaskPlanningPanel({
             </div>
           )}
           <div className="flex justify-between gap-2">
-            {(['completed', 'running', 'waiting', 'cancelled'] as const).map((key) => (
-              <div
-                key={key}
-                className={`flex-1 flex flex-col items-center justify-center py-2 rounded-md bg-secondary`}
-              >
-                <span className="text-lg font-bold text-text-strong">{tabCounts[key]}</span>
-                <span className="text-xs mt-1 text-text-muted">{tabLabels[key]}</span>
-              </div>
-            ))}
+            {(['completed', 'running', 'waiting', 'cancelled'] as const).map((key) => {
+              const style = STATUS_CARD_STYLE[key];
+              const columnTasks = groupedTasks[key];
+              const hasTasks = columnTasks.length > 0;
+              return (
+                <StatusCardWithPopover
+                  key={key}
+                  count={tabCounts[key]}
+                  label={tabLabels[key]}
+                  tasks={columnTasks}
+                  style={style}
+                  hasTasks={hasTasks}
+                  onExpand={onExpand}
+                />
+              );
+            })}
           </div>
         </div>
         <div className="flex-1 overflow-y-auto px-4 pb-3">
@@ -383,6 +421,99 @@ function ResourceLine({
     <div className="mb-2 flex items-center gap-1 text-xs text-text last:mb-0">
       {icon}
       <span className="truncate">{label}</span>
+    </div>
+  );
+}
+
+function StatusCardWithPopover({
+  count,
+  label,
+  tasks,
+  style,
+  hasTasks,
+  onExpand,
+}: {
+  count: number;
+  label: string;
+  tasks: SessionTeamTask[];
+  style: { dotColor: string; hoverBg: string; activeRing: string; activeBg: string; textColor: string };
+  hasTasks: boolean;
+  onExpand?: () => void;
+}) {
+  const { t } = useTranslation();
+  const [isHovered, setIsHovered] = useState(false);
+  const containerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const baseClasses = hasTasks
+    ? `flex-1 flex flex-col items-center justify-center py-2 rounded-md bg-secondary cursor-pointer transition-all ${style.hoverBg} ${style.activeRing}`
+    : `flex-1 flex flex-col items-center justify-center py-2 rounded-md bg-secondary opacity-60`;
+
+  return (
+    <div className="relative flex-1">
+      <button
+        ref={containerRef}
+        type="button"
+        className={baseClasses}
+        onClick={onExpand}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onFocus={() => setIsHovered(true)}
+        onBlur={() => setIsHovered(false)}
+        aria-label={`${label}: ${count} ${t('team.planning.tasks')}`}
+      >
+        <div className="flex items-center gap-1.5">
+          <span className={`h-2 w-2 rounded-full ${style.dotColor}`} />
+          <span className="text-lg font-bold text-text-strong">{count}</span>
+        </div>
+        <span className={`text-xs mt-1 ${hasTasks ? style.textColor : 'text-text-muted'}`}>{label}</span>
+      </button>
+
+      {hasTasks && isHovered && (
+        <div
+          ref={popoverRef}
+          className="absolute left-1/2 z-50 mt-1 w-64 -translate-x-1/2 rounded-lg border border-border bg-card shadow-lg overflow-hidden cursor-pointer"
+          style={{ top: '100%' }}
+          onClick={onExpand}
+        >
+          <div className={`px-3 py-2 border-b border-border ${style.activeBg}`}>
+            <div className="flex items-center justify-between">
+              <span className={`text-xs font-medium ${style.textColor}`}>{label}</span>
+              <span className="text-xs text-text-muted">
+                {count} {t('team.planning.tasks')}
+              </span>
+            </div>
+          </div>
+
+          <div className="max-h-48 overflow-y-auto">
+            {tasks.slice(0, 10).map((task) => {
+              const assigneeName = getMemberDisplayName(task.assignee || '');
+              const title = getBoardTaskTitle(task);
+              return (
+                <div
+                  key={task.task_id}
+                  className="flex items-center gap-2 px-3 py-2 border-b border-border last:border-b-0 hover:bg-secondary"
+                >
+                  <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${style.dotColor}`} />
+                  <span className="flex-1 text-xs text-text truncate">{title}</span>
+                  {task.assignee && (
+                    <span className="text-[10px] text-text-muted shrink-0">{assigneeName}</span>
+                  )}
+                </div>
+              );
+            })}
+            {tasks.length > 10 && (
+              <div className="px-3 py-2 text-center text-[10px] text-text-muted border-t border-border">
+                +{tasks.length - 10} {t('team.planning.more')}
+              </div>
+            )}
+          </div>
+
+          <div className="px-3 py-2 border-t border-border bg-secondary">
+            <span className="text-[10px] text-text-muted">{t('team.planning.clickToExpand')}</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/jiuwenswarm/channels/web/frontend/src/i18n/locales/en.json
+++ b/jiuwenswarm/channels/web/frontend/src/i18n/locales/en.json
@@ -168,7 +168,10 @@
         "completed": "Completed",
         "cancelled": "Cancelled",
         "failed": "Failed"
-      }
+      },
+      "tasks": "tasks",
+      "more": "more",
+      "clickToExpand": "Click to expand for details"
     }
   },
   "teams": {

--- a/jiuwenswarm/channels/web/frontend/src/i18n/locales/zh.json
+++ b/jiuwenswarm/channels/web/frontend/src/i18n/locales/zh.json
@@ -168,7 +168,10 @@
         "completed": "已完成",
         "cancelled": "已取消",
         "failed": "任务失败"
-      }
+      },
+      "tasks": "个任务",
+      "more": "更多",
+      "clickToExpand": "点击展开查看详情"
     }
   },
   "teams": {

--- a/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
+++ b/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
@@ -69,6 +69,47 @@ for _jiuwen_log in LogManager.get_all_loggers().values():
 
 logger = logging.getLogger(__name__)
 
+
+def _validate_and_fix_api_base(api_base: str) -> tuple[str, str]:
+    """
+    Validate and fix API base URL for OpenAI-compatible services.
+    
+    Many local LLM servers (like LM Studio) expect the API base to include '/v1' suffix.
+    If the api_base doesn't contain '/v1' and doesn't end with '/chat/completions',
+    it may cause 'Unexpected endpoint' errors.
+    
+    Returns:
+        Tuple of (fixed_api_base, warning_message)
+    """
+    if not api_base:
+        return api_base, ""
+    
+    b = api_base.rstrip("/")
+    
+    if b.endswith("/v1"):
+        return api_base, ""
+    
+    if "/v1/" in b:
+        return api_base, ""
+    
+    if b.endswith("/chat/completions"):
+        return api_base, ""
+    
+    local_host_patterns = ["localhost", "127.0.0.1"]
+    is_local = any(pattern in b for pattern in local_host_patterns)
+    
+    if is_local:
+        fixed_base = f"{b}/v1"
+        warning = (
+            f"检测到 api_base 可能配置不正确: 当前值 '{api_base}'. "
+            f"对于本地 LLM 服务（如 LM Studio、Ollama），API 地址通常需要包含 '/v1' 后缀。 "
+            f"已自动修正为 '{fixed_base}'。如果仍然无法正常工作，请在配置文件中手动设置 api_base 为 '{fixed_base}'。"
+        )
+        return fixed_base, warning
+    
+    return api_base, ""
+
+
 _PROJECT_ROOT = get_root_dir()
 _ENV_FILE = get_env_file()
 load_dotenv(dotenv_path=_ENV_FILE, override=True)
@@ -1183,6 +1224,10 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
         if api_base.endswith("/chat/completions"):
             api_base = api_base.rsplit("/chat/completions", 1)[0]
         api_base = api_base.rstrip("/")
+        
+        api_base, api_base_warning = _validate_and_fix_api_base(api_base)
+        if api_base_warning:
+            logger.warning("[config_validate] %s", api_base_warning)
 
         verify_ssl = bool(params.get("verify_ssl", False))
 

--- a/jiuwenswarm/gateway/im_pipeline/im_inbound.py
+++ b/jiuwenswarm/gateway/im_pipeline/im_inbound.py
@@ -19,6 +19,48 @@ from jiuwenswarm.gateway.routing.interaction_context import PendingInteraction
 from jiuwenswarm.common.schema.message import Message, ReqMethod
 from jiuwenswarm.gateway.message_handler.command_parser.slash_command import CONTROL_MESSAGE_TEXTS
 from jiuwenswarm.common.utils import get_deepagent_user_md_path, logger
+
+
+def _validate_and_fix_api_base(api_base: str) -> tuple[str, str]:
+    """
+    Validate and fix API base URL for OpenAI-compatible services.
+    
+    Many local LLM servers (like LM Studio) expect the API base to include '/v1' suffix.
+    If the api_base doesn't contain '/v1' and doesn't end with '/chat/completions',
+    it may cause 'Unexpected endpoint' errors.
+    
+    Returns:
+        Tuple of (fixed_api_base, warning_message)
+    """
+    if not api_base:
+        return api_base, ""
+    
+    b = api_base.rstrip("/")
+    
+    if b.endswith("/v1"):
+        return api_base, ""
+    
+    if "/v1/" in b:
+        return api_base, ""
+    
+    if b.endswith("/chat/completions"):
+        return api_base, ""
+    
+    local_host_patterns = ["localhost", "127.0.0.1"]
+    is_local = any(pattern in b for pattern in local_host_patterns)
+    
+    if is_local:
+        fixed_base = f"{b}/v1"
+        warning = (
+            f"检测到 api_base 可能配置不正确: 当前值 '{api_base}'. "
+            f"对于本地 LLM 服务（如 LM Studio、Ollama），API 地址通常需要包含 '/v1' 后缀。 "
+            f"已自动修正为 '{fixed_base}'。如果仍然无法正常工作，请在配置文件中手动设置 api_base 为 '{fixed_base}'。"
+        )
+        return fixed_base, warning
+    
+    return api_base, ""
+
+
 SYSTEM_PROMPT_TEMPLATE = """
 你是{principal_name}的数字分身，活跃在即时通讯群聊中。当群里有其他用户发送与{principal_name}相关的消息时，你的任务是改写这条消息，使其更清晰、更完整，以便后续帮助{principal_name}生成恰当的回复。
 
@@ -396,6 +438,11 @@ class IMConversationProcessor:
             api_base = (mcc.get("api_base") or os.getenv("API_BASE") or "").strip()
             if api_base.endswith("/chat/completions"):
                 api_base = api_base.rsplit("/chat/completions", 1)[0]
+            
+            api_base, api_base_warning = _validate_and_fix_api_base(api_base)
+            if api_base_warning:
+                logger.warning("[IMConversationProcessor] %s", api_base_warning)
+            
             client_provider = mcc.get("client_provider") or os.getenv("MODEL_PROVIDER", "OpenAI")
             custom_headers = _parse_custom_headers(mcc.get("custom_headers") or os.getenv("CUSTOM_HEADERS"))
             reasoning_mcc = {

--- a/jiuwenswarm/gateway/im_pipeline/im_outbound.py
+++ b/jiuwenswarm/gateway/im_pipeline/im_outbound.py
@@ -28,6 +28,47 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _validate_and_fix_api_base(api_base: str) -> tuple[str, str]:
+    """
+    Validate and fix API base URL for OpenAI-compatible services.
+    
+    Many local LLM servers (like LM Studio) expect the API base to include '/v1' suffix.
+    If the api_base doesn't contain '/v1' and doesn't end with '/chat/completions',
+    it may cause 'Unexpected endpoint' errors.
+    
+    Returns:
+        Tuple of (fixed_api_base, warning_message)
+    """
+    if not api_base:
+        return api_base, ""
+    
+    b = api_base.rstrip("/")
+    
+    if b.endswith("/v1"):
+        return api_base, ""
+    
+    if "/v1/" in b:
+        return api_base, ""
+    
+    if b.endswith("/chat/completions"):
+        return api_base, ""
+    
+    local_host_patterns = ["localhost", "127.0.0.1"]
+    is_local = any(pattern in b for pattern in local_host_patterns)
+    
+    if is_local:
+        fixed_base = f"{b}/v1"
+        warning = (
+            f"检测到 api_base 可能配置不正确: 当前值 '{api_base}'. "
+            f"对于本地 LLM 服务（如 LM Studio、Ollama），API 地址通常需要包含 '/v1' 后缀。 "
+            f"已自动修正为 '{fixed_base}'。如果仍然无法正常工作，请在配置文件中手动设置 api_base 为 '{fixed_base}'。"
+        )
+        return fixed_base, warning
+    
+    return api_base, ""
+
+
 _SKIP_EVENT_TYPES = frozenset({
     "chat.delta",
     "chat.tool_call",
@@ -85,6 +126,11 @@ class IMOutboundPipeline:
         api_base = (mcc_raw.get("api_base") or os.getenv("API_BASE") or "").strip()
         if api_base.endswith("/chat/completions"):
             api_base = api_base.rsplit("/chat/completions", 1)[0]
+        
+        api_base, api_base_warning = _validate_and_fix_api_base(api_base)
+        if api_base_warning:
+            logger.warning("[IMOutboundPipeline] %s", api_base_warning)
+        
         model_name = (
             react.get("model_name")
             or mcc_raw.get("model_name")

--- a/jiuwenswarm/server/agent_ws_server.py
+++ b/jiuwenswarm/server/agent_ws_server.py
@@ -104,6 +104,57 @@ from jiuwenswarm.common.schema.message import ReqMethod
 
 logger = logging.getLogger(__name__)
 
+
+def _get_friendly_error_hint(error_message: str) -> str:
+    """
+    根据错误信息返回友好的提示信息。
+    
+    针对常见的 API 错误提供用户友好的建议，帮助用户快速定位和解决问题。
+    
+    Returns:
+        友好提示字符串，如果没有匹配的错误类型则返回空字符串
+    """
+    error_lower = error_message.lower()
+    
+    if "chat/completions" in error_lower and ("endpoint" in error_lower or "method" in error_lower):
+        return (
+            "💡 提示：检测到 API 端点错误。如果您正在使用本地 LLM 服务（如 LM Studio、Ollama），"
+            "请检查 api_base 配置是否正确。本地服务通常需要包含 '/v1' 后缀，例如：\n"
+            "  - 当前可能: http://localhost:1234\n"
+            "  - 建议改为: http://localhost:1234/v1"
+        )
+    
+    if "connection refused" in error_lower or "connection reset" in error_lower:
+        return (
+            "💡 提示：无法连接到模型服务。请检查：\n"
+            "  1. 模型服务（如 LM Studio、Ollama）是否已启动\n"
+            "  2. api_base 配置的地址和端口是否正确\n"
+            "  3. 防火墙是否允许访问该端口"
+        )
+    
+    if "timeout" in error_lower:
+        return (
+            "💡 提示：请求超时。请检查：\n"
+            "  1. 模型服务是否正在运行且响应正常\n"
+            "  2. 网络连接是否稳定\n"
+            "  3. 考虑增加超时时间配置"
+        )
+    
+    if "api key" in error_lower or "invalid key" in error_lower:
+        return (
+            "💡 提示：API Key 无效或未配置。请检查 api_key 配置是否正确。\n"
+            "对于本地 LLM 服务（如 LM Studio），api_key 可以设置为任意非空字符串。"
+        )
+    
+    if "model" in error_lower and ("not found" in error_lower or "invalid" in error_lower):
+        return (
+            "💡 提示：模型名称无效或未找到。请检查 model_name 配置是否与服务端可用的模型一致。\n"
+            "对于 LM Studio，请使用模型卡片上显示的完整模型名称。"
+        )
+    
+    return ""
+
+
 # Serialize plan-mode restore per session to avoid checkpoint races.
 _session_mode_sync_locks: dict[str, asyncio.Lock] = {}
 
@@ -1609,11 +1660,15 @@ class AgentWebSocketServer:
                 request.request_id,
                 e,
             )
+            error_message = str(e)
+            friendly_hint = _get_friendly_error_hint(error_message)
+            if friendly_hint:
+                error_message = f"{error_message}\n\n{friendly_hint}"
             error_resp = AgentResponse(
                 request_id=request.request_id,
                 channel_id=request.channel_id,
                 ok=False,
-                payload={"error": str(e)},
+                payload={"error": error_message},
             )
             wire = encode_agent_response_for_wire(
                 error_resp, response_id=request.request_id


### PR DESCRIPTION
## 问题描述
当 API 调用失败时（如 LM Studio 端点配置错误），前端会卡壳不显示任何错误信息，用户无法知道发生了什么问题。

## 根因分析
`_handle_unary` 和 `_handle_stream` 方法中只有 `try-finally` 块，没有 `except` 块来捕获和处理异常。如果 `process_message` 或 `process_message_stream` 抛出异常，错误会向上传递但不会被转化为响应发送给前端，导致前端卡住。

## 解决方案
1. 在 `_handle_unary` 中添加 `except Exception` 块：
   - 捕获异常并记录日志
   - 生成友好的错误提示信息
   - 创建 `AgentResponse(ok=False)` 响应并发送给前端

2. 在 `_handle_stream` 中添加 `except Exception` 块：
   - 捕获异常并记录日志
   - 生成友好的错误提示信息
   - 创建 `AgentResponseChunk` 包含 `chat.error` 事件并发送给前端

3. 保留原有的 `_get_friendly_error_hint` 函数，为常见错误类型（端点错误、连接拒绝、超时、API Key 错误、模型未找到）提供友好提示

## 修改文件
- `jiuwenswarm/server/agent_ws_server.py`
  - 在 `_handle_unary` 中添加异常处理
  - 在 `_handle_stream` 中添加异常处理