### PR TITLE
feat(skills): add poster generation skill

### DIFF
--- a/jiuwenswarm/resources/agent/workspace/skills/poster-layered/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/poster-layered/SKILL.md
@@ -89,7 +89,7 @@ python scripts/overlay_text.py \
 
 脚本相对本技能目录；若工作目录不同，用绝对路径调用。依赖：`Pillow`（`pip install pillow`）。系统需有可用中文字体（脚本会尝试常见路径，也可在 `layout.json` 里指定 `font_path`）。
 
-3. `text_rerender += 1`。若超过上限，停止并报告。
+3. `text_rerender += 1`。若 `text_rerender >= max_text_rerender`，停止并报告。
 
 ### Step 3 — OCR 对照放行
 

--- a/jiuwenswarm/resources/agent/workspace/skills/poster-layered/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/poster-layered/SKILL.md
@@ -70,7 +70,7 @@ poster_job/<job_id>/
 1. 根据风格写生图 prompt，**明确要求画面中无文字**，可预留空白安全区给标题/正文。
 2. 调用 `generate_image`（需已配置 `models.image_gen` / `IMAGE_GEN_*`）。
 3. 将结果保存/复制为 `base.png`（若工具返回路径，复制到 `poster_job/<job_id>/base.png`）。
-4. `full_regen += 1`。若 `full_regen > max_full_regen`，停止并报告。
+4. `full_regen += 1`。若 `full_regen >= max_full_regen`，停止并报告。
 5. （可选）对 `base.png` 调一次 `visual_question_answering`：  
    `question = "图中是否出现任何可读文字或字母？只回答 YES 或 NO。"`  
    若 YES：不得进入叠字交付；应改 prompt 再抽底图，或接受轻微残留但 **正文仍只以叠字为准**（MVP 推荐直接重抽底图，计入 `full_regen`）。

--- a/jiuwenswarm/resources/agent/workspace/skills/poster-layered/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/poster-layered/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: poster-layered
+version: 0.1.0
+author: openjiuwen
+description: 分层海报：无字/少字底图 + 程序叠字 + OCR 对照放行，减少整图重抽与人工错字校对
+tags: [poster, multimodal, ocr, mvp]
+allowed_tools:
+  - generate_image
+  - visual_question_answering
+  - bash
+  - read_file
+  - write_file
+---
+
+# 分层海报 Skill（MVP）
+
+当用户要做海报、宣传图、封面且文案必须正确时，**必须**使用本技能。  
+目标：错字不触发整图重抽；交付前自动 OCR 对照；人工只审风格。
+
+## 硬约束（违反即失败）
+
+1. **文案先定稿**：未得到用户确认的 `copy.md`（或等价定稿），禁止调用 `generate_image`。
+2. **底图禁止烤正文**：生图 prompt 必须含「no text / no letters / no Chinese characters / blank text areas」或中文等价说明；标题若必须艺术字，单行 ≤ 4 字且后续仍以 OCR 校验；长文案、副标题、小字、名单 **一律程序叠字**。
+3. **禁止用「改 prompt 整图重抽」修错字**。错字只走：改叠字参数 → 重新叠字 → 再 OCR。
+4. **次数上限**：
+   - `max_full_regen`（整图）= **2**
+   - `max_text_rerender`（叠字）= **5**
+   - 超限则停止自动重试，向用户报告失败原因与已生成的底图/叠字稿路径，请用户改文案或布局。
+
+## 工作区约定
+
+在当前 session/workspace 下创建目录（若不存在则创建）：
+
+```text
+poster_job/<job_id>/
+  copy.md           # 定稿文案（唯一真相源）
+  layout.json       # 叠字布局
+  base.png          # 无字/少字底图
+  poster.png        # 当前候选成片
+  ocr_last.txt      # 最近一次 OCR 原文
+  manifest.json     # 状态与重试计数
+```
+
+`layout.json` 最小字段示例见 `references/layout.schema.md`。
+
+## SOP
+
+### Step 0 — 收集与定稿
+
+1. 向用户确认：尺寸（如 `1080x1920` / `1080x1080`）、风格关键词、必须出现的文案（主标题/副标题/正文/脚注）。
+2. 用 `write_file` 写入 `copy.md`，结构建议：
+
+```markdown
+# copy
+## title
+...
+## subtitle
+...
+## body
+...
+## footer
+...
+```
+
+3. **展示文案请用户确认**。未确认不得进入 Step 1。
+4. 初始化 `manifest.json`：`full_regen=0`, `text_rerender=0`, `status=copy_locked`。
+
+### Step 1 — 无字/少字底图
+
+1. 根据风格写生图 prompt，**明确要求画面中无文字**，可预留空白安全区给标题/正文。
+2. 调用 `generate_image`（需已配置 `models.image_gen` / `IMAGE_GEN_*`）。
+3. 将结果保存/复制为 `base.png`（若工具返回路径，复制到 `poster_job/<job_id>/base.png`）。
+4. `full_regen += 1`。若 `full_regen > max_full_regen`，停止并报告。
+5. （可选）对 `base.png` 调一次 `visual_question_answering`：  
+   `question = "图中是否出现任何可读文字或字母？只回答 YES 或 NO。"`  
+   若 YES：不得进入叠字交付；应改 prompt 再抽底图，或接受轻微残留但 **正文仍只以叠字为准**（MVP 推荐直接重抽底图，计入 `full_regen`）。
+
+### Step 2 — 程序叠字
+
+1. 根据 `copy.md` 与用户意向写/更新 `layout.json`（坐标、字号、颜色、对齐、字体路径）。
+2. 运行叠字脚本（优先）：
+
+```bash
+python scripts/overlay_text.py \
+  --base poster_job/<job_id>/base.png \
+  --layout poster_job/<job_id>/layout.json \
+  --out poster_job/<job_id>/poster.png
+```
+
+脚本相对本技能目录；若工作目录不同，用绝对路径调用。依赖：`Pillow`（`pip install pillow`）。系统需有可用中文字体（脚本会尝试常见路径，也可在 `layout.json` 里指定 `font_path`）。
+
+3. `text_rerender += 1`。若超过上限，停止并报告。
+
+### Step 3 — OCR 对照放行
+
+1. 调用 `visual_question_answering`：
+   - `image_path_or_url` = `poster.png` 的可访问路径/URL（沙箱路径若不可用，先复制到工具可读位置）。
+   - `question` = 使用下方「OCR 放行提问」模板，并把 `copy.md` 全文贴进提问。
+2. 将工具返回的 OCR 段写入 `ocr_last.txt`。
+3. **放行条件（全部满足）**：
+   - `copy.md` 中 **title / subtitle / body / footer** 每一段的规范文本（去首尾空白、合并连续空白）均能在 OCR 结果中找到对应子串；或 Agent 做字符级比对后 **无增删改字**（允许 OCR 常见标点/全半角差异，见下）。
+   - 允许忽略：全角/半角标点、多余空格、换行位置。
+   - **不允许忽略**：错字、漏字、多字、数字错误、英文大小写若文案中有明确要求。
+4. **不放行**：只调整 `layout.json`（字号、位置、描边、对比度）或 `copy.md`（若用户同意改文案），回到 **Step 2**；**禁止**为修错字调用 `generate_image`。
+5. 放行后：`status=released`，向用户交付 `poster.png` 路径，并说明「文案已 OCR 对照通过；请仅审风格与构图」。
+
+### OCR 放行提问模板
+
+```text
+请对图片做精确 OCR，按阅读顺序列出所有可见文字。
+然后对照下面「定稿文案」，逐段判断是否完全一致（忽略空格与换行、全半角标点）。
+对每一段输出：PASS 或 FAIL，FAIL 时指出差异。
+最后一行只输出：OVERALL_PASS 或 OVERALL_FAIL。
+
+【定稿文案】
+<粘贴 copy.md 全文>
+```
+
+仅当最后一行为 `OVERALL_PASS`（或等价明确通过）时才可交付。
+
+## 失败路由（摘要）
+
+| 现象 | 动作 | 计数 |
+|------|------|------|
+| 底图仍有大段字 | 改「无字」prompt，整图重抽 | `full_regen` |
+| 叠字后 OCR FAIL | 改 layout/对比度，重新叠字 | `text_rerender` |
+| 用户要改文案 | 更新 copy.md → 确认 → Step 2（不重抽底图） | `text_rerender` |
+| 用户要改风格/构图 | 可 Step 1 重抽底图，文案不变 | `full_regen` |
+| 超限 | 停止自动重试，交人决策 | — |
+
+## 不适用本 MVP 时
+
+- 必须把长文艺术字「烤进」画面且无法叠字：说明限制，建议降级为短词艺术字 + 其余叠字，或改用外部设计工具。
+- 未配置 `generate_image` / vision OCR：先提示配置 `models.image_gen` 与 `models.vision`。

--- a/jiuwenswarm/resources/agent/workspace/skills/poster-layered/references/layout.schema.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/poster-layered/references/layout.schema.md
@@ -1,0 +1,42 @@
+# layout.json 约定（MVP）
+
+```json
+{
+  "font_path": "/System/Library/Fonts/PingFang.ttc",
+  "blocks": [
+    {
+      "id": "title",
+      "text": "主标题文案",
+      "x": 80,
+      "y": 200,
+      "font_size": 72,
+      "fill": "#FFFFFF",
+      "stroke_fill": "#000000",
+      "stroke_width": 2,
+      "max_width": 920,
+      "align": "center",
+      "line_gap": 12
+    },
+    {
+      "id": "body",
+      "text": "正文……",
+      "x": 80,
+      "y": 1200,
+      "font_size": 36,
+      "fill": "#F5F5F5",
+      "max_width": 920,
+      "align": "left"
+    }
+  ]
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `font_path` | 全局默认字体；block 可覆盖 |
+| `blocks[].text` | 必须与 `copy.md` 对应段一致 |
+| `x,y` | 左上角像素 |
+| `max_width` | 换行宽度；`align` 为 center/right 时相对此宽度对齐 |
+| `stroke_*` | 可选描边，提高 OCR 对比度 |
+
+`blocks[].text` 应从定稿 `copy.md` 拷贝，不要在 layout 里另写一套文案。

--- a/jiuwenswarm/resources/agent/workspace/skills/poster-layered/scripts/overlay_text.py
+++ b/jiuwenswarm/resources/agent/workspace/skills/poster-layered/scripts/overlay_text.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Overlay text onto a poster base image using layout.json (Pillow)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:
+    print("ERROR: Pillow required. Install with: pip install pillow", file=sys.stderr)
+    sys.exit(2)
+
+# Common CJK-capable fonts on macOS / Linux / Windows (first existing wins).
+_FONT_CANDIDATES = [
+    "/System/Library/Fonts/PingFang.ttc",
+    "/System/Library/Fonts/STHeiti Light.ttc",
+    "/Library/Fonts/Arial Unicode.ttf",
+    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "C:/Windows/Fonts/msyh.ttc",
+    "C:/Windows/Fonts/simhei.ttf",
+]
+
+
+def _resolve_font(font_path: str | None, size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    paths: list[str] = []
+    if font_path:
+        paths.append(font_path)
+    paths.extend(_FONT_CANDIDATES)
+    for p in paths:
+        if p and Path(p).is_file():
+            try:
+                return ImageFont.truetype(p, size=size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def _wrap_text(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont, max_width: int) -> list[str]:
+    if max_width <= 0:
+        return text.splitlines() or [text]
+    lines: list[str] = []
+    for paragraph in text.split("\n"):
+        if not paragraph:
+            lines.append("")
+            continue
+        current = ""
+        for ch in paragraph:
+            trial = current + ch
+            bbox = draw.textbbox((0, 0), trial, font=font)
+            if bbox[2] - bbox[0] <= max_width:
+                current = trial
+            else:
+                if current:
+                    lines.append(current)
+                current = ch
+        if current:
+            lines.append(current)
+    return lines or [""]
+
+
+def overlay(base_path: Path, layout_path: Path, out_path: Path) -> None:
+    layout = json.loads(layout_path.read_text(encoding="utf-8"))
+    blocks = layout.get("blocks") or []
+    default_font = layout.get("font_path")
+
+    img = Image.open(base_path).convert("RGBA")
+    draw = ImageDraw.Draw(img)
+
+    for block in blocks:
+        text = str(block.get("text") or "")
+        if not text.strip():
+            continue
+        x = int(block.get("x", 0))
+        y = int(block.get("y", 0))
+        size = int(block.get("font_size", 48))
+        fill = block.get("fill") or "#FFFFFF"
+        stroke_fill = block.get("stroke_fill")
+        stroke_width = int(block.get("stroke_width") or 0)
+        max_width = int(block.get("max_width") or 0)
+        align = str(block.get("align") or "left")
+        line_gap = int(block.get("line_gap") or max(4, size // 6))
+        font = _resolve_font(block.get("font_path") or default_font, size)
+
+        lines = _wrap_text(draw, text, font, max_width)
+        cy = y
+        for line in lines:
+            bbox = draw.textbbox((0, 0), line, font=font)
+            w = bbox[2] - bbox[0]
+            if align == "center" and max_width > 0:
+                lx = x + (max_width - w) // 2
+            elif align == "right" and max_width > 0:
+                lx = x + max_width - w
+            else:
+                lx = x
+            kwargs: dict = {"font": font, "fill": fill}
+            if stroke_width > 0 and stroke_fill:
+                kwargs["stroke_width"] = stroke_width
+                kwargs["stroke_fill"] = stroke_fill
+            draw.text((lx, cy), line, **kwargs)
+            cy += (bbox[3] - bbox[1]) + line_gap
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rgb = img.convert("RGB")
+    rgb.save(out_path, format="PNG")
+    print(f"OK wrote {out_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Overlay text on poster base image")
+    parser.add_argument("--base", required=True, type=Path)
+    parser.add_argument("--layout", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+    if not args.base.is_file():
+        print(f"ERROR: base not found: {args.base}", file=sys.stderr)
+        sys.exit(1)
+    if not args.layout.is_file():
+        print(f"ERROR: layout not found: {args.layout}", file=sys.stderr)
+        sys.exit(1)
+    overlay(args.base, args.layout, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/jiuwenswarm/resources/agent/workspace/skills/poster-layered/scripts/overlay_text.py
+++ b/jiuwenswarm/resources/agent/workspace/skills/poster-layered/scripts/overlay_text.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 from pathlib import Path
 
-try:
-    from PIL import Image, ImageDraw, ImageFont
-except ImportError:
-    print("ERROR: Pillow required. Install with: pip install pillow", file=sys.stderr)
-    sys.exit(2)
+from PIL import Image, ImageDraw, ImageFont
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 # Common CJK-capable fonts on macOS / Linux / Windows (first existing wins).
 _FONT_CANDIDATES = [
@@ -107,23 +107,24 @@ def overlay(base_path: Path, layout_path: Path, out_path: Path) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     rgb = img.convert("RGB")
     rgb.save(out_path, format="PNG")
-    print(f"OK wrote {out_path}")
+    logger.info("OK wrote %s", out_path)
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser(description="Overlay text on poster base image")
     parser.add_argument("--base", required=True, type=Path)
     parser.add_argument("--layout", required=True, type=Path)
     parser.add_argument("--out", required=True, type=Path)
     args = parser.parse_args()
     if not args.base.is_file():
-        print(f"ERROR: base not found: {args.base}", file=sys.stderr)
-        sys.exit(1)
+        logger.error("base not found: %s", args.base)
+        return 1
     if not args.layout.is_file():
-        print(f"ERROR: layout not found: {args.layout}", file=sys.stderr)
-        sys.exit(1)
+        logger.error("layout not found: %s", args.layout)
+        return 1
     overlay(args.base, args.layout, args.out)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/jiuwenswarm/resources/agent/workspace/skills/poster-layered/scripts/overlay_text.py
+++ b/jiuwenswarm/resources/agent/workspace/skills/poster-layered/scripts/overlay_text.py
@@ -83,7 +83,8 @@ def overlay(base_path: Path, layout_path: Path, out_path: Path) -> None:
         stroke_width = int(block.get("stroke_width") or 0)
         max_width = int(block.get("max_width") or 0)
         align = str(block.get("align") or "left")
-        line_gap = int(block.get("line_gap") or max(4, size // 6))
+        line_gap_raw = block.get("line_gap")
+        line_gap = int(line_gap_raw) if line_gap_raw is not None else max(4, size // 6)
         font = _resolve_font(block.get("font_path") or default_font, size)
 
         lines = _wrap_text(draw, text, font, max_width)


### PR DESCRIPTION
Paired: [GitHub #857](https://github.com/openJiuwen-ai/jiuwenswarm/pull/857) ↔ [GitCode !3922](https://gitcode.com/openJiuwen/jiuwenswarm/pull/3922)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind feature

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [x] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [x] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->

## 背景

文生图海报场景中，文案被“烤进”像素后，错一个字往往需要整图重抽并反复改 prompt，算力浪费大，且仍需人工校对错字。本 PR 增加预置 Skill MVP，用分层产线把错字修复从整图重抽中拆开。

## 主要改动

新增预置技能 `poster-layered`：

- `SKILL.md`：定稿文案 → 无字/少字底图 → 程序叠字 → OCR 对照放行的硬约束与 SOP
- `scripts/overlay_text.py`：基于 Pillow 的叠字脚本
- `references/layout.schema.md`：`layout.json` 字段约定

路径：`jiuwenswarm/resources/agent/workspace/skills/poster-layered/`（与其它预置 skill 一致；该目录在 `.gitignore` 中，需 `-f` 纳入版本库，与既有 skills 相同）。

## 向后兼容

仅新增预置 Skill，不改对外 API / 运行时默认行为；未安装或未启用时无影响。

## 验证

- **结构**：预置路径含 `SKILL.md` / `scripts` / `references`，frontmatter 含 `name` / `description`
- **叠字冒烟**：用纯色底图 + 中文 `layout.json` 运行 `overlay_text.py`，成功写出 `poster.png`，且与底图内容 hash 不同（依赖 Pillow）
- **端到端（手工，需配置 `models.image_gen` + `models.vision`）**：
  1. 技能广场预置安装/启用 `poster-layered`
  2. 正常一单：定稿 → 底图 → 叠字 → OCR `OVERALL_PASS` 后交付
  3. 故意错字：仅重跑叠字，不应为修错字再次 `generate_image`
- **说明**：本 draft 暂未附正式 UT/ST；合入前可补 `overlay_text.py` 单测与 E2E 清单勾选。