### PR TITLE
fix(feishu): bind card action symbols in the ImportError fallback

### DIFF
--- a/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
@@ -93,6 +93,8 @@ except ImportError:
     FEISHU_AVAILABLE = False
     lark = None
     Emoji = None
+    P2CardActionTrigger = None
+    P2CardActionTriggerResponse = None
 
 # 非文本消息类型的显示占位符映射
 MSG_TYPE_MAP = {

--- a/tests/unit_tests/channel/test_feishu_import_fallback.py
+++ b/tests/unit_tests/channel/test_feishu_import_fallback.py
@@ -1,0 +1,64 @@
+# pylint: disable=protected-access
+"""Tests for FeishuChannel import fallback when the lark_oapi SDK is absent.
+
+``feishu_connect`` guards its ``lark_oapi`` imports with ``try/except
+ImportError`` and exposes ``FEISHU_AVAILABLE`` so the rest of the gateway can
+run without the Feishu SDK -- the same pattern used by the Telegram, Discord
+and DingTalk channels. These tests pin that contract down.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+MODULE = "jiuwenswarm.gateway.channel_manager.im_platforms.feishu.feishu_connect"
+
+
+@pytest.fixture
+def without_lark_sdk():
+    """Reload the module as if lark_oapi were not installed."""
+    saved = {
+        name: mod
+        for name, mod in sys.modules.items()
+        if name == "lark_oapi" or name.startswith("lark_oapi.")
+    }
+    saved[MODULE] = sys.modules.get(MODULE)
+    for name in saved:
+        sys.modules.pop(name, None)
+    # A ``None`` entry makes ``import lark_oapi`` raise ImportError.
+    sys.modules["lark_oapi"] = None
+    try:
+        yield
+    finally:
+        sys.modules.pop("lark_oapi", None)
+        for name, mod in saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+        importlib.import_module(MODULE)
+
+
+def test_import_without_lark_sdk_degrades(without_lark_sdk):
+    """Import must degrade gracefully instead of raising NameError.
+
+    ``P2CardActionTrigger`` / ``P2CardActionTriggerResponse`` are referenced in
+    ``_on_card_action_trigger_sync``'s signature. Annotations are evaluated when
+    the class body runs, so leaving them unbound in the ``except ImportError``
+    branch turns a missing optional SDK into a module-level NameError.
+    """
+    module = importlib.import_module(MODULE)
+
+    assert module.FEISHU_AVAILABLE is False
+    assert module.P2CardActionTrigger is None
+    assert module.P2CardActionTriggerResponse is None
+
+
+def test_channel_classes_usable_without_lark_sdk(without_lark_sdk):
+    """The channel classes stay importable and constructible after the fallback."""
+    module = importlib.import_module(MODULE)
+
+    config = module.FeishuConfig(enabled=True, app_id="app", app_secret="secret")
+    assert config.channel_id == "feishu"
+    assert hasattr(module.FeishuChannel, "_on_card_action_trigger_sync")

--- a/tests/unit_tests/channel/test_feishu_import_fallback.py
+++ b/tests/unit_tests/channel/test_feishu_import_fallback.py
@@ -1,4 +1,3 @@
-# pylint: disable=protected-access
 """Tests for FeishuChannel import fallback when the lark_oapi SDK is absent.
 
 ``feishu_connect`` guards its ``lark_oapi`` imports with ``try/except


### PR DESCRIPTION
Paired: [GitHub #942](https://github.com/openJiuwen-ai/jiuwenswarm/pull/942) ↔ [GitCode !3939](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/3939)

## What

The `except ImportError` fallback in `feishu_connect.py` leaves two names unbound, which turns a missing optional SDK into a module-level `NameError`.

## Why it breaks

`feishu_connect` guards its `lark_oapi` imports and exposes `FEISHU_AVAILABLE` so the gateway can run without the Feishu SDK — the same pattern the Telegram, Discord and DingTalk channels use. But the fallback only rebinds two of the imported names:

```python
try:
    import lark_oapi as lark
    from lark_oapi.api.im.v1 import (...)
    from lark_oapi.event.callback.model.p2_card_action_trigger import (
        P2CardActionTrigger,
        P2CardActionTriggerResponse,
    )
    FEISHU_AVAILABLE = True
except ImportError:
    FEISHU_AVAILABLE = False
    lark = None
    Emoji = None          # P2CardActionTrigger / ...Response left unbound
```

Both missing names are used as annotations on `_on_card_action_trigger_sync` (line 2772):

```python
def _on_card_action_trigger_sync(self, data: P2CardActionTrigger) -> P2CardActionTriggerResponse:
```

This module has no `from __future__ import annotations`, so those annotations are evaluated eagerly while the `FeishuChannel` class body executes. The import fails before the module finishes loading:

```
NameError: name 'P2CardActionTrigger' is not defined
```

So the degraded path never runs, and the `if not FEISHU_AVAILABLE:` guard at line 344 is unreachable — `FEISHU_AVAILABLE = False` is assigned, but the module raises a few hundred lines later.

Importing the four channel modules with their SDKs absent shows Feishu is the only one affected:

| channel | result |
| --- | --- |
| **feishu** | ❌ `NameError: name 'P2CardActionTrigger' is not defined` |
| telegram | ✅ degrades |
| discord | ✅ degrades |
| dingtalk | ✅ degrades |

Also worth noting: `lark-oapi>=1.5.3` is declared with an open upper bound, and `lark_oapi.event.callback.model.p2_card_action_trigger` is a deep internal path. If a future release moves it, the `ImportError` is real — and users would hit a confusing `NameError` instead of the intended "Feishu SDK unavailable" degradation.

## Changes

Two lines in the fallback branch:

```python
except ImportError:
    FEISHU_AVAILABLE = False
    lark = None
    Emoji = None
    P2CardActionTrigger = None
    P2CardActionTriggerResponse = None
```

`None` matches how `lark` and `Emoji` are already handled, and the two names are only referenced under `FEISHU_AVAILABLE` guards or inside handlers that never run without the SDK. Checked the rest of the `try` block: no other imported symbol is referenced at module scope, so these two are the only gaps.

An alternative fix would be `from __future__ import annotations` to defer annotation evaluation — but `P2CardActionTriggerResponse` is also *called* at runtime (line 2862), so it needs a real binding either way. The two-line fallback is the smaller, more consistent change.

## Tests

`tests/unit_tests/channel/test_feishu_import_fallback.py` reloads the module with `lark_oapi` masked out of `sys.modules` and asserts the degraded contract: import succeeds, `FEISHU_AVAILABLE is False`, both symbols are `None`, and `FeishuConfig` / `FeishuChannel` stay usable. The fixture restores `sys.modules` afterwards so the rest of the suite is unaffected.

Both tests fail on `develop` and pass with this change:

```bash
uv run pytest tests/unit_tests/channel/test_feishu_import_fallback.py
# without the fix: 2 failed
# with the fix:    2 passed
```

## How to test

```bash
uv run pytest tests/unit_tests/channel/
```

Verified locally on Python 3.12. No behaviour change when `lark_oapi` is installed — the `try` branch is untouched.