### PR TITLE
feat(team): add request-scoped SwarmFlow concurrency limits

### DIFF
--- a/docs/en/CLI.md
+++ b/docs/en/CLI.md
@@ -275,6 +275,8 @@ jiuwenswarm chat "Hello, introduce yourself"
 | `--show-reasoning` | — | Include reasoning output (to stderr) |
 | `--show-tools` | — | Include compact tool call/result status (to stderr) |
 | `--timeout <seconds>` | — | Total response timeout in seconds |
+| `--swarmflow-max-workflows <count>` | Server config | Cap concurrent SwarmFlow runs for a new Team session |
+| `--swarmflow-max-agents <count>` | Server config | Cap concurrent SwarmFlow worker agents for a new Team session |
 
 ### Modes (`--mode`)
 
@@ -296,7 +298,14 @@ jiuwenswarm chat --mode code "help me analyze the code"
 
 # Using canonical values
 jiuwenswarm chat --mode code.plan "design a user system"
+
+# Bound a large multi-agent build without changing server configuration
+jiuwenswarm chat --mode code.team --swarmflow-max-workflows 2 \
+  --swarmflow-max-agents 6 "build and test the service"
 ```
+
+SwarmFlow limits can only tighten the server's configured caps. They take effect
+when the Team runtime is created; a reused `--session` retains its original limits.
 
 ### Session Reuse
 

--- a/jiuwenswarm/agents/harness/team/config_loader.py
+++ b/jiuwenswarm/agents/harness/team/config_loader.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any
 
 from openjiuwen.agent_teams.paths import get_agent_teams_home
+from openjiuwen.agent_teams.workflow.concurrency import ConcurrencyLimits
+from openjiuwen.agent_teams.workflow.engine.cap import resolve_agents_per_run_cap
 
 from jiuwenswarm.common.config import get_config
 
@@ -20,6 +22,7 @@ _DEFAULT_COMPLETION_TIMEOUT = 600.0
 _DEFAULT_AGENT_WORKSPACE = {"stable_base": True}
 _DEFAULT_TEAM_WORKSPACE = {"enabled": True}
 _DEFAULT_TRANSPORT = {"type": "inprocess"}
+_SWARMFLOW_OVERRIDE_FIELDS = frozenset({"max_workflows", "max_agents_total"})
 
 
 def _select_first_modes_team(config_base: dict[str, Any]) -> dict[str, Any]:
@@ -356,10 +359,54 @@ def _resolve_enable_permissions(config_base: dict[str, Any], team_raw: dict[str,
     return global_enabled and team_enabled
 
 
+def _apply_swarmflow_concurrency_override(
+    spec_dict: dict[str, Any],
+    override: dict[str, Any] | None,
+) -> None:
+    """Apply request limits without allowing them to exceed administrator caps."""
+    if override is None:
+        return
+    if not isinstance(override, dict):
+        raise ValueError("swarmflow_concurrency must be an object")
+    unknown = set(override) - _SWARMFLOW_OVERRIDE_FIELDS
+    if unknown:
+        raise ValueError(
+            f"unsupported swarmflow_concurrency fields: {', '.join(sorted(unknown))}"
+        )
+    for name, value in override.items():
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise ValueError(f"swarmflow_concurrency.{name} must be a positive integer")
+    if not override:
+        return
+
+    defaults = ConcurrencyLimits()
+    limits = deepcopy(spec_dict.get("swarmflow_concurrency") or {})
+    configured_max_agents = limits.get("max_agents_total", defaults.max_agents_total)
+    max_agents = min(
+        configured_max_agents,
+        override.get("max_agents_total", configured_max_agents),
+    )
+    limits["max_agents_total"] = max_agents
+    configured_max_workflows = limits.get("max_workflows", defaults.max_workflows)
+    limits["max_workflows"] = min(
+        configured_max_workflows,
+        override.get("max_workflows", configured_max_workflows),
+        max_agents,
+    )
+    limits["agents_per_run"] = min(
+        resolve_agents_per_run_cap(
+            limits.get("agents_per_run", defaults.agents_per_run)
+        ),
+        max_agents,
+    )
+    spec_dict["swarmflow_concurrency"] = limits
+
+
 def load_team_spec_dict(
     config_base: dict[str, Any] | None = None,
     *,
     requested_model_name: str | None = None,
+    swarmflow_concurrency: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Load team config and build a TeamAgentSpec-compatible dict.
 
@@ -383,6 +430,7 @@ def load_team_spec_dict(
     )
     spec_dict = deepcopy(team_raw)
     spec_dict.pop("enable_team_plan", None)
+    _apply_swarmflow_concurrency_override(spec_dict, swarmflow_concurrency)
 
     spec_dict["team_name"] = str(team_raw.get("team_name", "team")).strip() or "team"
     spec_dict["lifecycle"] = team_raw.get("lifecycle", "persistent")

--- a/jiuwenswarm/agents/harness/team/team_manager.py
+++ b/jiuwenswarm/agents/harness/team/team_manager.py
@@ -487,6 +487,7 @@ class TeamManager:
         session_id: str,
         *,
         requested_model_name: str | None = None,
+        swarmflow_concurrency: dict[str, Any] | None = None,
     ) -> TeamAgentSpec:
         config_base = get_config()
         # Keep dependency checks scoped to distributed mode to make the
@@ -513,6 +514,7 @@ class TeamManager:
         spec_dict = load_team_spec_dict(
             config_base=config_base,
             requested_model_name=requested_model_name,
+            swarmflow_concurrency=swarmflow_concurrency,
         )
         spec_dict = TeamManager._normalize_team_identity_fields(spec_dict)
         if TeamManager._is_distributed_mode(config_base):
@@ -573,6 +575,7 @@ class TeamManager:
         channel_id: str | None = None,
         request_metadata: dict[str, Any] | None = None,
         requested_model_name: str | None = None,
+        swarmflow_concurrency: dict[str, Any] | None = None,
     ) -> TeamAgentSpec:
         """Build a team spec via provider-based assembly (no parent DeepAgent).
 
@@ -587,6 +590,7 @@ class TeamManager:
             request_id: Originating request id, if any.
             channel_id: Raw channel id from the request, if any.
             request_metadata: Request metadata mapping.
+            swarmflow_concurrency: Optional session-start SwarmFlow caps.
 
         Returns:
             The enriched ``TeamAgentSpec`` ready to build (``build_context`` set;
@@ -599,6 +603,7 @@ class TeamManager:
         spec = self._load_team_spec(
             session_id,
             requested_model_name=requested_model_name,
+            swarmflow_concurrency=swarmflow_concurrency,
         )
         self._apply_session_scoped_team_name(spec, session_id=session_id)
         self.apply_team_plan_mode(spec, request_metadata=request_metadata)

--- a/jiuwenswarm/cli/chat.py
+++ b/jiuwenswarm/cli/chat.py
@@ -314,6 +314,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--timeout", type=float,
         help="Total response timeout in seconds.",
     )
+    p.add_argument(
+        "--swarmflow-max-workflows", type=int,
+        help="Team session cap for concurrent SwarmFlow runs.",
+    )
+    p.add_argument(
+        "--swarmflow-max-agents", type=int,
+        help="Team session cap for concurrent SwarmFlow worker agents.",
+    )
     return p
 
 
@@ -331,6 +339,17 @@ def _validate_args(args: argparse.Namespace) -> int | None:
     if args.timeout is not None and args.timeout <= 0:
         logger.error("--timeout must be positive")
         return 2
+    swarmflow_limits = (
+        getattr(args, "swarmflow_max_workflows", None),
+        getattr(args, "swarmflow_max_agents", None),
+    )
+    if any(value is not None for value in swarmflow_limits):
+        if args.mode not in ("team", "team.plan", "code.team"):
+            logger.error("--swarmflow-* options require a Team mode")
+            return 2
+        if any(value is not None and value <= 0 for value in swarmflow_limits):
+            logger.error("--swarmflow-* values must be positive")
+            return 2
     return None
 
 
@@ -351,7 +370,7 @@ def _build_request(args: argparse.Namespace, prompt: str) -> dict:
         if pd not in trusted_dirs:
             trusted_dirs.append(pd)
 
-    return {
+    request = {
         "type": "req",
         "id": f"chat-{uuid_module.uuid4().hex[:12]}",
         "method": "chat.send",
@@ -370,6 +389,17 @@ def _build_request(args: argparse.Namespace, prompt: str) -> dict:
             "agent_ref": {"mode": args.mode, "id": "default"},
         },
     }
+    swarmflow_concurrency = {
+        name: value
+        for name, value in (
+            ("max_workflows", getattr(args, "swarmflow_max_workflows", None)),
+            ("max_agents_total", getattr(args, "swarmflow_max_agents", None)),
+        )
+        if value is not None
+    }
+    if swarmflow_concurrency:
+        request["params"]["swarmflow_concurrency"] = swarmflow_concurrency
+    return request
 
 
 async def _spinner_loop(renderer: HumanRenderer) -> None:

--- a/jiuwenswarm/cli/chat.py
+++ b/jiuwenswarm/cli/chat.py
@@ -389,14 +389,13 @@ def _build_request(args: argparse.Namespace, prompt: str) -> dict:
             "agent_ref": {"mode": args.mode, "id": "default"},
         },
     }
-    swarmflow_concurrency = {
-        name: value
-        for name, value in (
-            ("max_workflows", getattr(args, "swarmflow_max_workflows", None)),
-            ("max_agents_total", getattr(args, "swarmflow_max_agents", None)),
-        )
-        if value is not None
-    }
+    swarmflow_concurrency = {}
+    max_workflows = getattr(args, "swarmflow_max_workflows", None)
+    if max_workflows is not None:
+        swarmflow_concurrency["max_workflows"] = max_workflows
+    max_agents = getattr(args, "swarmflow_max_agents", None)
+    if max_agents is not None:
+        swarmflow_concurrency["max_agents_total"] = max_agents
     if swarmflow_concurrency:
         request["params"]["swarmflow_concurrency"] = swarmflow_concurrency
     return request

--- a/jiuwenswarm/common/schema/chat_send.py
+++ b/jiuwenswarm/common/schema/chat_send.py
@@ -75,6 +75,9 @@ class ChatSendParams(TypedDict, total=False):
     model_name: NotRequired[str]
     """模型名称（Web 前端可选传递）。"""
 
+    swarmflow_concurrency: NotRequired[dict]
+    """本次 Team 会话创建时使用的 SwarmFlow 并发上限。"""
+
     request_id: NotRequired[str]
     """请求 ID（interrupt resume / 问答回复场景关联）。"""
 

--- a/jiuwenswarm/server/runtime/agent_adapter/team_helpers.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/team_helpers.py
@@ -1483,6 +1483,11 @@ async def process_team_message_stream(
             if isinstance(params_obj, dict)
             else ""
         ) or None
+        swarmflow_concurrency = (
+            params_obj.get("swarmflow_concurrency")
+            if isinstance(params_obj, dict)
+            else None
+        )
         # Provider-based assembly: build members from the shared config source,
         # no pre-built parent DeepAgent required.
         team_spec = await team_manager.get_swarm_enriched_team_spec(
@@ -1493,6 +1498,7 @@ async def process_team_message_stream(
             channel_id=channel_id,
             request_metadata=request_metadata,
             requested_model_name=requested_model_name,
+            swarmflow_concurrency=swarmflow_concurrency,
         )
         _persist_team_file_monitor_roots(session_id, team_spec)
     except Exception as exc:

--- a/tests/unit_tests/agentserver/test_team_config_loader.py
+++ b/tests/unit_tests/agentserver/test_team_config_loader.py
@@ -15,6 +15,41 @@ def _wrap_modes_team(team_mapping: dict[str, dict]) -> dict:
     return {"modes": {"team": team_mapping}}
 
 
+def test_request_swarmflow_limits_are_validated_and_clamped_to_admin_config():
+    configured = {
+        "max_workflows": 8,
+        "agents_per_run": 6,
+        "max_agents_total": 12,
+    }
+    config = _wrap_modes_team({"demo": {"swarmflow_concurrency": configured}})
+
+    spec = load_team_spec_dict(
+        config_base=config,
+        swarmflow_concurrency={"max_workflows": 20, "max_agents_total": 4},
+    )
+
+    assert spec["swarmflow_concurrency"] == {
+        "max_workflows": 4,
+        "agents_per_run": 4,
+        "max_agents_total": 4,
+    }
+    assert configured == {
+        "max_workflows": 8,
+        "agents_per_run": 6,
+        "max_agents_total": 12,
+    }
+    workflows_only = load_team_spec_dict(
+        config_base=config,
+        swarmflow_concurrency={"max_workflows": 2},
+    )
+    assert workflows_only["swarmflow_concurrency"]["max_agents_total"] == 12
+    with pytest.raises(ValueError, match="positive integer"):
+        load_team_spec_dict(
+            config_base=config,
+            swarmflow_concurrency={"max_agents_total": 0},
+        )
+
+
 def test_load_team_spec_dict_reads_models_defaults_from_repository_config(monkeypatch):
     """Repository config template should provide the default team model from models.defaults."""
     repo_config = Path(__file__).resolve().parents[3] / "jiuwenswarm" / "resources" / "config.yaml"

--- a/tests/unit_tests/agentserver/test_team_helpers.py
+++ b/tests/unit_tests/agentserver/test_team_helpers.py
@@ -1389,6 +1389,7 @@ async def test_process_team_message_stream_handles_team_evolve_list(monkeypatch,
         records=[_evolution_record("First summary line")],
     )
     captured_spec: list[object] = []
+    captured_kwargs: dict[str, object] = {}
 
     class _FakeManager(_InactiveTeamRuntimeManagerMixin):
         @staticmethod
@@ -1397,6 +1398,7 @@ async def test_process_team_message_stream_handles_team_evolve_list(monkeypatch,
 
         @staticmethod
         async def get_swarm_enriched_team_spec(**kwargs):
+            captured_kwargs.update(kwargs)
             spec = SimpleNamespace(
                 team_name="unit-team",
                 workspace=SimpleNamespace(root_path=str(tmp_path / "team-workspace")),
@@ -1411,6 +1413,10 @@ async def test_process_team_message_stream_handles_team_evolve_list(monkeypatch,
         request_id="req-team-stream",
         channel_id="web",
         metadata=None,
+        params={
+            "mode": "code.team",
+            "swarmflow_concurrency": {"max_agents_total": 4},
+        },
     )
     inputs = {"query": "/evolve_list demo-skill"}
 
@@ -1435,6 +1441,7 @@ async def test_process_team_message_stream_handles_team_evolve_list(monkeypatch,
     assert chunks[1].is_complete is False
     assert chunks[2].is_complete is True
     assert captured_spec
+    assert captured_kwargs["swarmflow_concurrency"] == {"max_agents_total": 4}
 
 
 @pytest.mark.anyio

--- a/tests/unit_tests/cli/test_chat.py
+++ b/tests/unit_tests/cli/test_chat.py
@@ -221,6 +221,22 @@ class TestBuildRequest:
         ids = {_build_request(args, "test")["id"] for _ in range(5)}
         assert len(ids) == 5
 
+    @staticmethod
+    def test_swarmflow_limits_are_sent_for_team_mode(monkeypatch):
+        monkeypatch.setattr(os, "getcwd", lambda: "/cwd")
+        args = build_parser().parse_args([
+            "--mode", "code.team",
+            "--swarmflow-max-workflows", "2",
+            "--swarmflow-max-agents", "6",
+            "build it",
+        ])
+
+        assert _validate_args(args) is None
+        assert _build_request(args, "build it")["params"]["swarmflow_concurrency"] == {
+            "max_workflows": 2,
+            "max_agents_total": 6,
+        }
+
 
 class TestValidateArgs:
     @staticmethod
@@ -260,6 +276,11 @@ class TestValidateArgs:
                                   show_reasoning=False, show_tools=False, timeout=None)
         assert _validate_args(args) is None
         assert args.mode == "agent"
+
+    @staticmethod
+    def test_swarmflow_limits_require_team_mode():
+        args = build_parser().parse_args(["--swarmflow-max-agents", "2", "test"])
+        assert _validate_args(args) == 2
 
 
 class TestParser:


### PR DESCRIPTION
Paired: [GitHub #1210](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1210) ↔ [GitCode !4029](https://gitcode.com/openJiuwen/jiuwenswarm/pull/4029)

**What type of PR is this?**

  /kind feature


  **What does this PR do / why do we need it**:

  JiuwenSwarm already provides administrator-configured SwarmFlow concurrency limits, but every Team session uses the same global limits. Hosted services and automation jobs cannot request a smaller resource
  allocation without changing policy for every user.

  This PR adds two optional Team-mode CLI arguments:

  - `--swarmflow-max-workflows`
  - `--swarmflow-max-agents`

  The requested limits are forwarded through `chat.send` to Team configuration loading when a session runtime is created.

  Safety properties:

  - A request can only reduce administrator-configured limits, never increase them.
  - `max_workflows`, `agents_per_run`, and `max_agents_total` remain mutually consistent.
  - Zero, negative, Boolean, and unsupported values are rejected.
  - Existing clients and sessions that do not provide these options retain current behavior.
  - No new dependency is introduced.

  This was motivated by an IncidentHub multi-agent benchmark in which one hosted job launched six sequential workflows and used more than five million model tokens across build and repair phases. This
  feature limits concurrent resource consumption per Team session. It intentionally does not impose a total workflow or token budget.


  **Which issue(s) this PR fixes**:

  N/A — benchmark-backed feature proposal; no equivalent open issue or pull request was found.


  **What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

  - 229 targeted unit tests passed; 2 existing tests were skipped.
  - CLI tests verify both new options are parsed and transmitted only in Team mode.
  - Configuration tests verify requested limits are clamped to administrator limits.
  - Invalid and unsupported request values are rejected.
  - Team helper tests verify request values reach Team runtime construction.
  - Direct `TeamAgentSpec` validation produced effective limits of:
    - `max_workflows=4`
    - `agents_per_run=4`
    - `max_agents_total=4`
  - `git diff --check` passed.
  - No additional network call, background process, or third-party dependency is introduced.
  - The branch was rebased onto current `develop`.
  - All 50 open PRs were reviewed. PR #1081 touches `team_helpers.py` at a separate hunk and its patch applies cleanly.


  **Self-checklist**:

  + - [ ] **Design**: Maintainer design review has not yet been requested; feedback is welcome.
  + - [x] **Test**: New CLI, validation, forwarding, and invariant test cases are included.
  + - [x] **Verification**: Functional and reliability verification results are documented above.
  + - [ ] **Interface**: This adds optional CLI flags and an optional request field; maintainer interface confirmation is requested.
  + - [x] **Document**: `docs/en/CLI.md` documents the new options and usage example.


  **Special notes for reviewers**:

  - The interface change is additive and optional.
  - Existing clients retain their current behavior.
  - No third-party dependency changes are involved.