### PR TITLE
 feat(cli): add atomic run reports and reliable terminal error exits

### DIFF
--- a/docs/en/CLI.md
+++ b/docs/en/CLI.md
@@ -274,6 +274,7 @@ jiuwenswarm chat "Hello, introduce yourself"
 | `--jsonl` | — | Print each Gateway event frame as JSON Lines |
 | `--show-reasoning` | — | Include reasoning output (to stderr) |
 | `--show-tools` | — | Include compact tool call/result status (to stderr) |
+| `--report <path>` | — | Atomically write a JSON run summary without changing stdout |
 | `--timeout <seconds>` | — | Total response timeout in seconds |
 
 ### Modes (`--mode`)
@@ -360,6 +361,16 @@ jiuwenswarm chat --json "analyze README"
 # JSONL output (pipe-friendly)
 jiuwenswarm chat --jsonl "analyze README" | jq
 ```
+
+For CI and scheduled jobs, `--report` records the invocation outcome even when
+human, JSON, or JSONL output is redirected elsewhere:
+
+```bash
+jiuwenswarm chat --report artifacts/run.json "deploy the service"
+```
+
+The report contains the exit code, mode, session ID, output mode, timestamps,
+and duration. Prompts and model output are intentionally excluded.
 
 ### Interrupts
 

--- a/jiuwenswarm/cli/chat.py
+++ b/jiuwenswarm/cli/chat.py
@@ -44,6 +44,7 @@ from jiuwenswarm.cli.gateway_client import GatewayClient
 from jiuwenswarm.cli.events import (
     event_kind,
     is_content_final,
+    is_error_event,
     is_terminal_event,
 )
 from jiuwenswarm.cli.render import HumanRenderer, JsonRenderer, JsonlRenderer
@@ -309,6 +310,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--show-tools", action="store_true",
         help="Include compact tool call/result status (stderr).",
+    )
+    p.add_argument(
+        "--report",
+        help="Atomically write a machine-readable run summary to this path.",
     )
     p.add_argument(
         "--timeout", type=float,
@@ -615,6 +620,10 @@ async def _run_interactive_loop(
             payload = data.get("payload", {})
             kind = event_kind(event_type)
 
+            if is_error_event(event_type, payload):
+                renderer.handle_error(payload)
+                return 1
+
             # Any event arriving during the team idle-watch window means
             # the team is still active (member tool calls, reasoning, etc.).
             # Reset the idle timer so we don't prematurely prompt the user.
@@ -631,13 +640,6 @@ async def _run_interactive_loop(
             elif kind == "tool_result":
                 renderer.handle_tool_result(payload)
             elif kind == "final":
-                # team.error is broadcast through the chat.final envelope
-                # (gateway default for unknown EventType). Route it to the
-                # error handler so the message is shown instead of silently
-                # exiting on an empty content field.
-                if payload.get("event_type") == "team.error":
-                    renderer.handle_error(payload)
-                    return 1
                 # Unknown/control event types are transported in a chat.final
                 # envelope. They must not consume HumanRenderer's one final
                 # slot or arm the team idle timer.
@@ -651,9 +653,6 @@ async def _run_interactive_loop(
                 if team_mode:
                     team_final_seen = True
                     team_final_time = time.monotonic()
-            elif kind == "error":
-                renderer.handle_error(payload)
-                return 1
             elif kind == "processing_status":
                 if payload.get("is_processing", False):
                     renderer.ensure_loading()
@@ -759,9 +758,6 @@ async def _run_interactive_loop(
                 # processing_status(is_processing=False) or team.error ends
                 # the stream.
                 if team_mode and event_type == "chat.final":
-                    if payload.get("event_type") == "team.error":
-                        renderer.clear_loading()
-                        return 1
                     # leader reply or team control event — keep listening
                     continue
                 # In team mode, a completed round (processing_status
@@ -876,13 +872,9 @@ async def _run_jsonl_loop(
         event_type = data.get("event", "")
         payload = data.get("payload", {})
         renderer.handle_event(event_type, payload)
-        if event_type == "chat.error":
+        if is_error_event(event_type, payload):
             return 1
         if is_terminal_event(event_type, payload):
-            # team.error is wrapped in chat.final by the gateway; treat it
-            # as an error exit so callers can detect the failure.
-            if payload.get("event_type") == "team.error":
-                return 1
             # In team mode, chat.final (leader reply) is not terminal —
             # the team keeps working. Keep listening for
             # processing_status(is_processing=False).
@@ -898,38 +890,28 @@ async def _run_json_loop(
 ) -> int:
     team_mode = request.get("params", {}).get("mode", "") in ("team", "team.plan", "code.team")
     await client.send_request(request)
-    has_error = False
     while True:
         data = await client.recv()
         if data.get("type") != "event":
             continue
         event_type = data.get("event", "")
         payload = data.get("payload", {})
-        if event_type == "chat.final":
-            # team.error is wrapped in chat.final by the gateway; route it
-            # through the error path so has_error is set and the JSON output
-            # reports ok=false.
-            if payload.get("event_type") == "team.error":
-                renderer.handle_error(payload)
-                has_error = True
-            else:
-                renderer.handle_event(event_type, payload)
-        elif event_type == "chat.error":
+        if is_error_event(event_type, payload):
             renderer.handle_error(payload)
-            has_error = True
+            renderer.output()
+            return 1
+        if event_type == "chat.final":
+            renderer.handle_event(event_type, payload)
         elif event_type == "chat.delta":
             pass
         else:
             renderer.handle_event(event_type, payload)
         if is_terminal_event(event_type, payload):
             if team_mode and event_type == "chat.final":
-                if payload.get("event_type") == "team.error":
-                    renderer.output()
-                    return 1
                 # leader reply — team keeps working, keep listening
                 continue
             renderer.output()
-            return 1 if has_error else 0
+            return 0
 
 
 async def _run_chat(
@@ -988,7 +970,63 @@ def _print_connection_hint(url: str, args: argparse.Namespace) -> None:
         logger.error("Start services with: jiuwenswarm-start app")
 
 
+def _write_run_report(
+    path: str,
+    args: argparse.Namespace,
+    exit_code: int,
+    *,
+    started_at: datetime.datetime,
+    started_monotonic: float,
+) -> None:
+    finished_at = datetime.datetime.now(datetime.UTC)
+    target = Path(path).expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+    report = {
+        "schema_version": 1,
+        "ok": exit_code == 0,
+        "exit_code": exit_code,
+        "mode": args.mode,
+        "session_id": args.session,
+        "output_mode": "jsonl" if args.jsonl else "json" if args.json else "human",
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat(),
+        "duration_ms": round((time.monotonic() - started_monotonic) * 1000),
+    }
+    try:
+        temporary.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
 def run_chat(args: argparse.Namespace) -> int:
+    report_path = getattr(args, "report", None)
+    if not report_path:
+        return _run_chat_command(args)
+
+    started_at = datetime.datetime.now(datetime.UTC)
+    started_monotonic = time.monotonic()
+    args.session = args.session or _generate_session_id()
+    exit_code = _run_chat_command(args)
+    try:
+        _write_run_report(
+            report_path,
+            args,
+            exit_code,
+            started_at=started_at,
+            started_monotonic=started_monotonic,
+        )
+    except OSError as exc:
+        logger.error("cannot write run report %s: %s", report_path, exc)
+        return exit_code or 1
+    return exit_code
+
+
+def _run_chat_command(args: argparse.Namespace) -> int:
     error = _validate_args(args)
     if error is not None:
         return error

--- a/jiuwenswarm/cli/events.py
+++ b/jiuwenswarm/cli/events.py
@@ -13,13 +13,21 @@ def is_content_final(payload: dict[str, Any]) -> bool:
     return not inner or inner == "chat.final"
 
 
+def is_error_event(event_type: str, payload: dict[str, Any]) -> bool:
+    """Return whether a terminal chat event carries an error."""
+    return event_type == "chat.error" or (
+        event_type == "chat.final"
+        and (
+            payload.get("event_type") == "team.error"
+            or payload.get("error") not in (None, "")
+        )
+    )
+
+
 def is_terminal_event(event_type: str, payload: dict[str, Any]) -> bool:
-    if event_type == "chat.error":
+    if is_error_event(event_type, payload):
         return True
     if event_type == "chat.final":
-        inner = payload.get("event_type", "")
-        if inner == "team.error":
-            return True
         # Gateway uses chat.final as a compatibility envelope for event types
         # without an EventType mapping (team.runtime_ready, chat.llm_usage,
         # keepalive, etc.). Those control events do not end the response.

--- a/tests/unit_tests/cli/test_chat.py
+++ b/tests/unit_tests/cli/test_chat.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import pytest
 
+import jiuwenswarm.cli.chat as chat_module
 from jiuwenswarm.cli.chat import (
     MODE_ALIASES,
     VALID_MODES,
@@ -28,6 +29,7 @@ from jiuwenswarm.cli.chat import (
     _validate_args,
     build_parser,
     resolve_mode,
+    run_chat,
 )
 from jiuwenswarm.cli.events import (
     event_kind,
@@ -319,6 +321,28 @@ class TestParser:
         assert ns.show_reasoning is True
         assert ns.show_tools is True
         assert ns.timeout == 60
+
+
+def test_run_report_records_failed_invocation_without_prompt(monkeypatch, tmp_path):
+    report_path = tmp_path / "reports" / "run.json"
+    args = build_parser().parse_args([
+        "--mode", "code.team",
+        "--report", str(report_path),
+        "private prompt",
+    ])
+    monkeypatch.setattr(chat_module, "_run_chat_command", lambda _args: 3)
+
+    assert run_chat(args) == 3
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["schema_version"] == 1
+    assert report["ok"] is False
+    assert report["exit_code"] == 3
+    assert report["mode"] == "code.team"
+    assert report["session_id"].startswith("cli-")
+    assert report["output_mode"] == "human"
+    assert report["duration_ms"] >= 0
+    assert "prompt" not in report
+    assert not list(report_path.parent.glob("*.tmp"))
 
 
 class TestEvents:
@@ -783,6 +807,40 @@ class TestInteractiveLoop:
                        "trusted_dirs": ["/tmp"]},
         }
         code = await _run_interactive_loop(client, renderer, request)
+        assert code == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("runner", "renderer_type"),
+        [
+            (chat_module._run_interactive_loop, HumanRenderer),
+            (chat_module._run_json_loop, JsonRenderer),
+            (chat_module._run_jsonl_loop, JsonlRenderer),
+        ],
+    )
+    async def test_final_error_returns_1_in_every_output_mode(
+        self, runner, renderer_type
+    ):
+        messages = [
+            {
+                "type": "event",
+                "event": "chat.final",
+                "payload": {"error": "model request failed"},
+            },
+        ]
+        client = await self._make_connected_client(messages)
+        request = {
+            "type": "req", "id": "r1", "method": "chat.send",
+            "is_stream": True,
+            "params": {"session_id": "s1", "content": "hi", "query": "hi",
+                       "mode": "code.team", "cwd": "/tmp", "project_dir": "/tmp",
+                       "trusted_dirs": ["/tmp"]},
+        }
+
+        code = await asyncio.wait_for(
+            runner(client, renderer_type(), request), timeout=1
+        )
+
         assert code == 1
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/cli/test_events.py
+++ b/tests/unit_tests/cli/test_events.py
@@ -88,6 +88,10 @@ class TestEvents:
         ) is True
 
     @staticmethod
+    def test_is_terminal_chat_final_error_payload():
+        assert is_terminal_event("chat.final", {"error": "boom"}) is True
+
+    @staticmethod
     def test_is_terminal_chat_error():
         assert is_terminal_event("chat.error", {}) is True
 


### PR DESCRIPTION
Paired: [GitHub #1211](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1211) ↔ [GitCode !4030](https://gitcode.com/openJiuwen/jiuwenswarm/pull/4030)

**What type of PR is this?**

  /kind feature


  **What does this PR do / why do we need it**:

  JiuwenSwarm CLI automation currently has to infer invocation success from streamed human, JSON, or JSONL output. It has no durable summary that survives connection failures without changing the selected
  stdout format.

  A live multi-agent benchmark also exposed a reliability problem: a terminal `chat.final` event containing a non-empty `error` field could be interpreted as successful completion.

  This PR adds:

  - `--report PATH`, which writes a versioned JSON invocation summary.
  - Atomic report replacement using a temporary file and `os.replace`.
  - A shared terminal-error classifier used by human, JSON, and JSONL modes.
  - Non-zero exit status for `chat.error`, nested `team.error`, and `chat.final` events containing an error.
  - `ok: false` in reports when execution fails.

  The report contains only:

  - Schema version
  - Success state and exit code
  - Mode and session ID
  - Output mode
  - Start and finish timestamps
  - Duration

  Prompts, model responses, reasoning, and tool output are intentionally excluded. JSONL remains the existing detailed event-trace format.


  **Which issue(s) this PR fixes**:

  N/A — benchmark-backed feature proposal; no equivalent open issue or pull request was found.


  **What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

  - All 116 CLI and event tests passed.
  - Human, JSON, and JSONL modes return exit code 1 for terminal `chat.final` error payloads.
  - Existing `team.error` handling remains covered.
  - Control events transported inside `chat.final` remain non-terminal.
  - A failed invocation creates a report with `ok: false` and the correct exit code.
  - An unreachable-Gateway smoke test returned exit code 3 and still produced valid JSON with a generated session ID and measured duration.
  - Tests verify prompts are absent from reports.
  - Tests verify no temporary report file remains after a successful atomic write.
  - A report-write failure cannot turn a failed invocation into success.
  - `git diff --check` and changed-file Ruff checks passed.
  - No third-party dependency is introduced.
  - The branch was rebased onto current `develop`.
  - No changed-file overlap or equivalent proposal was found among the 50 open PRs.


  **Self-checklist**:

  + - [ ] **Design**: Maintainer design review has not yet been requested; feedback is welcome.
  + - [x] **Test**: New run-report and terminal-error test cases are included.
  + - [x] **Verification**: Functional and reliability verification results are documented above.
  + - [ ] **Interface**: This adds an optional CLI flag and report schema; maintainer interface confirmation is requested.
  + - [x] **Document**: `docs/en/CLI.md` documents the report option, contents, and privacy scope.


  **Special notes for reviewers**:

  - The CLI change is additive and optional.
  - Normal stdout behavior is unchanged when `--report` is used.
  - No third-party dependency changes are involved.