### PR TITLE
feat(memory): support cron schedules for Dreaming

### DIFF
--- a/docs/en/Memory.md
+++ b/docs/en/Memory.md
@@ -93,10 +93,19 @@ memory:
     agent:
       enabled: false
       interval_seconds: 14400   # 4 hours by default
+      # cron_expr: "0 0 * * *"  # Optional: every day at 00:00
+      # timezone: Asia/Shanghai
     code:
       enabled: false
       interval_seconds: 14400
+      # cron_expr: "0 0 * * *"
+      # timezone: Asia/Shanghai
 ```
+
+`cron_expr` accepts either a 5-field cron expression
+(`minute hour day month weekday`) or a 7-field Quartz expression
+(`second minute hour day month weekday year`). When set, it takes precedence
+over `interval_seconds`.
 
 Env overrides:
 
@@ -105,6 +114,8 @@ Env overrides:
 | `DREAMING_AGENT_ENABLED` | Toggle for agent-mode Dreaming |
 | `DREAMING_CODE_ENABLED` | Toggle for code-mode Dreaming |
 | `DREAMING_INTERVAL` | Sweep interval in seconds (applies to both modes) |
+| `DREAMING_CRON_EXPR` | Cron schedule (applies to both modes and takes precedence over the interval) |
+| `DREAMING_TIMEZONE` | IANA timezone for the cron schedule; defaults to `Asia/Shanghai` |
 
 The LLM call reuses `models.default`; no extra model config required.
 
@@ -167,7 +178,9 @@ For enabling, see [Configuration → Dreaming Configuration](#dreaming-configura
 
 ### How it works
 
-- **Scheduling**: an in-process Orchestrator fires every `interval_seconds`, with a 120s initial delay after startup
+- **Scheduling**: without `cron_expr`, an in-process Orchestrator fires every
+  `interval_seconds`, with a 120s initial delay after startup. With
+  `cron_expr`, it fires at the next matching wall-clock time in `timezone`.
 - **Busy backoff**: skipped when the agent is actively handling a request; retried next cycle
 - **Incremental scan**: a checkpoint tracks processed sessions; sessions with fewer than 4 rounds or older than 30 days are skipped
 - **Cost control**: at most 10 sessions per sweep, each compressed to under 30K tokens; at most 5 entries extracted per session

--- a/docs/zh/记忆.md
+++ b/docs/zh/记忆.md
@@ -90,7 +90,9 @@ JiuwenSwarm 支持两种记忆模式，可通过 `memory.engine` 配置项控制
 | `code` | 调试根因、API 边界行为、设计决策等可复用技术经验 | `{workspace}/coding_memory/consolidated_{hash}.md`（按内容去重） |
 
 **工作机制**：
-- **定时触发**：每隔 `interval_seconds` 检查一次，启动后 120s 后首次开始扫描
+- **定时触发**：未配置 `cron_expr` 时，每隔 `interval_seconds`
+  检查一次，启动 120s 后首次扫描；配置后则按 `timezone` 指定时区，
+  在下一个符合表达式的墙上时钟时间扫描
 - **忙碌退避**：Agent 正在处理请求时跳过本次扫描，下一周期再试
 - **增量扫描**：通过 checkpoint 记录已处理 session，不重复处理
 
@@ -104,10 +106,18 @@ memory:
     agent:
       enabled: false
       interval_seconds: 14400   # 默认 4 小时
+      # cron_expr: "0 0 * * *"  # 可选：每天 00:00
+      # timezone: Asia/Shanghai
     code:
       enabled: false
       interval_seconds: 14400
+      # cron_expr: "0 0 * * *"
+      # timezone: Asia/Shanghai
 ```
+
+`cron_expr` 支持 5 段式 Cron 表达式（分、时、日、月、周）和 7 段式
+Quartz 表达式（秒、分、时、日、月、周、年）。配置后会优先于
+`interval_seconds` 生效。
 
 **环境变量覆盖**：
 
@@ -116,6 +126,8 @@ memory:
 | `DREAMING_AGENT_ENABLED` | Agent 模式 Dreaming 开关 |
 | `DREAMING_CODE_ENABLED` | Code 模式 Dreaming 开关 |
 | `DREAMING_INTERVAL` | 扫描间隔（秒），覆盖两种模式 |
+| `DREAMING_CRON_EXPR` | 定时表达式，覆盖两种模式并优先于扫描间隔 |
+| `DREAMING_TIMEZONE` | 定时表达式使用的 IANA 时区，默认 `Asia/Shanghai` |
 
 ### Agent Swarm 协同
 

--- a/jiuwenswarm/agents/harness/common/memory/dreaming/__init__.py
+++ b/jiuwenswarm/agents/harness/common/memory/dreaming/__init__.py
@@ -17,19 +17,24 @@ from typing import Callable
 
 from openjiuwen.core.memory.dreaming import DreamingOrchestrator
 
+from .scheduler import CronDreamingOrchestrator
+
 __all__ = [
     "start_dreaming",
     "stop_dreaming",
     "get_dreaming_orchestrator",
     "DreamingOrchestrator",
+    "CronDreamingOrchestrator",
 ]
 
 logger = logging.getLogger(__name__)
 
-_orchestrators: dict[str, DreamingOrchestrator] = {}
+DreamingService = DreamingOrchestrator | CronDreamingOrchestrator
+
+_orchestrators: dict[str, DreamingService] = {}
 
 
-def get_dreaming_orchestrator(mode: str = "agent") -> DreamingOrchestrator | None:
+def get_dreaming_orchestrator(mode: str = "agent") -> DreamingService | None:
     return _orchestrators.get(mode)
 
 
@@ -38,7 +43,7 @@ async def start_dreaming(
     output_dir: str,
     mode: str = "agent",
     busy_checker: Callable[[], bool] | None = None,
-) -> DreamingOrchestrator | None:
+) -> DreamingService | None:
     """Start dreaming service.
     Idempotent: same mode repeated call returns existing instance.
     """
@@ -55,12 +60,21 @@ async def start_dreaming(
     sweeper = Sweeper(sessions_dir, output_dir, mode=mode)
     sweeper.init()
 
-    orch = DreamingOrchestrator(
-        sweep_fn=sweeper.run_sweep,
-        interval_seconds=cfg.interval_seconds,
-        busy_checker=busy_checker,
-        name=f"dreaming-{mode}",
-    )
+    if cfg.cron_expr is not None:
+        orch: DreamingService = CronDreamingOrchestrator(
+            sweep_fn=sweeper.run_sweep,
+            cron_expr=cfg.cron_expr,
+            timezone=cfg.timezone,
+            busy_checker=busy_checker,
+            name=f"dreaming-{mode}",
+        )
+    else:
+        orch = DreamingOrchestrator(
+            sweep_fn=sweeper.run_sweep,
+            interval_seconds=cfg.interval_seconds,
+            busy_checker=busy_checker,
+            name=f"dreaming-{mode}",
+        )
     await orch.start()
     _orchestrators[mode] = orch
     return orch

--- a/jiuwenswarm/agents/harness/common/memory/dreaming/scheduler.py
+++ b/jiuwenswarm/agents/harness/common/memory/dreaming/scheduler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone as datetime_timezone
 from typing import Any, Awaitable, Callable
 from zoneinfo import ZoneInfo
 
@@ -50,8 +50,8 @@ def _delay_until(next_time: datetime, now: datetime) -> float:
     return max(
         0.0,
         (
-            next_time.astimezone(timezone.utc)
-            - now.astimezone(timezone.utc)
+            next_time.astimezone(datetime_timezone.utc)
+            - now.astimezone(datetime_timezone.utc)
         ).total_seconds(),
     )
 
@@ -134,8 +134,6 @@ class CronDreamingOrchestrator:
                 await asyncio.sleep(delay)
                 if self._running:
                     await self._tick()
-        except asyncio.CancelledError:
-            raise
         except Exception:
             logger.exception(
                 "[%s] cron loop terminated unexpectedly",
@@ -164,7 +162,5 @@ class CronDreamingOrchestrator:
             logger.info("[%s] start sweep", self._name)
             await self._sweep_fn()
             logger.info("[%s] sweep completed", self._name)
-        except asyncio.CancelledError:
-            raise
         except Exception:
             logger.exception("[%s] sweep failed", self._name)

--- a/jiuwenswarm/agents/harness/common/memory/dreaming/scheduler.py
+++ b/jiuwenswarm/agents/harness/common/memory/dreaming/scheduler.py
@@ -1,0 +1,170 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Cron-based scheduling for Dreaming memory consolidation."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+from zoneinfo import ZoneInfo
+
+from croniter import croniter
+
+logger = logging.getLogger(__name__)
+
+
+def _next_scheduled_time(cron_expr: str, base_time: datetime) -> datetime:
+    """Return the next cron occurrence after an aware base time."""
+    if base_time.tzinfo is None:
+        raise ValueError("base_time must be timezone-aware")
+
+    field_count = len(cron_expr.split())
+    if field_count not in (5, 7):
+        raise ValueError(
+            f"cron_expr must have 5 or 7 fields, got {field_count}"
+        )
+
+    second_at_beginning = field_count == 7
+    if not croniter.is_valid(
+        cron_expr,
+        second_at_beginning=second_at_beginning,
+    ):
+        raise ValueError(f"invalid cron expression: {cron_expr!r}")
+
+    next_time = croniter(
+        cron_expr,
+        base_time,
+        second_at_beginning=second_at_beginning,
+    ).get_next(datetime)
+    if not isinstance(next_time, datetime):
+        raise RuntimeError("croniter returned an invalid datetime")
+    if next_time.tzinfo is None:
+        next_time = next_time.replace(tzinfo=base_time.tzinfo)
+    return next_time
+
+
+def _delay_until(next_time: datetime, now: datetime) -> float:
+    """Return elapsed seconds until an occurrence, including DST changes."""
+    if next_time.tzinfo is None or now.tzinfo is None:
+        raise ValueError("scheduled times must be timezone-aware")
+    return max(
+        0.0,
+        (
+            next_time.astimezone(timezone.utc)
+            - now.astimezone(timezone.utc)
+        ).total_seconds(),
+    )
+
+
+class CronDreamingOrchestrator:
+    """Idle-aware Dreaming service triggered by a cron expression."""
+
+    def __init__(
+        self,
+        sweep_fn: Callable[[], Awaitable[None]],
+        cron_expr: str,
+        timezone: str,
+        busy_checker: Callable[[], bool] | None = None,
+        name: str = "dreaming",
+    ) -> None:
+        self._sweep_fn = sweep_fn
+        self._cron_expr = cron_expr.strip()
+        self._timezone_name = timezone.strip()
+        self._timezone = ZoneInfo(self._timezone_name)
+        self._busy_checker = busy_checker
+        self._name = name
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+        _next_scheduled_time(
+            self._cron_expr,
+            datetime.now(self._timezone),
+        )
+
+    @property
+    def health(self) -> dict[str, Any]:
+        return {
+            "running": self._running,
+            "cron_expr": self._cron_expr,
+            "timezone": self._timezone_name,
+        }
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(
+            self._loop(),
+            name=f"{self._name}-loop",
+        )
+        logger.info(
+            "[%s] Orchestrator started, cron=%s timezone=%s",
+            self._name,
+            self._cron_expr,
+            self._timezone_name,
+        )
+
+    async def stop(self) -> None:
+        if not self._running and self._task is None:
+            return
+        self._running = False
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+        logger.info("[%s] Orchestrator stopped", self._name)
+
+    async def _loop(self) -> None:
+        try:
+            while self._running:
+                now = datetime.now(self._timezone)
+                next_time = _next_scheduled_time(
+                    self._cron_expr,
+                    now,
+                )
+                delay = _delay_until(next_time, now)
+                logger.info(
+                    "[%s] next sweep scheduled at %s",
+                    self._name,
+                    next_time.isoformat(),
+                )
+                await asyncio.sleep(delay)
+                if self._running:
+                    await self._tick()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                "[%s] cron loop terminated unexpectedly",
+                self._name,
+            )
+            self._running = False
+
+    async def _tick(self) -> None:
+        try:
+            if self._busy_checker is not None:
+                try:
+                    if self._busy_checker():
+                        logger.info(
+                            "[%s] agent busy, skip scheduled sweep",
+                            self._name,
+                        )
+                        return
+                except Exception:
+                    logger.warning(
+                        "[%s] busy_checker raised an exception, "
+                        "skipping the check",
+                        self._name,
+                        exc_info=True,
+                    )
+
+            logger.info("[%s] start sweep", self._name)
+            await self._sweep_fn()
+            logger.info("[%s] sweep completed", self._name)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("[%s] sweep failed", self._name)

--- a/jiuwenswarm/agents/harness/common/memory/dreaming/sweeper.py
+++ b/jiuwenswarm/agents/harness/common/memory/dreaming/sweeper.py
@@ -41,10 +41,12 @@ _MIN_SESSION_AGE_BYPASS_DAYS = 7
 class DreamingConfig:
     enabled: bool = False
     interval_seconds: float = 14400.0
+    cron_expr: str | None = None
+    timezone: str = "Asia/Shanghai"
 
     @classmethod
     def load(cls, mode: str = "code") -> "DreamingConfig":
-        """Load configuration from the config.yaml memory.dreaming.{mode} or return enabled=False."""
+        """Load ``memory.dreaming.{mode}`` configuration."""
         try:
             from jiuwenswarm.common.config import get_config
             raw = get_config().get("memory", {}).get("dreaming", {}).get(mode, {})
@@ -56,13 +58,41 @@ class DreamingConfig:
                 enabled = env_val.lower() in ("true", "1", "yes")
             else:
                 enabled = bool(raw.get("enabled", False))
-            interval = float(os.getenv(
-                "DREAMING_INTERVAL",
-                str(raw.get("interval_seconds", 14400.0)),
-            ))
-            return cls(enabled=enabled, interval_seconds=interval)
+
+            cron_expr = str(
+                os.getenv(
+                    "DREAMING_CRON_EXPR",
+                    raw.get("cron_expr", ""),
+                )
+                or ""
+            ).strip() or None
+            timezone_name = str(
+                os.getenv(
+                    "DREAMING_TIMEZONE",
+                    raw.get("timezone", "Asia/Shanghai"),
+                )
+                or "Asia/Shanghai"
+            ).strip() or "Asia/Shanghai"
+
+            interval = 14400.0
+            if cron_expr is None:
+                interval = float(os.getenv(
+                    "DREAMING_INTERVAL",
+                    str(raw.get("interval_seconds", 14400.0)),
+                ))
+            return cls(
+                enabled=enabled,
+                interval_seconds=interval,
+                cron_expr=cron_expr,
+                timezone=timezone_name,
+            )
         except Exception as exc:
-            logger.warning("[dreaming] %s configuration load failed, using default values: %s", mode, exc)
+            logger.warning(
+                "[dreaming] %s configuration load failed, "
+                "using default values: %s",
+                mode,
+                exc,
+            )
             return cls()
 
 

--- a/tests/unit_tests/agentserver/memory/test_dreaming_scheduler.py
+++ b/tests/unit_tests/agentserver/memory/test_dreaming_scheduler.py
@@ -1,0 +1,203 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Tests for Dreaming cron scheduling."""
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from jiuwenswarm.agents.harness.common.memory import dreaming
+from jiuwenswarm.agents.harness.common.memory.dreaming.scheduler import (
+    CronDreamingOrchestrator,
+    _delay_until,
+    _next_scheduled_time,
+)
+from jiuwenswarm.agents.harness.common.memory.dreaming.sweeper import (
+    DreamingConfig,
+)
+
+
+def _load_config(
+    monkeypatch: pytest.MonkeyPatch,
+    config: dict,
+    *,
+    mode: str = "agent",
+) -> DreamingConfig:
+    config_module = types.ModuleType("jiuwenswarm.common.config")
+    config_module.get_config = lambda: config
+    monkeypatch.setitem(
+        sys.modules,
+        "jiuwenswarm.common.config",
+        config_module,
+    )
+    for env_name in (
+        "DREAMING_AGENT_ENABLED",
+        "DREAMING_CODE_ENABLED",
+        "DREAMING_INTERVAL",
+        "DREAMING_CRON_EXPR",
+        "DREAMING_TIMEZONE",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+    return DreamingConfig.load(mode)
+
+
+def test_next_scheduled_time_at_midnight() -> None:
+    timezone = ZoneInfo("Asia/Shanghai")
+    base_time = datetime(2026, 7, 26, 23, 30, tzinfo=timezone)
+
+    next_time = _next_scheduled_time("0 0 * * *", base_time)
+
+    assert next_time == datetime(
+        2026,
+        7,
+        27,
+        0,
+        0,
+        tzinfo=timezone,
+    )
+
+
+def test_next_scheduled_time_accepts_seven_field_quartz() -> None:
+    timezone = ZoneInfo("Asia/Shanghai")
+    base_time = datetime(2026, 7, 26, 23, 30, tzinfo=timezone)
+
+    next_time = _next_scheduled_time(
+        "0 0 0 * * ? *",
+        base_time,
+    )
+
+    assert next_time == datetime(
+        2026,
+        7,
+        27,
+        0,
+        0,
+        tzinfo=timezone,
+    )
+
+
+def test_delay_until_accounts_for_daylight_saving_change() -> None:
+    timezone = ZoneInfo("Europe/Berlin")
+    now = datetime(2026, 10, 25, 1, 30, tzinfo=timezone)
+    next_time = datetime(2026, 10, 25, 3, 30, tzinfo=timezone)
+
+    assert _delay_until(next_time, now) == 10800.0
+
+
+def test_cron_orchestrator_rejects_invalid_expression() -> None:
+    async def sweep() -> None:
+        return None
+
+    with pytest.raises(ValueError, match="5 or 7 fields"):
+        CronDreamingOrchestrator(
+            sweep_fn=sweep,
+            cron_expr="not a cron expression",
+            timezone="Asia/Shanghai",
+        )
+
+
+def test_config_loads_cron_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _load_config(
+        monkeypatch,
+        {
+            "memory": {
+                "dreaming": {
+                    "agent": {
+                        "enabled": True,
+                        "cron_expr": "0 0 * * *",
+                        "timezone": "Asia/Shanghai",
+                    }
+                }
+            }
+        },
+    )
+
+    assert cfg.enabled is True
+    assert cfg.cron_expr == "0 0 * * *"
+    assert cfg.timezone == "Asia/Shanghai"
+
+
+def test_cron_environment_overrides_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _load_config(
+        monkeypatch,
+        {
+            "memory": {
+                "dreaming": {
+                    "agent": {
+                        "enabled": True,
+                        "cron_expr": "0 1 * * *",
+                        "timezone": "UTC",
+                    }
+                }
+            }
+        },
+    )
+    monkeypatch.setenv("DREAMING_CRON_EXPR", "0 2 * * *")
+    monkeypatch.setenv("DREAMING_TIMEZONE", "Asia/Shanghai")
+
+    cfg = DreamingConfig.load("agent")
+
+    assert cfg.cron_expr == "0 2 * * *"
+    assert cfg.timezone == "Asia/Shanghai"
+
+
+@pytest.mark.asyncio
+async def test_start_dreaming_selects_cron_orchestrator(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jiuwenswarm.agents.harness.common.memory.dreaming import (
+        sweeper as sweeper_module,
+    )
+
+    cfg = DreamingConfig(
+        enabled=True,
+        cron_expr="0 0 * * *",
+        timezone="Asia/Shanghai",
+    )
+    monkeypatch.setattr(
+        sweeper_module.DreamingConfig,
+        "load",
+        classmethod(lambda cls, mode: cfg),
+    )
+    monkeypatch.setattr(sweeper_module.Sweeper, "init", lambda self: None)
+
+    captured: dict = {}
+
+    class FakeCronOrchestrator:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+        async def start(self) -> None:
+            captured["started"] = True
+
+        async def stop(self) -> None:
+            captured["stopped"] = True
+
+    monkeypatch.setattr(
+        dreaming,
+        "CronDreamingOrchestrator",
+        FakeCronOrchestrator,
+    )
+    dreaming._orchestrators.clear()
+
+    try:
+        orchestrator = await dreaming.start_dreaming(
+            sessions_dir=str(tmp_path / "sessions"),
+            output_dir=str(tmp_path / "memory"),
+            mode="agent",
+        )
+
+        assert isinstance(orchestrator, FakeCronOrchestrator)
+        assert captured["cron_expr"] == "0 0 * * *"
+        assert captured["timezone"] == "Asia/Shanghai"
+        assert captured["started"] is True
+    finally:
+        await dreaming.stop_dreaming("agent")


### PR DESCRIPTION
Paired: [GitHub #1424](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1424) ↔ [GitCode !4131](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4131)

<!--
Thanks for sending a pull request!

1) Contributor guidelines:
https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If reviewer assignment is needed, add the `openJiuwen-assistant` label.
-->

**What type of PR is this?**

/kind feature


**What does this PR do / why do we need it**:

This PR adds wall-clock Cron scheduling to the Dreaming offline memory consolidation service. Dreaming previously supported only a fixed `interval_seconds` cadence (four hours by default), which cannot express operational requirements such as "run every day at midnight".

The change:

- adds optional `cron_expr` and `timezone` Dreaming settings;
- supports standard 5-field Cron expressions and 7-field Quartz-style expressions;
- adds `DREAMING_CRON_EXPR` and `DREAMING_TIMEZONE` environment overrides;
- gives Cron scheduling precedence over the existing interval while preserving interval behavior when no Cron expression is configured;
- uses IANA time zones and computes elapsed delays through UTC so daylight saving transitions are handled correctly;
- skips a scheduled sweep when the agent is busy, then resumes at the next Cron occurrence;
- keeps one failed sweep from terminating subsequent scheduled executions;
- documents the configuration in both English and Chinese.

### Feature design

#### Scenarios and motivation

Operators need Dreaming to run during predictable idle windows, for example at 00:00 local time, rather than at a process-relative interval. A wall-clock schedule is easier to coordinate with traffic patterns, maintenance windows, and model-cost policies. Existing installations that use `interval_seconds` must continue to work unchanged.

#### Architecture

The existing `start_dreaming()` integration remains the single entry point. Configuration selects either the new Cron orchestrator or the existing interval orchestrator; both invoke the same `Sweeper.run_sweep()` pipeline and reuse the same busy checker.

```mermaid
flowchart TD
    A["Agent/Code adapter startup"] --> B["start_dreaming()"]
    B --> C["DreamingConfig.load(mode)"]
    C --> D{"cron_expr configured?"}
    D -- "Yes" --> E["CronDreamingOrchestrator"]
    D -- "No" --> F["Existing interval DreamingOrchestrator"]
    E --> G["Calculate next wall-clock occurrence in IANA timezone"]
    G --> H["Wait using UTC elapsed duration"]
    H --> I{"Agent busy?"}
    F --> I
    I -- "Yes" --> J["Skip this cycle"]
    I -- "No" --> K["Sweeper.run_sweep()"]
    J --> G
    K --> G
```

#### Expected outcome

- Administrators can schedule Dreaming at deterministic local times.
- Both 5-field Cron and 7-field Quartz-style expressions are accepted.
- DST transitions do not produce incorrect elapsed waits.
- Busy agents are not interrupted by offline consolidation.
- Existing interval-based configuration remains backward compatible.


**Which issue(s) this PR fixes**:

Fixes #1347

Related mirror: https://gitcode.com/openJiuwen/jiuwenswarm/issues/2603


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

### Test plan

1. Unit and system tests
   - Validate 5-field Cron next-occurrence calculation.
   - Validate 7-field Quartz-style expressions.
   - Validate IANA timezone handling and elapsed delay across a DST fallback.
   - Validate invalid-expression rejection.
   - Validate YAML/environment loading and environment precedence.
   - Validate selection of `CronDreamingOrchestrator`.
   - Run the existing Dreaming Sweeper and lifecycle suites.
2. Static and build checks
   - Run Ruff on all changed Python files and the new test file.
   - Run the Web production build to ensure the complete application still compiles.
   - Run `git diff --check`.
3. Real browser/model E2E
   - Start the real AgentServer, Gateway, and Vite frontend.
   - Configure a real model from the browser without logging the API key.
   - Send `请只回复：E2E_OK_1347`.
   - Verify the real model response is exactly `E2E_OK_1347` and the browser session reaches the completed state.
4. Real Cron E2E
   - Start an isolated real application with `DREAMING_CRON_EXPR=*/10 * * * * * *` and `DREAMING_TIMEZONE=Asia/Hong_Kong`.
   - Verify the browser reports the backend as connected.
   - Observe multiple real wall-clock triggers entering `Sweeper.run_sweep()`, completing, and scheduling the next occurrence.

### Test results

#### Unit and system suites

```text
$ uv run pytest --basetemp=<workspace>/.tmp_pytest_issue_1347 --no-cov \
    tests/unit_tests/agentserver/memory/test_dreaming_scheduler.py \
    tests/unit_tests/agentserver/memory/test_dreaming_sweeper.py \
    tests/system_tests/test_dreaming_e2e.py

collected 62 items
============================= 62 passed in 5.96s ==============================
```

#### Ruff

```text
$ uv run ruff check \
    jiuwenswarm/agents/harness/common/memory/dreaming/__init__.py \
    jiuwenswarm/agents/harness/common/memory/dreaming/scheduler.py \
    jiuwenswarm/agents/harness/common/memory/dreaming/sweeper.py \
    tests/unit_tests/agentserver/memory/test_dreaming_scheduler.py

All checks passed!
```

#### Web production build

```text
$ npm run build
✓ 4460 modules transformed.
✓ built in 26.45s
```

#### Real browser/model E2E

```text
Model: deepseek-v4-pro
Prompt: 请只回复：E2E_OK_1347
Rendered response: E2E_OK_1347
Browser session state: completed
```

Browser result screenshot:

<img width="1236" height="1145" alt="browser-model-e2e-1347" src="https://github.com/user-attachments/assets/5c888c5d-effd-495d-9916-15dc18943be8" />

#### Real Cron E2E

```text
Configuration:
  DREAMING_AGENT_ENABLED=true
  DREAMING_CRON_EXPR=*/10 * * * * * *
  DREAMING_TIMEZONE=Asia/Hong_Kong

Observed summary:
  Orchestrator starts: 1
  Next-occurrence calculations: 15
  Real sweep starts: 14
  Real sweep completions: 14
  Failures: 0

Sample wall-clock triggers:
  19:32:10.024  [dreaming-agent] start sweep
  19:32:20.037  [dreaming-agent] start sweep
  19:32:30.029  [dreaming-agent] start sweep
  19:32:40.015  [dreaming-agent] start sweep
  19:32:50.008  [dreaming-agent] start sweep
```

The isolated Cron run intentionally contained no eligible sessions. Each real Sweeper invocation took the safe empty-input path, so the validation exercised the production scheduling/integration path without consuming model quota or modifying user memory.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

- [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
- [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
- [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
- [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
- [x] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- Special notes for reviewers:
- Existing interval scheduling remains the fallback when cron_expr is absent.
- No dependency versions were changed.
-->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1347
<!-- /bot1-related-issues -->