### PR TITLE
feat(slack): add opt-in channel automations and cron delivery

### DIFF
--- a/docs/en/InternationalChannels.md
+++ b/docs/en/InternationalChannels.md
@@ -326,9 +326,11 @@ JiuwenSwarm connects to Slack through the asynchronous Slack Bolt Socket Mode ad
    - `chat:write`
    - `app_mentions:read`
    - `im:history`
+   - To process links automatically in selected channels, also add `channels:history`
 5. Under **Event Subscriptions**, subscribe to these Bot Events:
    - `app_mention`
    - `message.im`
+   - To process links automatically in selected channels, also subscribe to `message.channels`
 6. Install the app to the workspace and save the generated `xoxb-...` Bot Token.
 7. Add the bot to every Slack channel where it should respond.
 
@@ -347,8 +349,12 @@ channels:
     app_token: "xapp-your-app-token"
     allow_from: []
     allowed_channel_ids: []
+    auto_link_channel_ids: []
+    auto_link_prompt: ""
     default_channel_id:
     reply_in_thread: true
+    acknowledge_requests: false
+    acknowledgement_text: "Received. Analyzing…"
     enabled: true
 ```
 
@@ -358,14 +364,24 @@ channels:
 | `app_token` | Required Socket Mode App Token in `xapp-...` format | empty |
 | `allow_from` | Allow-list of Slack user IDs; empty allows all users | `[]` |
 | `allowed_channel_ids` | Channel IDs allowed to mention the bot; empty allows all channels and does not restrict DMs | `[]` |
+| `auto_link_channel_ids` | Channel IDs where link messages trigger the bot without a mention; empty disables the feature | `[]` |
+| `auto_link_prompt` | Optional instructions appended to automatically processed link messages | empty |
 | `default_channel_id` | Fallback channel for outbound messages without request context | empty |
 | `reply_in_thread` | Reply in the thread containing the triggering channel message | `true` |
+| `acknowledge_requests` | Immediately confirm accepted Slack requests before agent processing | `false` |
+| `acknowledgement_text` | Text used for the immediate confirmation | `Received. Analyzing…` |
 | `enabled` | Enable the Slack channel | `false` |
 
 ### 3. Use the Bot
 
 - In a channel, send `@bot your message`. JiuwenSwarm processes it and replies in the message thread by default.
 - Send the bot a direct message without mentioning it.
+- Channels in `auto_link_channel_ids` automatically process member messages containing an HTTP/HTTPS link and reply in a thread; plain text is still ignored.
+- Set `auto_link_prompt` to add workflow-specific instructions; when empty, JiuwenSwarm forwards the original link message unchanged.
+- When `acknowledge_requests` is enabled, accepted mentions, direct messages, and automatic links receive an immediate confirmation before agent processing begins.
+- Cron jobs created from Slack use `targets: slack` by default and return results
+  to the originating channel or thread. Jobs without Slack request context use
+  `default_channel_id`.
 - Channel conversations are isolated by Slack thread, so separate threads do not share a JiuwenSwarm session.
 - The current integration sends final text replies and suppresses token-level `chat.delta` events to avoid channel noise and Slack rate limits.
 
@@ -390,6 +406,19 @@ Slack user IDs and channel IDs are available from the member profile and channel
 
 - Confirm the app has `im:history` and subscribes to `message.im`.
 - Reinstall the app to the workspace after changing scopes or event subscriptions.
+
+**Links in an automatic channel do not trigger the bot**
+
+- Confirm the channel ID is in `auto_link_channel_ids` and the bot is a member.
+- Confirm the app has `channels:history` and subscribes to `message.channels`.
+- Confirm the message is from a human, contains an HTTP/HTTPS link, and the sender passes `allow_from`.
+- Reinstall the app after changing scopes or event subscriptions.
+
+**A Slack cron job does not deliver its result**
+
+- Confirm the job's `targets` value is `slack`.
+- For jobs without Slack request context, configure `default_channel_id`.
+- Confirm the bot is a member of the destination channel and has `chat:write`.
 
 ---
 

--- a/docs/zh/海外频道.md
+++ b/docs/zh/海外频道.md
@@ -326,9 +326,11 @@ JiuwenSwarm 通过 Slack Bolt 的异步 Socket Mode 接入 Slack。Socket Mode �
    - `chat:write`
    - `app_mentions:read`
    - `im:history`
+   - 如果需要自动处理指定频道中的链接，再添加 `channels:history`
 5. 在 **Event Subscriptions** 中订阅 Bot Events：
    - `app_mention`
    - `message.im`
+   - 如果需要自动处理指定频道中的链接，再订阅 `message.channels`
 6. 将应用安装到 Workspace，保存生成的 `xoxb-...` Bot Token。
 7. 将机器人加入需要使用的 Slack 频道。
 
@@ -347,8 +349,12 @@ channels:
     app_token: "xapp-your-app-token"
     allow_from: []
     allowed_channel_ids: []
+    auto_link_channel_ids: []
+    auto_link_prompt: ""
     default_channel_id:
     reply_in_thread: true
+    acknowledge_requests: false
+    acknowledgement_text: "Received. Analyzing…"
     enabled: true
 ```
 
@@ -358,14 +364,23 @@ channels:
 | `app_token` | Socket Mode App Token，格式为 `xapp-...`，必填 | 空 |
 | `allow_from` | 允许访问的 Slack 用户 ID；空列表允许所有用户 | `[]` |
 | `allowed_channel_ids` | 允许 @机器人 的频道 ID；空列表允许所有频道，不影响私聊 | `[]` |
+| `auto_link_channel_ids` | 无需 @即可自动处理链接消息的频道 ID；空列表关闭该能力 | `[]` |
+| `auto_link_prompt` | 可选：附加到自动处理链接消息后的任务说明 | 空 |
 | `default_channel_id` | 出站消息缺少上下文时使用的备用频道 | 空 |
 | `reply_in_thread` | 在频道中将回复发送到触发消息所在的线程 | `true` |
+| `acknowledge_requests` | Agent 开始处理前立即确认已接受的 Slack 请求 | `false` |
+| `acknowledgement_text` | 即时确认消息的文本 | `Received. Analyzing…` |
 | `enabled` | 是否启用 Slack 频道 | `false` |
 
 ### 3. 使用方式
 
 - 在频道中 `@机器人 消息内容`，JiuwenSwarm 会处理消息并默认在线程中回复。
 - 在 Slack 中直接私聊机器人，不需要 @提及。
+- `auto_link_channel_ids` 中的频道会自动处理包含 HTTP/HTTPS 链接的成员消息，并在线程中回复；普通文字消息仍会被忽略。
+- 可以通过 `auto_link_prompt` 添加特定工作流说明；留空时 JiuwenSwarm 会原样传递链接消息。
+- 启用 `acknowledge_requests` 后，合法的 @提及、私聊和自动链接请求会在 Agent 开始处理前立即收到确认消息。
+- 从 Slack 创建的定时任务默认使用 `targets: slack`，结果会返回原频道或线程；
+  没有 Slack 请求上下文的任务使用 `default_channel_id`。
 - 频道会话按 Slack 线程隔离；不同线程不会共享同一个 JiuwenSwarm 会话上下文。
 - 当前版本发送最终文本回复，不发送逐 Token 的 `chat.delta`，以避免 Slack 频道刷屏和触发限流。
 
@@ -390,6 +405,19 @@ Slack 用户 ID 和频道 ID 可以在 Slack 客户端中通过成员资料或�
 
 - 确认已添加 `im:history` scope 并订阅 `message.im`。
 - 修改 scopes 或 events 后需要重新安装应用到 Workspace。
+
+**指定频道中的链接没有自动触发**
+
+- 确认频道 ID 已加入 `auto_link_channel_ids`，且机器人已经加入该频道。
+- 确认已添加 `channels:history` scope 并订阅 `message.channels`。
+- 确认消息来自真人、包含 HTTP/HTTPS 链接，并且发送者满足 `allow_from`。
+- 修改 scopes 或 events 后需要重新安装应用到 Workspace。
+
+**Slack 定时任务没有发送结果**
+
+- 确认任务的 `targets` 为 `slack`。
+- 对于没有 Slack 请求上下文的任务，确认已配置 `default_channel_id`。
+- 确认机器人已加入目标频道并拥有 `chat:write`。
 
 ---
 

--- a/jiuwenswarm/agents/harness/common/tools/cron/cron_tools.py
+++ b/jiuwenswarm/agents/harness/common/tools/cron/cron_tools.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import contextvars
 import logging
 from dataclasses import dataclass
@@ -187,6 +186,8 @@ class CronTools:
             return normalize_target_channel_id(channel_raw, default=CronTargetChannel.WEB.value)
         if channel.startswith("feishu"):
             return CronTargetChannel.FEISHU.value
+        if channel.startswith("slack"):
+            return CronTargetChannel.SLACK.value
         if channel.startswith("wecom"):
             return CronTargetChannel.WECOM.value
         if channel.startswith("xiaoyi"):
@@ -557,7 +558,14 @@ class CronTools:
                         "cron_expr": {"type": "string"},
                         "timezone": {"type": "string"},
                         "description": {"type": "string"},
-                        "targets": {"type": "string"},
+                        "targets": {
+                            "type": "string",
+                            "enum": [e.value for e in CronTargetChannel],
+                            "description": (
+                                "Delivery channel. If omitted, use the current "
+                                "request source channel."
+                            ),
+                        },
                         "enabled": {"type": "boolean"},
                         "wake_offset_seconds": {"type": "integer"},
                         "mode": {
@@ -632,7 +640,8 @@ class CronTools:
                                     "type": "string",
                                     "enum": [e.value for e in CronTargetChannel],
                                     "description": (
-                                        "推送频道：web/tui/feishu/dingtalk/whatsapp/wecom/xiaoyi/wechat"
+                                        "推送频道：web/tui/feishu/slack/dingtalk/"
+                                        "whatsapp/wecom/xiaoyi/wechat"
                                     ),
                                 },
                                 "mode": {

--- a/jiuwenswarm/channels/web/frontend/src/components/ChannelsPanel/index.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChannelsPanel/index.tsx
@@ -166,8 +166,12 @@ type SlackConfig = {
   app_token: string;
   allow_from: string[];
   allowed_channel_ids: string[];
+  auto_link_channel_ids: string[];
+  auto_link_prompt: string;
   default_channel_id: string;
   reply_in_thread: boolean;
+  acknowledge_requests: boolean;
+  acknowledgement_text: string;
 };
 
 type SlackDraft = {
@@ -176,8 +180,12 @@ type SlackDraft = {
   app_token: string;
   allow_from: string;
   allowed_channel_ids: string;
+  auto_link_channel_ids: string;
+  auto_link_prompt: string;
   default_channel_id: string;
   reply_in_thread: boolean;
+  acknowledge_requests: boolean;
+  acknowledgement_text: string;
 };
 
 type WhatsAppConfig = {
@@ -282,14 +290,20 @@ const DEFAULT_DISCORD_CONF: DiscordConfig = {
   allow_from: [],
 };
 
+const DEFAULT_SLACK_ACKNOWLEDGEMENT_TEXT = 'Received. Analyzing…';
+
 const DEFAULT_SLACK_CONF: SlackConfig = {
   enabled: false,
   bot_token: '',
   app_token: '',
   allow_from: [],
   allowed_channel_ids: [],
+  auto_link_channel_ids: [],
+  auto_link_prompt: '',
   default_channel_id: '',
   reply_in_thread: true,
+  acknowledge_requests: false,
+  acknowledgement_text: DEFAULT_SLACK_ACKNOWLEDGEMENT_TEXT,
 };
 
 const DEFAULT_WHATSAPP_CONF: WhatsAppConfig = {
@@ -733,8 +747,14 @@ function normalizeSlackConfig(input: unknown): SlackConfig {
     app_token: String(data.app_token ?? '').trim(),
     allow_from: normalizeList(data.allow_from),
     allowed_channel_ids: normalizeList(data.allowed_channel_ids),
+    auto_link_channel_ids: normalizeList(data.auto_link_channel_ids),
+    auto_link_prompt: String(data.auto_link_prompt ?? '').trim(),
     default_channel_id: String(data.default_channel_id ?? '').trim(),
     reply_in_thread: data.reply_in_thread === undefined ? true : Boolean(data.reply_in_thread),
+    acknowledge_requests: Boolean(data.acknowledge_requests),
+    acknowledgement_text:
+      String(data.acknowledgement_text ?? '').trim() ||
+      DEFAULT_SLACK_ACKNOWLEDGEMENT_TEXT,
   };
 }
 
@@ -745,8 +765,12 @@ function draftFromSlackConfig(conf: SlackConfig): SlackDraft {
     app_token: conf.app_token,
     allow_from: conf.allow_from.join('\n'),
     allowed_channel_ids: conf.allowed_channel_ids.join('\n'),
+    auto_link_channel_ids: conf.auto_link_channel_ids.join('\n'),
+    auto_link_prompt: conf.auto_link_prompt,
     default_channel_id: conf.default_channel_id,
     reply_in_thread: conf.reply_in_thread,
+    acknowledge_requests: conf.acknowledge_requests,
+    acknowledgement_text: conf.acknowledgement_text,
   };
 }
 
@@ -757,8 +781,14 @@ function buildSlackPayload(draft: SlackDraft): Record<string, unknown> {
     app_token: draft.app_token.trim(),
     allow_from: normalizeAllowFromText(draft.allow_from),
     allowed_channel_ids: normalizeAllowFromText(draft.allowed_channel_ids),
+    auto_link_channel_ids: normalizeAllowFromText(draft.auto_link_channel_ids),
+    auto_link_prompt: draft.auto_link_prompt.trim(),
     default_channel_id: draft.default_channel_id.trim(),
     reply_in_thread: draft.reply_in_thread,
+    acknowledge_requests: draft.acknowledge_requests,
+    acknowledgement_text:
+      draft.acknowledgement_text.trim() ||
+      DEFAULT_SLACK_ACKNOWLEDGEMENT_TEXT,
   };
 }
 
@@ -1346,8 +1376,13 @@ export function ChannelsPanel({ isConnected }: ChannelsPanelProps) {
       normalizeAllowFromText(baseDraft.allow_from).join('\n') !== normalizeAllowFromText(slackDraft.allow_from).join('\n') ||
       normalizeAllowFromText(baseDraft.allowed_channel_ids).join('\n') !==
         normalizeAllowFromText(slackDraft.allowed_channel_ids).join('\n') ||
+      normalizeAllowFromText(baseDraft.auto_link_channel_ids).join('\n') !==
+        normalizeAllowFromText(slackDraft.auto_link_channel_ids).join('\n') ||
+      baseDraft.auto_link_prompt !== slackDraft.auto_link_prompt ||
       baseDraft.default_channel_id !== slackDraft.default_channel_id ||
-      baseDraft.reply_in_thread !== slackDraft.reply_in_thread
+      baseDraft.reply_in_thread !== slackDraft.reply_in_thread ||
+      baseDraft.acknowledge_requests !== slackDraft.acknowledge_requests ||
+      baseDraft.acknowledgement_text !== slackDraft.acknowledgement_text
     );
   }, [slackConfig, slackDraft]);
   const hasWhatsAppConfigChanges = useMemo(() => {
@@ -3600,7 +3635,46 @@ export function ChannelsPanel({ isConnected }: ChannelsPanelProps) {
                                   </button>
                                 </td>
                               </tr>
-                              {(['bot_token', 'app_token', 'default_channel_id'] as const).map((field) => (
+                              <tr
+                                className="border-t border-border first:border-t-0 even:bg-secondary/10"
+                                data-testid="channels-panel-channel-config-field"
+                                data-variant="acknowledge_requests"
+                              >
+                                <td
+                                  className="px-4 py-2.5 align-middle mono text-xs text-text-muted w-[32%]"
+                                  data-testid="channels-panel-channel-config-field-label"
+                                  data-variant="acknowledge_requests"
+                                >
+                                  acknowledge_requests
+                                </td>
+                                <td
+                                  className="px-4 py-2.5 align-middle"
+                                  data-testid="channels-panel-channel-config-field-toggle"
+                                  data-variant="acknowledge_requests"
+                                >
+                                  <button
+                                    type="button"
+                                    role="switch"
+                                    aria-checked={slackDraft.acknowledge_requests}
+                                    onClick={() =>
+                                      handleSlackFieldChange(
+                                        'acknowledge_requests',
+                                        !slackDraft.acknowledge_requests,
+                                      )
+                                    }
+                                    className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent focus:outline-none ${
+                                      slackDraft.acknowledge_requests ? 'bg-ok' : 'bg-secondary'
+                                    }`}
+                                  >
+                                    <span
+                                      className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-[var(--color-control-thumb)] shadow ${
+                                        slackDraft.acknowledge_requests ? 'translate-x-4' : 'translate-x-0'
+                                      }`}
+                                    />
+                                  </button>
+                                </td>
+                              </tr>
+                              {(['bot_token', 'app_token', 'default_channel_id', 'acknowledgement_text'] as const).map((field) => (
                                 <tr
                                   key={field}
                                   className="border-t border-border first:border-t-0 even:bg-secondary/10"
@@ -3623,7 +3697,9 @@ export function ChannelsPanel({ isConnected }: ChannelsPanelProps) {
                                             ? t('channels.placeholders.slackBotToken')
                                             : field === 'app_token'
                                               ? t('channels.placeholders.slackAppToken')
-                                              : t('channels.placeholders.slackChannelId')
+                                              : field === 'default_channel_id'
+                                                ? t('channels.placeholders.slackChannelId')
+                                                : t('channels.placeholders.slackAcknowledgementText')
                                         }
                                         className={`w-full rounded-md border border-border bg-bg px-3 py-2 text-[13px] outline-none focus:border-accent ${
                                           isSensitiveSlackField(field) ? 'pr-10' : ''
@@ -3691,6 +3767,34 @@ export function ChannelsPanel({ isConnected }: ChannelsPanelProps) {
                                     className="w-full rounded-md border border-border bg-bg px-3 py-2 text-[13px] outline-none focus:border-accent resize-y"
                                     data-testid="channels-panel-channel-config-field-textarea"
                                     data-variant="allowed_channel_ids"
+                                  />
+                                </td>
+                              </tr>
+                              <tr className="border-t border-border first:border-t-0 even:bg-secondary/10">
+                                <td className="px-4 py-2.5 align-top mono text-xs text-text-muted w-[32%]">
+                                  auto_link_channel_ids
+                                </td>
+                                <td className="px-4 py-2.5 break-all text-[13px] align-middle">
+                                  <textarea
+                                    value={slackDraft.auto_link_channel_ids}
+                                    onChange={(e) => handleSlackFieldChange('auto_link_channel_ids', e.target.value)}
+                                    placeholder={t('channels.placeholders.slackAutoLinkChannelIds')}
+                                    rows={4}
+                                    className="w-full rounded-md border border-border bg-bg px-3 py-2 text-[13px] outline-none focus:border-accent resize-y"
+                                  />
+                                </td>
+                              </tr>
+                              <tr className="border-t border-border first:border-t-0 even:bg-secondary/10">
+                                <td className="px-4 py-2.5 align-top mono text-xs text-text-muted w-[32%]">
+                                  auto_link_prompt
+                                </td>
+                                <td className="px-4 py-2.5 break-all text-[13px] align-middle">
+                                  <textarea
+                                    value={slackDraft.auto_link_prompt}
+                                    onChange={(e) => handleSlackFieldChange('auto_link_prompt', e.target.value)}
+                                    placeholder={t('channels.placeholders.slackAutoLinkPrompt')}
+                                    rows={3}
+                                    className="w-full rounded-md border border-border bg-bg px-3 py-2 text-[13px] outline-none focus:border-accent resize-y"
                                   />
                                 </td>
                               </tr>

--- a/jiuwenswarm/channels/web/frontend/src/components/CronPanel/index.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/CronPanel/index.tsx
@@ -131,10 +131,10 @@ function PaginationBar({ currentPage, totalPages, pageSize, totalCount, onPageCh
 const PROACTIVE_AUTO_JOB_ID = 'proactive-tick-auto';
 
 // 用于展示已有任务的推送频道（含历史数据可能存在的 wecom/wechat）
-const KNOWN_TARGET_KEYS = ['web', 'tui', 'xiaoyi', 'feishu', 'dingtalk', 'whatsapp', 'wecom', 'wechat'];
+const KNOWN_TARGET_KEYS = ['web', 'tui', 'xiaoyi', 'feishu', 'slack', 'dingtalk', 'whatsapp', 'wecom', 'wechat'];
 // 创建/编辑时可选的推送频道：wecom/wechat 已被 upstream 下架（见提交 e12d1952、d57567e4），
 // 不在下拉里出现，但已有数据仍按上面 KNOWN_TARGET_KEYS 正常展示
-const SELECTABLE_TARGET_KEYS = ['web', 'tui', 'xiaoyi', 'feishu', 'dingtalk', 'whatsapp'];
+const SELECTABLE_TARGET_KEYS = ['web', 'tui', 'xiaoyi', 'feishu', 'slack', 'dingtalk', 'whatsapp'];
 
 // 执行历史目前只有"该功能即将上线"占位（等 backend-requests.md #1 的真实数据接口交付），
 // 用户要求先不在界面上露出入口（tab + 行内"运行历史"菜单项），但保留代码，等后端接口交付后

--- a/jiuwenswarm/channels/web/frontend/src/i18n/locales/en.json
+++ b/jiuwenswarm/channels/web/frontend/src/i18n/locales/en.json
@@ -650,7 +650,7 @@
       "discordHint": "Discord Bot messaging is supported. Enable Message Content Intent in Developer Portal and optionally set the target channel, the block_dm toggle can be used to block direct message.",
       "slackTitle": "Slack Channel Configuration",
       "slackSubtitle": "Configure Slack Socket Mode bot settings",
-      "slackHint": "Create a Slack app with Socket Mode enabled, an xoxb bot token, and an xapp app token. Subscribe to app_mention and message.im events.",
+      "slackHint": "Create a Slack app with Socket Mode enabled, an xoxb bot token, and an xapp app token. Basic chat uses app_mention and message.im. Automatic link channels also require channels:history and the message.channels event.",
       "telegramTitle": "Telegram Channel Configuration",
       "telegramSubtitle": "Configure Telegram Bot service settings",
       "whatsappTitle": "WhatsApp Channel Configuration",
@@ -692,6 +692,9 @@
       "slackChannelId": "Enter the fallback Slack channel ID",
       "slackUserIds": "One Slack user ID per line (empty allows all users)",
       "slackChannelIds": "One Slack channel ID per line (empty allows all channels)",
+      "slackAutoLinkChannelIds": "One Slack channel ID per line for automatic link processing (empty disables it)",
+      "slackAutoLinkPrompt": "Optional instructions appended to automatically processed link messages",
+      "slackAcknowledgementText": "Message sent immediately before agent processing",
       "allowFrom": "One chatid/userid per line (comma-separated is also supported)"
     },
     "saved": {
@@ -1435,6 +1438,7 @@
       "tui": "Terminal (tui)",
       "xiaoyi": "Xiaoyi (xiaoyi)",
       "feishu": "Lark (feishu)",
+      "slack": "Slack (slack)",
       "dingtalk": "DingTalk (dingtalk)",
       "whatsapp": "WhatsApp (whatsapp)",
       "wecom": "WeCom (wecom)",

--- a/jiuwenswarm/channels/web/frontend/src/i18n/locales/zh.json
+++ b/jiuwenswarm/channels/web/frontend/src/i18n/locales/zh.json
@@ -650,7 +650,7 @@
       "discordHint": "支持 Discord Bot 消息收发，请确保已在开发者后台开启 Message Content Intent 并配置目标频道，可使用block_dm开关屏蔽私信。",
       "slackTitle": "Slack 频道参数配置",
       "slackSubtitle": "配置 Slack Socket Mode 机器人服务参数",
-      "slackHint": "请创建并启用 Socket Mode 的 Slack App，配置 xoxb Bot Token 和 xapp App Token，并订阅 app_mention 与 message.im 事件。",
+      "slackHint": "请创建并启用 Socket Mode 的 Slack App，配置 xoxb Bot Token 和 xapp App Token。基础对话订阅 app_mention 与 message.im；自动链接频道还需 channels:history 权限和 message.channels 事件。",
       "telegramTitle": "Telegram 频道参数配置",
       "telegramSubtitle": "配置 Telegram Bot 服务相关参数",
       "whatsappTitle": "WhatsApp 频道参数配置",
@@ -692,6 +692,9 @@
       "slackChannelId": "请输入备用 Slack 频道 ID",
       "slackUserIds": "每行一个 Slack 用户 ID（留空允许所有用户）",
       "slackChannelIds": "每行一个 Slack 频道 ID（留空允许所有频道）",
+      "slackAutoLinkChannelIds": "每行一个自动处理链接的 Slack 频道 ID（留空关闭）",
+      "slackAutoLinkPrompt": "可选：附加到自动处理链接消息后的任务说明",
+      "slackAcknowledgementText": "Agent 开始处理前立即发送的确认消息",
       "allowFrom": "每行一个 chatid/userid（也支持逗号分隔）"
     },
     "saved": {
@@ -1433,6 +1436,7 @@
       "tui": "终端 (tui)",
       "xiaoyi": "小艺 (xiaoyi)",
       "feishu": "飞书 (feishu)",
+      "slack": "Slack (slack)",
       "dingtalk": "钉钉 (dingtalk)",
       "whatsapp": "WhatsApp (whatsapp)",
       "wecom": "企业微信 (wecom)",

--- a/jiuwenswarm/gateway/app_gateway.py
+++ b/jiuwenswarm/gateway/app_gateway.py
@@ -2495,14 +2495,29 @@ async def _run(
                         if isinstance(reply_in_thread_raw, str)
                         else bool(reply_in_thread_raw)
                     )
+                    acknowledge_raw = slack_conf.get("acknowledge_requests", False)
+                    acknowledge_requests = (
+                        str(acknowledge_raw).strip().lower() in ("true", "1", "yes", "on")
+                        if isinstance(acknowledge_raw, str)
+                        else bool(acknowledge_raw)
+                    )
                     slack_config = SlackChannelConfig(
                         enabled=True,
                         bot_token=str(slack_conf.get("bot_token") or "").strip(),
                         app_token=str(slack_conf.get("app_token") or "").strip(),
                         allow_from=slack_conf.get("allow_from") or [],
                         allowed_channel_ids=slack_conf.get("allowed_channel_ids") or [],
+                        auto_link_channel_ids=slack_conf.get("auto_link_channel_ids") or [],
+                        auto_link_prompt=str(
+                            slack_conf.get("auto_link_prompt") or ""
+                        ).strip(),
                         default_channel_id=str(slack_conf.get("default_channel_id") or "").strip(),
                         reply_in_thread=reply_in_thread,
+                        acknowledge_requests=acknowledge_requests,
+                        acknowledgement_text=str(
+                            slack_conf.get("acknowledgement_text")
+                            or "Received. Analyzing…"
+                        ).strip(),
                     )
                     slack_channel = SlackChannel(slack_config, _DummyBus())
                     channel_manager.register_channel(slack_channel)

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/slack/slack_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/slack/slack_connect.py
@@ -32,7 +32,8 @@ except ImportError:
     AsyncSocketModeHandler = None  # type: ignore[assignment,misc]
 
 
-_LEADING_MENTION_RE = re.compile(r"^\s*<@[A-Z0-9]+>\s*", re.IGNORECASE)
+_HTTP_URL_RE = re.compile(r"https?://[^\s<>()|]+", re.IGNORECASE)
+_DEFAULT_ACKNOWLEDGEMENT_TEXT = "Received. Analyzing…"
 _MAX_SLACK_TEXT_LENGTH = 4000
 _MAX_SEEN_EVENTS = 1024
 
@@ -46,8 +47,12 @@ class SlackChannelConfig:
     app_token: str = ""
     allow_from: list[str] = field(default_factory=list)
     allowed_channel_ids: list[str] = field(default_factory=list)
+    auto_link_channel_ids: list[str] = field(default_factory=list)
+    auto_link_prompt: str = ""
     default_channel_id: str = ""
     reply_in_thread: bool = True
+    acknowledge_requests: bool = False
+    acknowledgement_text: str = _DEFAULT_ACKNOWLEDGEMENT_TEXT
 
 
 class SlackChannel(BaseChannel):
@@ -61,6 +66,7 @@ class SlackChannel(BaseChannel):
         self._app: Any = None
         self._handler: Any = None
         self._client: Any = None
+        self._bot_user_id = ""
         self._on_message_cb: Callable[[Message], Any] | None = None
         self._seen_event_ids: set[str] = set()
         self._seen_event_order: deque[str] = deque()
@@ -101,6 +107,7 @@ class SlackChannel(BaseChannel):
         self._app = app
         self._handler = handler
         self._client = app.client
+        await self._load_bot_user_id()
         self._running = True
 
         try:
@@ -117,6 +124,7 @@ class SlackChannel(BaseChannel):
         self._handler = None
         self._app = None
         self._client = None
+        self._bot_user_id = ""
         if handler is not None:
             try:
                 await handler.close_async()
@@ -154,14 +162,33 @@ class SlackChannel(BaseChannel):
     async def _handle_app_mention(
         self, event: dict[str, Any], body: dict[str, Any]
     ) -> None:
-        await self._handle_slack_event(event, body, is_dm=False)
+        self._remember_bot_user_id(body)
+        await self._handle_slack_event(event, body, is_dm=False, trigger="mention")
 
     async def _handle_message_event(
         self, event: dict[str, Any], body: dict[str, Any]
     ) -> None:
-        if str(event.get("channel_type") or "") != "im":
+        self._remember_bot_user_id(body)
+        if str(event.get("channel_type") or "") == "im":
+            await self._handle_slack_event(event, body, is_dm=True, trigger="dm")
             return
-        await self._handle_slack_event(event, body, is_dm=True)
+
+        channel_id = str(event.get("channel") or "").strip()
+        text = str(event.get("text") or "").strip()
+        if channel_id not in self.config.auto_link_channel_ids:
+            return
+        if not _HTTP_URL_RE.search(text):
+            return
+        # A leading bot mention is handled by app_mention. Ignoring it here
+        # avoids dispatching the same Slack message through two event types.
+        if self._has_leading_bot_mention(text):
+            return
+        await self._handle_slack_event(
+            event,
+            body,
+            is_dm=False,
+            trigger="auto_link",
+        )
 
     async def _handle_slack_event(
         self,
@@ -169,6 +196,7 @@ class SlackChannel(BaseChannel):
         body: dict[str, Any],
         *,
         is_dm: bool,
+        trigger: str,
     ) -> None:
         if not self._running:
             return
@@ -181,21 +209,9 @@ class SlackChannel(BaseChannel):
         channel_id = str(event.get("channel") or "").strip()
         if not user_id or not channel_id or not self.is_allowed(user_id):
             return
-        if not is_dm and self.config.allowed_channel_ids:
+        if not is_dm and trigger != "auto_link" and self.config.allowed_channel_ids:
             if channel_id not in self.config.allowed_channel_ids:
                 return
-
-        event_id = str(
-            body.get("event_id") or event.get("client_msg_id") or event.get("ts") or ""
-        ).strip()
-        if event_id and not self._remember_event(event_id):
-            return
-
-        text = str(event.get("text") or "").strip()
-        if not is_dm:
-            text = _LEADING_MENTION_RE.sub("", text, count=1).strip()
-        if not text:
-            return
 
         team = body.get("team")
         team_id = str(
@@ -204,6 +220,27 @@ class SlackChannel(BaseChannel):
             or event.get("team")
             or ""
         ).strip()
+        event_id = str(
+            body.get("event_id") or event.get("client_msg_id") or event.get("ts") or ""
+        ).strip()
+        message_identity = str(
+            event.get("ts") or event.get("client_msg_id") or event_id
+        ).strip()
+        dedupe_key = ":".join(
+            part for part in (team_id, channel_id, message_identity) if part
+        )
+        if dedupe_key and not self._remember_event(dedupe_key):
+            return
+
+        text = str(event.get("text") or "").strip()
+        if not is_dm and trigger == "mention":
+            text = self._strip_leading_bot_mention(text).strip()
+        auto_link_prompt = self.config.auto_link_prompt.strip()
+        if trigger == "auto_link" and auto_link_prompt and auto_link_prompt not in text:
+            text = f"{text}\n\n{auto_link_prompt}"
+        if not text:
+            return
+
         message_ts = str(event.get("ts") or "").strip()
         root_thread_ts = str(event.get("thread_ts") or message_ts).strip()
         reply_thread_ts = ""
@@ -217,6 +254,23 @@ class SlackChannel(BaseChannel):
         else:
             session_id = f"slack_{team_id or 'default'}_{channel_id}_{root_thread_ts}"
 
+        await self._acknowledge_request(channel_id, reply_thread_ts)
+
+        metadata = {
+            "user_id": user_id,
+            "slack_event_id": event_id,
+            "slack_team_id": team_id,
+            "slack_channel_id": channel_id,
+            "slack_channel_type": "im"
+            if is_dm
+            else str(event.get("channel_type") or "channel"),
+            "slack_user_id": user_id,
+            "slack_message_ts": message_ts,
+            "slack_thread_ts": reply_thread_ts,
+        }
+        if trigger == "auto_link":
+            metadata["slack_trigger"] = "auto_link"
+
         req = Message(
             id=event_id or f"slack-{int(time.time() * 1000)}",
             type="req",
@@ -229,18 +283,7 @@ class SlackChannel(BaseChannel):
             chat_id=channel_id,
             user_id=user_id,
             req_method=ReqMethod.CHAT_SEND,
-            metadata={
-                "user_id": user_id,
-                "slack_event_id": event_id,
-                "slack_team_id": team_id,
-                "slack_channel_id": channel_id,
-                "slack_channel_type": "im"
-                if is_dm
-                else str(event.get("channel_type") or "channel"),
-                "slack_user_id": user_id,
-                "slack_message_ts": message_ts,
-                "slack_thread_ts": reply_thread_ts,
-            },
+            metadata=metadata,
         )
 
         if self._on_message_cb is not None:
@@ -249,6 +292,69 @@ class SlackChannel(BaseChannel):
                 await result
         else:
             await self.bus.route_user_message(req)
+
+    async def _load_bot_user_id(self) -> None:
+        if self._client is None:
+            return
+        try:
+            response = await self._client.auth_test()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Slack auth.test failed; bot mentions may be duplicated: %s", exc
+            )
+            return
+
+        self._bot_user_id = str(response.get("user_id") or "").strip()
+        if not self._bot_user_id:
+            logger.warning("Slack auth.test returned no bot user_id")
+
+    def _remember_bot_user_id(self, body: dict[str, Any]) -> None:
+        if self._bot_user_id:
+            return
+        authorizations = body.get("authorizations")
+        if not isinstance(authorizations, list):
+            return
+        for authorization in authorizations:
+            if not isinstance(authorization, dict) or not authorization.get("is_bot"):
+                continue
+            user_id = str(authorization.get("user_id") or "").strip()
+            if user_id:
+                self._bot_user_id = user_id
+                return
+
+    def _has_leading_bot_mention(self, text: str) -> bool:
+        pattern = self._leading_bot_mention_pattern()
+        return pattern is not None and pattern.match(text) is not None
+
+    def _strip_leading_bot_mention(self, text: str) -> str:
+        pattern = self._leading_bot_mention_pattern()
+        if pattern is None:
+            return text
+        return pattern.sub("", text, count=1)
+
+    def _leading_bot_mention_pattern(self) -> re.Pattern[str] | None:
+        if not self._bot_user_id:
+            return None
+        return re.compile(
+            rf"^\s*<@{re.escape(self._bot_user_id)}>\s*",
+            re.IGNORECASE,
+        )
+
+    async def _acknowledge_request(self, channel_id: str, thread_ts: str) -> None:
+        if not self.config.acknowledge_requests or self._client is None:
+            return
+
+        text = self.config.acknowledgement_text.strip()
+        if not text:
+            return
+
+        kwargs: dict[str, Any] = {"channel": channel_id, "text": text}
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+        try:
+            await self._client.chat_postMessage(**kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Slack acknowledgement failed: %s", exc)
 
     def _remember_event(self, event_id: str) -> bool:
         if event_id in self._seen_event_ids:
@@ -325,6 +431,8 @@ class SlackChannel(BaseChannel):
             extra={
                 "default_channel_id": self.config.default_channel_id,
                 "allowed_channel_ids": list(self.config.allowed_channel_ids),
+                "auto_link_channel_ids": list(self.config.auto_link_channel_ids),
+                "auto_link_prompt": self.config.auto_link_prompt,
                 "reply_in_thread": self.config.reply_in_thread,
             },
         )

--- a/jiuwenswarm/gateway/cron/controller.py
+++ b/jiuwenswarm/gateway/cron/controller.py
@@ -88,7 +88,7 @@ class CronController:
             return normalize_target_channel_id(self._target_channel.value)
         if not is_valid_target_channel_id(raw_s):
             raise ValueError(
-                "targets must be one of tui/web/feishu/dingtalk/whatsapp/wecom/xiaoyi/wechat"
+                "targets must be one of tui/web/feishu/slack/dingtalk/whatsapp/wecom/xiaoyi/wechat"
                 " or feishu_enterprise:<app_id>"
             )
         return normalize_target_channel_id(raw_s)
@@ -460,7 +460,7 @@ class CronController:
                             "type": "string",
                             "enum": [e.value for e in CronTargetChannel],
                             "description": (
-                                "Delivery channel: tui, web, feishu, dingtalk, "
+                                "Delivery channel: tui, web, feishu, slack, dingtalk, "
                                 "whatsapp, wecom, xiaoyi, wechat. "
                                 "If omitted, use the current request source channel."
                             ),
@@ -562,7 +562,8 @@ class CronController:
                                     "type": "string",
                                     "enum": [e.value for e in CronTargetChannel],
                                     "description": (
-                                        "推送频道：web/tui/feishu/dingtalk/whatsapp/wecom/xiaoyi/wechat"
+                                        "推送频道：web/tui/feishu/slack/dingtalk/"
+                                        "whatsapp/wecom/xiaoyi/wechat"
                                     ),
                                 },
                                 "mode": {

--- a/jiuwenswarm/gateway/cron/models.py
+++ b/jiuwenswarm/gateway/cron/models.py
@@ -22,6 +22,7 @@ class CronTargetChannel(str, Enum):
     WEB = "web"
     TUI = "tui"
     FEISHU = "feishu"
+    SLACK = "slack"
     WHATSAPP = "whatsapp"
     WECOM = "wecom"
     XIAOYI = "xiaoyi"

--- a/jiuwenswarm/resources/config.team.distributed.leader.yaml
+++ b/jiuwenswarm/resources/config.team.distributed.leader.yaml
@@ -398,8 +398,12 @@ channels:
     app_token:
     allow_from: []
     allowed_channel_ids: []
+    auto_link_channel_ids: []
+    auto_link_prompt: ""
     default_channel_id:
     reply_in_thread: true
+    acknowledge_requests: false
+    acknowledgement_text: "Received. Analyzing…"
     enabled: false
   whatsapp:
     # WhatsApp 配置（通过本地 Baileys bridge）

--- a/jiuwenswarm/resources/config.team.distributed.teammate.yaml
+++ b/jiuwenswarm/resources/config.team.distributed.teammate.yaml
@@ -402,8 +402,12 @@ channels:
     app_token:
     allow_from: []
     allowed_channel_ids: []
+    auto_link_channel_ids: []
+    auto_link_prompt: ""
     default_channel_id:
     reply_in_thread: true
+    acknowledge_requests: false
+    acknowledgement_text: "Received. Analyzing…"
     enabled: false
   whatsapp:
     # WhatsApp 配置（通过本地 Baileys bridge）

--- a/jiuwenswarm/resources/config.yaml
+++ b/jiuwenswarm/resources/config.yaml
@@ -830,9 +830,17 @@ channels:
     allow_from: []
     # Channel IDs allowed to mention the bot. Empty allows all channels.
     allowed_channel_ids: []
+    # Channel IDs where link messages trigger the bot without an @mention.
+    # Empty disables automatic link processing.
+    auto_link_channel_ids: []
+    # Optional instructions appended to automatically processed link messages.
+    auto_link_prompt: ""
     # Optional fallback channel for messages without request metadata.
     default_channel_id:
     reply_in_thread: true
+    # Immediately confirm accepted requests before agent processing begins.
+    acknowledge_requests: false
+    acknowledgement_text: "Received. Analyzing…"
     enabled: false
   whatsapp:
     # WhatsApp 配置（通过本地 Baileys bridge）

--- a/tests/unit/agentserver/test_cron_runtime.py
+++ b/tests/unit/agentserver/test_cron_runtime.py
@@ -266,6 +266,37 @@ async def test_cron_tools_create_job_resolves_route_project_dir(tmp_path, monkey
 
 
 @pytest.mark.asyncio
+async def test_cron_tools_create_job_defaults_to_slack_route(
+    tmp_path, monkeypatch
+) -> None:
+    _setup_project_store(tmp_path, monkeypatch)
+    tools, push = _make_cron_tools(tmp_path, monkeypatch)
+    session_id = "slack_T1_C1_1710000000.000100"
+
+    token = tools.push_cron_route(
+        CronToolRoute(channel_id="slack", session_id=session_id)
+    )
+    try:
+        job = await tools.create_job(
+            {
+                "id": "job-slack",
+                "name": "daily",
+                "cron_expr": "0 8 * * *",
+                "timezone": "Europe/Paris",
+                "description": "hello",
+            }
+        )
+    finally:
+        tools.reset_cron_route(token)
+
+    assert job["targets"] == "slack"
+    assert job["session_id"] == session_id
+    synced = push.payloads[-1]["body"]["data"]
+    assert synced["targets"] == "slack"
+    assert synced["session_id"] == session_id
+
+
+@pytest.mark.asyncio
 async def test_cron_tools_create_job_uses_route_project_id_and_work_mode(
     tmp_path, monkeypatch,
 ) -> None:

--- a/tests/unit_tests/channel/test_slack_channel.py
+++ b/tests/unit_tests/channel/test_slack_channel.py
@@ -60,10 +60,14 @@ async def test_app_mention_creates_thread_scoped_message_and_deduplicates() -> N
         "user": "U1",
         "channel": "C1",
         "channel_type": "channel",
-        "text": "<@B1> summarize this",
+        "text": "<@U-BOT> summarize this",
         "ts": "1710000000.000100",
     }
-    body = {"event_id": "Ev1", "team_id": "T1"}
+    body = {
+        "event_id": "Ev1",
+        "team_id": "T1",
+        "authorizations": [{"user_id": "U-BOT", "is_bot": True}],
+    }
 
     await channel._handle_app_mention(event, body)
     await channel._handle_app_mention(event, body)
@@ -118,6 +122,164 @@ async def test_direct_message_is_not_restricted_by_channel_allowlist() -> None:
 
 
 @pytest.mark.asyncio
+async def test_auto_link_channel_processes_links_with_optional_prompt() -> None:
+    channel = SlackChannel(
+        SlackChannelConfig(
+            enabled=True,
+            allow_from=["U1"],
+            allowed_channel_ids=["C-MENTIONS"],
+            auto_link_channel_ids=["C-RESEARCH"],
+            auto_link_prompt="Review this link using the configured workflow.",
+            reply_in_thread=True,
+        ),
+        RobotMessageRouter(),
+    )
+    channel._running = True
+    received: list[Message] = []
+    channel.on_message(received.append)
+
+    await channel._handle_message_event(
+        {
+            "type": "message",
+            "channel_type": "channel",
+            "channel": "C-RESEARCH",
+            "user": "U1",
+            "text": "plain text is ignored",
+            "ts": "1710000002.000100",
+        },
+        {"event_id": "EvAutoPlain", "team_id": "T1"},
+    )
+    await channel._handle_message_event(
+        {
+            "type": "message",
+            "channel_type": "channel",
+            "channel": "C-OTHER",
+            "user": "U1",
+            "text": "https://example.com/ignored",
+            "ts": "1710000002.000200",
+        },
+        {"event_id": "EvAutoOther", "team_id": "T1"},
+    )
+    await channel._handle_message_event(
+        {
+            "type": "message",
+            "channel_type": "channel",
+            "channel": "C-RESEARCH",
+            "user": "U1",
+            "text": "Please analyze <https://arxiv.org/abs/2401.00001|this paper>",
+            "ts": "1710000002.000300",
+        },
+        {"event_id": "EvAutoLink", "team_id": "T1"},
+    )
+
+    assert len(received) == 1
+    message = received[0]
+    assert message.params["content"] == (
+        "Please analyze <https://arxiv.org/abs/2401.00001|this paper>\n\n"
+        "Review this link using the configured workflow."
+    )
+    assert message.params["query"] == message.params["content"]
+    assert message.session_id == "slack_T1_C-RESEARCH_1710000002.000300"
+    assert message.metadata["slack_trigger"] == "auto_link"
+    assert message.metadata["slack_thread_ts"] == "1710000002.000300"
+
+
+@pytest.mark.asyncio
+async def test_auto_link_channel_preserves_message_without_a_prompt() -> None:
+    channel = SlackChannel(
+        SlackChannelConfig(
+            enabled=True,
+            auto_link_channel_ids=["C-RESEARCH"],
+        ),
+        RobotMessageRouter(),
+    )
+    channel._running = True
+    received: list[Message] = []
+    channel.on_message(received.append)
+
+    await channel._handle_message_event(
+        {
+            "type": "message",
+            "channel_type": "channel",
+            "channel": "C-RESEARCH",
+            "user": "U1",
+            "text": "https://example.com/release-notes",
+            "ts": "1710000002.000350",
+        },
+        {"event_id": "EvAutoNoPrompt", "team_id": "T1"},
+    )
+
+    assert len(received) == 1
+    assert received[0].params["content"] == "https://example.com/release-notes"
+
+
+@pytest.mark.asyncio
+async def test_auto_link_channel_ignores_leading_bot_mentions() -> None:
+    channel = SlackChannel(
+        SlackChannelConfig(
+            enabled=True,
+            auto_link_channel_ids=["C-RESEARCH"],
+        ),
+        RobotMessageRouter(),
+    )
+    channel._running = True
+    received: list[Message] = []
+    channel.on_message(received.append)
+
+    event = {
+        "type": "message",
+        "channel_type": "channel",
+        "channel": "C-RESEARCH",
+        "user": "U1",
+        "text": "<@U-BOT> analyze https://example.com/paper",
+        "ts": "1710000002.000400",
+    }
+    await channel._handle_message_event(
+        event,
+        {
+            "event_id": "EvAutoMention",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U-BOT", "is_bot": True}],
+        },
+    )
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_auto_link_channel_processes_links_with_other_user_mention() -> None:
+    channel = SlackChannel(
+        SlackChannelConfig(
+            enabled=True,
+            auto_link_channel_ids=["C-RESEARCH"],
+        ),
+        RobotMessageRouter(),
+    )
+    channel._running = True
+    received: list[Message] = []
+    channel.on_message(received.append)
+
+    await channel._handle_message_event(
+        {
+            "type": "message",
+            "channel_type": "channel",
+            "channel": "C-RESEARCH",
+            "user": "U1",
+            "text": "<@U2> review https://example.com/paper",
+            "ts": "1710000002.000450",
+        },
+        {
+            "event_id": "EvAutoUserMention",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U-BOT", "is_bot": True}],
+        },
+    )
+
+    assert len(received) == 1
+    assert received[0].params["content"] == "<@U2> review https://example.com/paper"
+
+
+@pytest.mark.asyncio
 async def test_event_filters_reject_bots_subtypes_users_and_channels() -> None:
     channel = SlackChannel(
         SlackChannelConfig(
@@ -160,9 +322,140 @@ async def test_event_filters_reject_bots_subtypes_users_and_channels() -> None:
 class _FakeSlackClient:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
+        self.auth_test_calls = 0
 
     async def chat_postMessage(self, **kwargs: Any) -> None:
         self.calls.append(kwargs)
+
+    async def auth_test(self) -> dict[str, str]:
+        self.auth_test_calls += 1
+        return {"user_id": "U-BOT"}
+
+
+@pytest.mark.asyncio
+async def test_auth_test_failure_does_not_block_bot_identity_loading() -> None:
+    class FailingSlackClient:
+        async def auth_test(self) -> dict[str, str]:
+            raise RuntimeError("Slack unavailable")
+
+    channel = SlackChannel(SlackChannelConfig(enabled=True), RobotMessageRouter())
+    channel._client = FailingSlackClient()
+
+    await channel._load_bot_user_id()
+
+    assert channel._bot_user_id == ""
+
+
+@pytest.mark.asyncio
+async def test_missing_bot_identity_still_deduplicates_message_and_mention() -> None:
+    channel = SlackChannel(
+        SlackChannelConfig(
+            enabled=True,
+            auto_link_channel_ids=["C-RESEARCH"],
+        ),
+        RobotMessageRouter(),
+    )
+    channel._running = True
+    received: list[Message] = []
+    channel.on_message(received.append)
+
+    shared_event = {
+        "user": "U1",
+        "channel": "C-RESEARCH",
+        "channel_type": "channel",
+        "text": "<@U-BOT> analyze https://example.com/paper",
+        "ts": "1710000002.000475",
+    }
+    await channel._handle_message_event(
+        {
+            **shared_event,
+            "type": "message",
+            "client_msg_id": "MsgAutoMention",
+        },
+        {"event_id": "EvAutoMentionMessage", "team_id": "T1"},
+    )
+    await channel._handle_app_mention(
+        {**shared_event, "type": "app_mention"},
+        {"event_id": "EvAutoMentionApp", "team_id": "T1"},
+    )
+
+    assert channel._bot_user_id == ""
+    assert len(received) == 1
+
+
+@pytest.mark.asyncio
+async def test_acknowledgement_is_sent_once_before_agent_processing() -> None:
+    channel = SlackChannel(
+        SlackChannelConfig(
+            enabled=True,
+            allow_from=["U1"],
+            allowed_channel_ids=["C1"],
+            reply_in_thread=True,
+            acknowledge_requests=True,
+            acknowledgement_text="Received. Analyzing…",
+        ),
+        RobotMessageRouter(),
+    )
+    client = _FakeSlackClient()
+    channel._running = True
+    channel._client = client
+    calls_seen_by_agent: list[list[dict[str, Any]]] = []
+    channel.on_message(lambda _: calls_seen_by_agent.append(list(client.calls)))
+
+    event = {
+        "type": "app_mention",
+        "user": "U1",
+        "channel": "C1",
+        "channel_type": "channel",
+        "text": "<@B1> analyze this",
+        "ts": "1710000002.000500",
+    }
+    body = {"event_id": "EvAck", "team_id": "T1"}
+
+    await channel._handle_app_mention(event, body)
+    await channel._handle_app_mention(event, body)
+
+    expected_call = {
+        "channel": "C1",
+        "text": "Received. Analyzing…",
+        "thread_ts": "1710000002.000500",
+    }
+    assert client.calls == [expected_call]
+    assert calls_seen_by_agent == [[expected_call]]
+
+
+@pytest.mark.asyncio
+async def test_acknowledgement_failure_does_not_block_agent_processing() -> None:
+    class FailingSlackClient:
+        async def chat_postMessage(self, **kwargs: Any) -> None:
+            raise RuntimeError("Slack unavailable")
+
+    channel = SlackChannel(
+        SlackChannelConfig(
+            enabled=True,
+            allow_from=["U1"],
+            acknowledge_requests=True,
+        ),
+        RobotMessageRouter(),
+    )
+    channel._running = True
+    channel._client = FailingSlackClient()
+    received: list[Message] = []
+    channel.on_message(received.append)
+
+    await channel._handle_message_event(
+        {
+            "type": "message",
+            "channel_type": "im",
+            "channel": "D1",
+            "user": "U1",
+            "text": "analyze this",
+            "ts": "1710000002.000600",
+        },
+        {"event_id": "EvAckFailure", "team_id": "T1"},
+    )
+
+    assert len(received) == 1
 
 
 @pytest.mark.asyncio
@@ -280,12 +573,15 @@ async def test_start_and_stop_socket_mode_lifecycle(
 
     assert channel.is_running
     assert registered_events == ["app_mention", "message"]
+    assert fake_client.auth_test_calls == 1
+    assert channel._bot_user_id == "U-BOT"
 
     await channel.stop()
     await asyncio.wait_for(task, timeout=1)
 
     assert not channel.is_running
     assert closed.is_set()
+    assert channel._bot_user_id == ""
 
 
 def test_make_delivery_target_builds_slack_thread_target() -> None:

--- a/tests/unit_tests/gateway/test_cron_scheduler.py
+++ b/tests/unit_tests/gateway/test_cron_scheduler.py
@@ -550,6 +550,44 @@ class TestHandleEventStoreValidation:
         assert cron["exec_session_id"] == run_info["session_id"]
 
     @pytest.mark.asyncio
+    async def test_slack_push_update_targets_slack_channel(self, tmp_path):
+        store = CronJobStore(path=tmp_path / "cron_jobs.json")
+        job = await _create_one_job(store, targets="slack")
+
+        handler = FakeMessageHandler()
+        svc = _make_scheduler(store, handler)
+        await svc.reload()
+
+        run_id = f"{job.id}:1234"
+        svc.runs[run_id] = CronRunState(
+            run_id=run_id,
+            job_id=job.id,
+            wake_at_iso="2026-06-09T08:55:00+08:00",
+            push_at_iso="2026-06-09T09:00:00+08:00",
+            job_name=job.name,
+            targets=job.targets,
+            session_id=None,
+            chat_type=None,
+            timezone=job.timezone,
+            result_text="repository digest",
+        )
+
+        ev = _Event(
+            at_ts=time.time(),
+            seq=1,
+            kind="push_update",
+            job_id=job.id,
+            run_id=run_id,
+        )
+        await svc.handle_event(ev)
+
+        assert len(handler.published) == 1
+        msg = handler.published[0]
+        assert msg.channel_id == "slack"
+        assert msg.session_id is None
+        assert _cron_published_content(msg) == "repository digest"
+
+    @pytest.mark.asyncio
     async def test_wake_executes_normally_when_job_present(self, tmp_path):
         store_file = tmp_path / "cron_jobs.json"
         store = CronJobStore(path=store_file)

--- a/tests/unit_tests/gateway/test_cron_slack_target.py
+++ b/tests/unit_tests/gateway/test_cron_slack_target.py
@@ -1,0 +1,14 @@
+"""Slack cron target validation."""
+
+from jiuwenswarm.gateway.cron.models import (
+    CronTargetChannel,
+    is_valid_target_channel_id,
+    normalize_target_channel_id,
+)
+
+
+def test_slack_is_a_supported_cron_target() -> None:
+    assert CronTargetChannel.SLACK.value == "slack"
+    assert is_valid_target_channel_id("slack")
+    assert is_valid_target_channel_id("SLACK")
+    assert normalize_target_channel_id("SLACK") == "slack"


### PR DESCRIPTION
Paired: [GitHub #1426](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1426) ↔ [GitCode !4133](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4133)

## Summary

- add opt-in URL-triggered processing for selected Slack channels
- add an optional prompt for automatically processed link messages
- add optional immediate acknowledgements for accepted Slack requests
- allow cron jobs to deliver results to Slack, including source-channel inference for jobs created from Slack
- expose the new settings through configuration, the Web UI, bilingual documentation, and targeted tests

## Motivation

The existing Slack integration supports interactive mentions and direct messages. Automated workflows additionally need three adapter-level capabilities:

1. scoped inbound triggers for selected channels
2. immediate feedback when long-running work is accepted
3. outbound delivery for scheduled jobs

This PR adds those capabilities without changing the existing mention or direct-message behavior. Task-specific behavior remains controlled by agent instructions, Skills, or cron descriptions.

## Behavior

- `auto_link_channel_ids` enables URL-triggered processing only in explicitly configured channels
- `auto_link_prompt` optionally appends workflow-specific instructions; its default is empty
- only a leading mention of the configured Slack bot is filtered from automatic-link handling; mentions of other workspace members are preserved
- cross-event deduplication uses the Slack message timestamp so the same message is dispatched once even if bot identity lookup is unavailable
- `acknowledge_requests` sends configurable feedback before agent processing begins
- a blank acknowledgement value consistently falls back to the documented default
- cron jobs created from Slack infer `targets: slack` when the target is omitted
- Slack-originated cron jobs return to the originating channel or thread; jobs without Slack request context use `default_channel_id`
- automatic messages retain Slack channel and thread metadata
- existing mentions and direct messages remain unchanged

## Compatibility

All new behavior is opt-in:

- automatic URL processing is disabled by default
- the optional URL-processing prompt is empty by default
- immediate acknowledgement is disabled by default
- scheduled Slack delivery requires either Slack request context or an explicit Slack target and destination channel
- no new Slack OAuth scopes are introduced for existing mention or direct-message behavior

## Non-goals

- this PR does not implement repository monitoring or research-analysis logic
- this PR does not automatically process every message in a Slack channel
- workflow-specific behavior belongs in agent configuration, Skills, or cron task descriptions

## Validation

- `python -m pytest tests/unit_tests/channel/test_slack_channel.py tests/unit/agentserver/test_cron_runtime.py tests/unit_tests/gateway/test_cron_scheduler.py tests/unit_tests/gateway/test_cron_slack_target.py -q` — 86 passed
- Ruff checks for the modified Python implementation and targeted tests — passed
- frontend TypeScript checking — passed
- Vite production build — passed
- end-to-end validation covers mentions, direct messages, URL-triggered requests, acknowledgements, and scheduled Slack delivery

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2408
<!-- /bot1-related-issues -->
