### PR TITLE
feat: track session task cost limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+JiuwenSwarm is a Python 3.11+ package rooted at `jiuwenswarm/`. Core areas include `agents/`, `cli/`, `gateway/`, `server/`, `channels/`, `symphony/`, and shared helpers in `common/`. `jiuwenbox/` is a packaged companion module with its own `src/` and `tests/`. Web frontend code lives under `jiuwenswarm/channels/web/frontend/`; TUI code lives under `jiuwenswarm/channels/tui/frontend/` and `packages/jiuwenswarm-tui/`. Tests are in `tests/`, with unit, integration, system, symphony, and UI E2E subtrees. Documentation and images are in `docs/` and `docs/assets/`; deployment examples are in `deploy/`.
+
+## Build, Test, and Development Commands
+
+- `pip install -e ".[test]"`: install the Python package with test dependencies.
+- `pytest`: run the configured Python test suite with coverage reports for `jiuwenswarm`.
+- `pytest tests/unit -m unit`: run a focused subset.
+- `python -m build`: build Python distribution artifacts when the `build` package is installed.
+- `cd jiuwenswarm && npm run dev`: start the web frontend through Vite.
+- `cd jiuwenswarm && npm run build`: generate frontend assets for packaging.
+- `cd jiuwenswarm/channels/web/frontend && npm run lint`: lint the React/TypeScript frontend.
+- `cd jiuwenswarm/channels/tui/frontend && npm run check`: typecheck, lint, and format-check the TUI frontend.
+
+## Coding Style & Naming Conventions
+
+Python code should follow PEP 8: 4-space indentation, `snake_case` functions/modules, and `PascalCase` classes. Keep imports rooted in `jiuwenswarm` or `jiuwenbox` rather than relying on path side effects. Frontend code uses TypeScript, React components in `PascalCase`, hooks/utilities in `camelCase`, and colocated `.css` files where existing components do so. Use Ruff, pylint, mypy, ESLint, Prettier, oxlint, and oxfmt through package scripts.
+
+## Testing Guidelines
+
+Pytest discovers `test_*.py` and `*_test.py` files, `Test*` classes, and `test_*` functions under `tests/`. Use markers declared in `pytest.ini`: `unit`, `integration`, `system`, `slow`, and `async`. Prefer targeted commands during development, followed by `pytest` before broader changes. Frontend tests are explicit npm scripts such as `npm run test:tool-result-lifecycle` from `jiuwenswarm/channels/web/frontend/`.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses concise conventional-style commits, commonly `fix(scope): message`, `fix: message`, and occasional bilingual Chinese descriptions. Prefer an imperative summary, for example `fix(tui): show correct Ctrl+D exit message`. Pull requests should describe the change, list validation commands, link the issue or task, and include screenshots or recordings for UI changes.
+
+## Security & Configuration Tips
+
+Do not commit local credentials, model API keys, generated runtime state, or `node_modules/`. Use templates in `jiuwenswarm/resources/` for configuration examples, and keep dependency floors in `pyproject.toml` when they document security fixes.

--- a/jiuwenswarm/channels/tui/frontend/src/app-state.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/app-state.ts
@@ -95,12 +95,21 @@ export interface ModelUsageEntry {
   input_tokens: number;
   output_tokens: number;
   total_tokens: number;
+  input_cost?: number;
+  output_cost?: number;
+  total_cost?: number;
 }
 
 export interface SessionUsageSummary {
   total_input_tokens: number;
   total_output_tokens: number;
   total_tokens: number;
+  cost_available: boolean;
+  total_input_cost?: number;
+  total_output_cost?: number;
+  total_cost?: number;
+  cost_limit?: number | null;
+  cost_limit_exceeded: boolean;
   byModel: ModelUsageEntry[];
 }
 
@@ -399,6 +408,8 @@ export class CliPiAppState {
   private statusLineText: string | null = null;
   private statusLineTimer: ReturnType<typeof setInterval> | null = null;
   private usageByModel = new Map<string, ModelUsageEntry>();
+  private sessionCostLimit: number | null = null;
+  private costLimitExceeded = false;
   private currentQueryUsage: CurrentQueryUsage = {
     input_tokens: 0,
     output_tokens: 0,
@@ -1261,6 +1272,8 @@ export class CliPiAppState {
       setInput: this._setInputRef ?? undefined,
       enterStatusView: undefined,
       getUsageSummary: () => this.getUsageSummary(),
+      getSessionCostLimit: () => this.getSessionCostLimit(),
+      setSessionCostLimit: (limit) => this.setSessionCostLimit(limit),
       restartStatusLine: () => this.restartStatusLinePoll(),
       getStatusLineJsonInput: () => this.buildStatusLineJsonInput(),
       hasRunningTeamTasks: () => {
@@ -1288,10 +1301,28 @@ export class CliPiAppState {
 
   getUsageSummary(): SessionUsageSummary {
     const entries = Array.from(this.usageByModel.values());
+    const inputCost = entries.reduce((s, e) => s + (e.input_cost ?? 0), 0);
+    const outputCost = entries.reduce((s, e) => s + (e.output_cost ?? 0), 0);
+    const totalCost = entries.reduce((s, e) => s + (e.total_cost ?? (e.input_cost ?? 0) + (e.output_cost ?? 0)), 0);
+    const costAvailable = entries.some((e) =>
+      typeof e.total_cost === "number" ||
+      typeof e.input_cost === "number" ||
+      typeof e.output_cost === "number"
+    );
     return {
       total_input_tokens: entries.reduce((s, e) => s + e.input_tokens, 0),
       total_output_tokens: entries.reduce((s, e) => s + e.output_tokens, 0),
       total_tokens: entries.reduce((s, e) => s + e.total_tokens, 0),
+      cost_available: costAvailable,
+      ...(costAvailable
+        ? {
+            total_input_cost: inputCost,
+            total_output_cost: outputCost,
+            total_cost: totalCost,
+          }
+        : {}),
+      cost_limit: this.sessionCostLimit,
+      cost_limit_exceeded: this.costLimitExceeded,
       byModel: entries,
     };
   }
@@ -1305,13 +1336,41 @@ export class CliPiAppState {
       typeof usage.total_tokens === "number" && Number.isFinite(usage.total_tokens)
         ? Math.max(0, usage.total_tokens)
         : inputDelta + outputDelta;
+    const inputCostDelta = this.safeCostValue(usage.input_cost);
+    const outputCostDelta = this.safeCostValue(usage.output_cost);
+    const explicitTotalCostDelta = this.safeCostValue(usage.total_cost);
+    const totalCostDelta = explicitTotalCostDelta ?? (
+      inputCostDelta !== undefined || outputCostDelta !== undefined
+        ? (inputCostDelta ?? 0) + (outputCostDelta ?? 0)
+        : undefined
+    );
     const entry: ModelUsageEntry = {
       model: key,
       input_tokens: (existing?.input_tokens ?? 0) + inputDelta,
       output_tokens: (existing?.output_tokens ?? 0) + outputDelta,
       total_tokens: (existing?.total_tokens ?? 0) + totalDelta,
     };
+    if (inputCostDelta !== undefined || existing?.input_cost !== undefined) {
+      entry.input_cost = (existing?.input_cost ?? 0) + (inputCostDelta ?? 0);
+    }
+    if (outputCostDelta !== undefined || existing?.output_cost !== undefined) {
+      entry.output_cost = (existing?.output_cost ?? 0) + (outputCostDelta ?? 0);
+    }
+    if (totalCostDelta !== undefined || existing?.total_cost !== undefined) {
+      entry.total_cost = (existing?.total_cost ?? 0) + (totalCostDelta ?? 0);
+    }
     this.usageByModel.set(key, entry);
+    this.enforceCostLimit();
+  }
+
+  setSessionCostLimit(limit: number | null): void {
+    this.sessionCostLimit = limit !== null ? Math.max(0, limit) : null;
+    this.costLimitExceeded = false;
+    this.emitChange();
+  }
+
+  getSessionCostLimit(): number | null {
+    return this.sessionCostLimit;
   }
 
   private updateCurrentUsageTokens(usage: Record<string, unknown>): void {
@@ -1333,6 +1392,32 @@ export class CliPiAppState {
 
   private safeTokenCount(value: unknown): number {
     return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : 0;
+  }
+
+  private safeCostValue(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : undefined;
+  }
+
+  private enforceCostLimit(): void {
+    if (this.sessionCostLimit === null || this.costLimitExceeded) {
+      return;
+    }
+    const summary = this.getUsageSummary();
+    if (!summary.cost_available || typeof summary.total_cost !== "number") {
+      return;
+    }
+    if (summary.total_cost <= this.sessionCostLimit) {
+      return;
+    }
+    this.costLimitExceeded = true;
+    this.sendEventOnly("chat.interrupt", { intent: "cancel", mode: this.mode });
+    this.addItem(
+      addError(
+        this.sessionId,
+        `Cost limit exceeded: $${summary.total_cost.toFixed(4)} > $${this.sessionCostLimit.toFixed(4)}. Task interrupted.`,
+      ),
+    );
+    this.emitChange();
   }
 
   private resetCurrentUsageTokens(): void {
@@ -1736,6 +1821,8 @@ export class CliPiAppState {
     this.sessionId = newId;
     this.lastVisibleUserRequest = null;
     this.usageByModel.clear();
+    this.sessionCostLimit = null;
+    this.costLimitExceeded = false;
     this.resetCurrentUsageTokens();
     this.workflowRuns = [];
     this.pendingHumanPrompts = new Map();
@@ -3256,6 +3343,16 @@ export class CliPiAppState {
         total_input_tokens: usage.total_input_tokens,
         total_output_tokens: usage.total_output_tokens,
         total_tokens: usage.total_tokens,
+        cost_available: usage.cost_available,
+        ...(usage.cost_available
+          ? {
+              total_input_cost: usage.total_input_cost ?? 0,
+              total_output_cost: usage.total_output_cost ?? 0,
+              total_cost: usage.total_cost ?? 0,
+              cost_limit: usage.cost_limit ?? null,
+              cost_limit_exceeded: usage.cost_limit_exceeded,
+            }
+          : {}),
       },
       context_window: {
         context_window_size: snapshot.contextWindowLimit ?? 0,

--- a/jiuwenswarm/channels/tui/frontend/src/app-state.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/app-state.ts
@@ -105,10 +105,15 @@ export interface SessionUsageSummary {
   total_output_tokens: number;
   total_tokens: number;
   cost_available: boolean;
+  cost_feature_enabled?: boolean;
+  cost_source?: string;
+  currency?: string | null;
   total_input_cost?: number;
   total_output_cost?: number;
   total_cost?: number;
   cost_limit?: number | null;
+  limit_supported?: boolean;
+  limit_enforcement_enabled?: boolean;
   cost_limit_exceeded: boolean;
   byModel: ModelUsageEntry[];
 }
@@ -408,8 +413,6 @@ export class CliPiAppState {
   private statusLineText: string | null = null;
   private statusLineTimer: ReturnType<typeof setInterval> | null = null;
   private usageByModel = new Map<string, ModelUsageEntry>();
-  private sessionCostLimit: number | null = null;
-  private costLimitExceeded = false;
   private currentQueryUsage: CurrentQueryUsage = {
     input_tokens: 0,
     output_tokens: 0,
@@ -1272,8 +1275,6 @@ export class CliPiAppState {
       setInput: this._setInputRef ?? undefined,
       enterStatusView: undefined,
       getUsageSummary: () => this.getUsageSummary(),
-      getSessionCostLimit: () => this.getSessionCostLimit(),
-      setSessionCostLimit: (limit) => this.setSessionCostLimit(limit),
       restartStatusLine: () => this.restartStatusLinePoll(),
       getStatusLineJsonInput: () => this.buildStatusLineJsonInput(),
       hasRunningTeamTasks: () => {
@@ -1314,6 +1315,8 @@ export class CliPiAppState {
       total_output_tokens: entries.reduce((s, e) => s + e.output_tokens, 0),
       total_tokens: entries.reduce((s, e) => s + e.total_tokens, 0),
       cost_available: costAvailable,
+      cost_feature_enabled: costAvailable,
+      cost_source: costAvailable ? "provider_reported" : "unavailable",
       ...(costAvailable
         ? {
             total_input_cost: inputCost,
@@ -1321,8 +1324,10 @@ export class CliPiAppState {
             total_cost: totalCost,
           }
         : {}),
-      cost_limit: this.sessionCostLimit,
-      cost_limit_exceeded: this.costLimitExceeded,
+      cost_limit: null,
+      limit_supported: false,
+      limit_enforcement_enabled: false,
+      cost_limit_exceeded: false,
       byModel: entries,
     };
   }
@@ -1360,17 +1365,7 @@ export class CliPiAppState {
       entry.total_cost = (existing?.total_cost ?? 0) + (totalCostDelta ?? 0);
     }
     this.usageByModel.set(key, entry);
-    this.enforceCostLimit();
-  }
-
-  setSessionCostLimit(limit: number | null): void {
-    this.sessionCostLimit = limit !== null ? Math.max(0, limit) : null;
-    this.costLimitExceeded = false;
     this.emitChange();
-  }
-
-  getSessionCostLimit(): number | null {
-    return this.sessionCostLimit;
   }
 
   private updateCurrentUsageTokens(usage: Record<string, unknown>): void {
@@ -1396,28 +1391,6 @@ export class CliPiAppState {
 
   private safeCostValue(value: unknown): number | undefined {
     return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : undefined;
-  }
-
-  private enforceCostLimit(): void {
-    if (this.sessionCostLimit === null || this.costLimitExceeded) {
-      return;
-    }
-    const summary = this.getUsageSummary();
-    if (!summary.cost_available || typeof summary.total_cost !== "number") {
-      return;
-    }
-    if (summary.total_cost <= this.sessionCostLimit) {
-      return;
-    }
-    this.costLimitExceeded = true;
-    this.sendEventOnly("chat.interrupt", { intent: "cancel", mode: this.mode });
-    this.addItem(
-      addError(
-        this.sessionId,
-        `Cost limit exceeded: $${summary.total_cost.toFixed(4)} > $${this.sessionCostLimit.toFixed(4)}. Task interrupted.`,
-      ),
-    );
-    this.emitChange();
   }
 
   private resetCurrentUsageTokens(): void {
@@ -1821,8 +1794,6 @@ export class CliPiAppState {
     this.sessionId = newId;
     this.lastVisibleUserRequest = null;
     this.usageByModel.clear();
-    this.sessionCostLimit = null;
-    this.costLimitExceeded = false;
     this.resetCurrentUsageTokens();
     this.workflowRuns = [];
     this.pendingHumanPrompts = new Map();
@@ -3346,6 +3317,8 @@ export class CliPiAppState {
         cost_available: usage.cost_available,
         ...(usage.cost_available
           ? {
+              cost_source: usage.cost_source ?? "provider_reported",
+              currency: usage.currency ?? null,
               total_input_cost: usage.total_input_cost ?? 0,
               total_output_cost: usage.total_output_cost ?? 0,
               total_cost: usage.total_cost ?? 0,

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/limit.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/limit.ts
@@ -1,0 +1,96 @@
+import { addError, addInfo } from "../helpers.js";
+import { CommandKind, type SlashCommand } from "../types.js";
+
+function formatCost(value: number): string {
+  return `$${value.toFixed(4)}`;
+}
+
+function showLimit(ctx: import("../types.js").CommandContext): void {
+  const summary = ctx.getUsageSummary();
+  const limit = ctx.getSessionCostLimit?.() ?? null;
+  const items = [
+    { label: "scope", value: "session" },
+    { label: "cost_limit", value: limit === null ? "infinite" : formatCost(limit) },
+  ];
+  if (summary.cost_available && typeof summary.total_cost === "number") {
+    items.push({ label: "current_cost", value: formatCost(summary.total_cost) });
+    if (limit !== null) {
+      items.push({
+        label: "remaining",
+        value: formatCost(Math.max(0, limit - summary.total_cost)),
+      });
+    }
+  } else {
+    items.push({ label: "current_cost", value: "unavailable (provider did not return cost)" });
+  }
+  ctx.addItem(
+    addInfo(ctx.sessionId, "Cost limit", "l", {
+      view: "kv",
+      title: "Limit",
+      items,
+    }),
+  );
+}
+
+function parseCost(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const normalized = raw.trim().replace(/^\$/, "");
+  if (!normalized) return null;
+  const value = Number(normalized);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+async function syncBackendLimit(
+  ctx: import("../types.js").CommandContext,
+  commandText: string,
+): Promise<void> {
+  try {
+    await ctx.request("chat.send", { query: commandText, mode: ctx.mode }, 30_000);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    ctx.addItem(addError(ctx.sessionId, `backend cost limit sync failed: ${message}`));
+  }
+}
+
+export function createLimitCommand(): SlashCommand {
+  return {
+    name: "limit",
+    description: "Show or set current task/session cost limit",
+    usage: "/limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
+    example: "/limit cost 2.50",
+    kind: CommandKind.BUILT_IN,
+    action: async (ctx, rawArgs = "") => {
+      const args = rawArgs.trim().split(/\s+/).filter(Boolean);
+      if (args.length === 0) {
+        showLimit(ctx);
+        return;
+      }
+      const scope = args[0] === "session" ? "session" : args[0] === "task" ? "task" : "session";
+      const offset = args[0] === "session" || args[0] === "task" ? 1 : 0;
+      const scopeLabel = scope === "task" ? "Current task/session" : "Session";
+      const command = args[offset];
+      if (command === "clear") {
+        ctx.setSessionCostLimit?.(null);
+        await syncBackendLimit(ctx, `/${["limit", scope, "clear"].filter(Boolean).join(" ")}`);
+        ctx.addItem(addInfo(ctx.sessionId, `${scopeLabel} cost limit cleared (infinite)`, "l"));
+        return;
+      }
+      if (command === "cost") {
+        const value = parseCost(args[offset + 1]);
+        if (value === null) {
+          ctx.addItem(addError(ctx.sessionId, "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]"));
+          return;
+        }
+        ctx.setSessionCostLimit?.(value);
+        const summary = ctx.getUsageSummary();
+        const suffix = summary.cost_available
+          ? ""
+          : " It will not be enforced until provider cost metadata is available.";
+        await syncBackendLimit(ctx, `/${["limit", scope, "cost", value.toString()].filter(Boolean).join(" ")}`);
+        ctx.addItem(addInfo(ctx.sessionId, `${scopeLabel} cost limit set to ${formatCost(value)}.${suffix}`, "l"));
+        return;
+      }
+      ctx.addItem(addError(ctx.sessionId, "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]"));
+    },
+  };
+}

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/limit.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/limit.ts
@@ -2,17 +2,21 @@ import { addError, addInfo } from "../helpers.js";
 import { CommandKind, type SlashCommand } from "../types.js";
 
 function formatCost(value: number): string {
-  return `$${value.toFixed(4)}`;
+  return value.toFixed(4);
 }
 
 function showLimit(ctx: import("../types.js").CommandContext): void {
   const summary = ctx.getUsageSummary();
-  const limit = ctx.getSessionCostLimit?.() ?? null;
+  const limit = summary.cost_limit ?? null;
   const items = [
     { label: "scope", value: "session" },
     { label: "cost_limit", value: limit === null ? "infinite" : formatCost(limit) },
   ];
   if (summary.cost_available && typeof summary.total_cost === "number") {
+    items.push({ label: "cost_source", value: summary.cost_source ?? "provider_reported" });
+    if (summary.currency) {
+      items.push({ label: "currency", value: summary.currency });
+    }
     items.push({ label: "current_cost", value: formatCost(summary.total_cost) });
     if (limit !== null) {
       items.push({
@@ -59,8 +63,8 @@ async function syncBackendLimit(
 export function createLimitCommand(): SlashCommand {
   return {
     name: "limit",
-    description: "Show or set current task/session cost limit",
-    usage: "/limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
+    description: "Show or set the current session cost limit",
+    usage: "/limit [cost <amount>|session cost <amount>|clear|session clear]",
     example: "/limit cost 2.50",
     kind: CommandKind.BUILT_IN,
     action: async (ctx, rawArgs = "") => {
@@ -69,32 +73,29 @@ export function createLimitCommand(): SlashCommand {
         showLimit(ctx);
         return;
       }
-      const scope = args[0] === "session" ? "session" : args[0] === "task" ? "task" : "session";
-      const offset = args[0] === "session" || args[0] === "task" ? 1 : 0;
-      const scopeLabel = scope === "task" ? "Current task/session" : "Session";
+      if (args[0] === "task") {
+        ctx.addItem(addError(ctx.sessionId, "Task-scoped cost limits are not supported yet; use session scope."));
+        return;
+      }
+      const scope = "session";
+      const offset = args[0] === "session" ? 1 : 0;
       const command = args[offset];
       if (command === "clear") {
-        ctx.setSessionCostLimit?.(null);
         await syncBackendLimit(ctx, `/${["limit", scope, "clear"].filter(Boolean).join(" ")}`);
-        ctx.addItem(addInfo(ctx.sessionId, `${scopeLabel} cost limit cleared (infinite)`, "l"));
+        ctx.addItem(addInfo(ctx.sessionId, "Session cost limit cleared (infinite)", "l"));
         return;
       }
       if (command === "cost") {
         const value = parseCost(args[offset + 1]);
         if (value === null) {
-          ctx.addItem(addError(ctx.sessionId, "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]"));
+          ctx.addItem(addError(ctx.sessionId, "Usage: /limit [cost <amount>|session cost <amount>|clear|session clear]"));
           return;
         }
-        ctx.setSessionCostLimit?.(value);
-        const summary = ctx.getUsageSummary();
-        const suffix = summary.cost_available
-          ? ""
-          : " It will not be enforced until provider cost metadata is available.";
         await syncBackendLimit(ctx, `/${["limit", scope, "cost", value.toString()].filter(Boolean).join(" ")}`);
-        ctx.addItem(addInfo(ctx.sessionId, `${scopeLabel} cost limit set to ${formatCost(value)}.${suffix}`, "l"));
+        ctx.addItem(addInfo(ctx.sessionId, `Requested session cost limit: ${formatCost(value)}`, "l"));
         return;
       }
-      ctx.addItem(addError(ctx.sessionId, "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]"));
+      ctx.addItem(addError(ctx.sessionId, "Usage: /limit [cost <amount>|session cost <amount>|clear|session clear]"));
     },
   };
 }

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/limit.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/limit.ts
@@ -45,7 +45,11 @@ async function syncBackendLimit(
   commandText: string,
 ): Promise<void> {
   try {
-    await ctx.request("chat.send", { query: commandText, mode: ctx.mode }, 30_000);
+    await ctx.request(
+      "chat.send",
+      { query: commandText, mode: ctx.mode, log_as_user: false },
+      30_000,
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     ctx.addItem(addError(ctx.sessionId, `backend cost limit sync failed: ${message}`));

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/status.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/status.ts
@@ -95,7 +95,10 @@ function showOverview(ctx: import("../types.js").CommandContext, payload: Status
 
 function showUsage(ctx: import("../types.js").CommandContext, summary: SessionUsageSummary): void {
   const fmt = (n: number) => n.toLocaleString("en-US");
-  const fmtCost = (n: number) => `$${n.toFixed(4)}`;
+  const fmtCost = (n: number) => {
+    const currency = summary.currency?.trim();
+    return currency ? `${n.toFixed(4)} ${currency}` : n.toFixed(4);
+  };
 
   const items = [
     { label: "input_tokens", value: fmt(summary.total_input_tokens) },
@@ -103,6 +106,7 @@ function showUsage(ctx: import("../types.js").CommandContext, summary: SessionUs
     { label: "total_tokens", value: fmt(summary.total_tokens) },
   ];
   if (summary.cost_available && typeof summary.total_cost === "number") {
+    items.push({ label: "cost_source", value: summary.cost_source ?? "provider_reported" });
     items.push({ label: "total_cost", value: fmtCost(summary.total_cost) });
     if (summary.cost_limit != null) {
       items.push({ label: "cost_limit", value: fmtCost(summary.cost_limit) });

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/status.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/status.ts
@@ -95,12 +95,19 @@ function showOverview(ctx: import("../types.js").CommandContext, payload: Status
 
 function showUsage(ctx: import("../types.js").CommandContext, summary: SessionUsageSummary): void {
   const fmt = (n: number) => n.toLocaleString("en-US");
+  const fmtCost = (n: number) => `$${n.toFixed(4)}`;
 
   const items = [
     { label: "input_tokens", value: fmt(summary.total_input_tokens) },
     { label: "output_tokens", value: fmt(summary.total_output_tokens) },
     { label: "total_tokens", value: fmt(summary.total_tokens) },
   ];
+  if (summary.cost_available && typeof summary.total_cost === "number") {
+    items.push({ label: "total_cost", value: fmtCost(summary.total_cost) });
+    if (summary.cost_limit != null) {
+      items.push({ label: "cost_limit", value: fmtCost(summary.cost_limit) });
+    }
+  }
 
   if (summary.byModel.length > 0) {
     for (const entry of summary.byModel) {
@@ -109,6 +116,9 @@ function showUsage(ctx: import("../types.js").CommandContext, summary: SessionUs
         { label: `  input`, value: fmt(entry.input_tokens) },
         { label: `  output`, value: fmt(entry.output_tokens) },
       );
+      if (typeof entry.total_cost === "number") {
+        items.push({ label: `  cost`, value: fmtCost(entry.total_cost) });
+      }
     }
   }
 

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/usage.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/usage.ts
@@ -4,12 +4,19 @@ import { CommandKind, type SlashCommand } from "../types.js";
 function showUsage(ctx: import("../types.js").CommandContext): void {
   const summary = ctx.getUsageSummary();
   const fmt = (n: number) => n.toLocaleString("en-US");
+  const fmtCost = (n: number) => `$${n.toFixed(4)}`;
 
   const items = [
     { label: "input_tokens", value: fmt(summary.total_input_tokens) },
     { label: "output_tokens", value: fmt(summary.total_output_tokens) },
     { label: "total_tokens", value: fmt(summary.total_tokens) },
   ];
+  if (summary.cost_available && typeof summary.total_cost === "number") {
+    items.push({ label: "total_cost", value: fmtCost(summary.total_cost) });
+    if (summary.cost_limit != null) {
+      items.push({ label: "cost_limit", value: fmtCost(summary.cost_limit) });
+    }
+  }
 
   if (summary.byModel.length > 0) {
     for (const entry of summary.byModel) {
@@ -18,6 +25,9 @@ function showUsage(ctx: import("../types.js").CommandContext): void {
         { label: `  input`, value: fmt(entry.input_tokens) },
         { label: `  output`, value: fmt(entry.output_tokens) },
       );
+      if (typeof entry.total_cost === "number") {
+        items.push({ label: `  cost`, value: fmtCost(entry.total_cost) });
+      }
     }
   }
 
@@ -33,7 +43,7 @@ function showUsage(ctx: import("../types.js").CommandContext): void {
 export function createUsageCommand(): SlashCommand {
   return {
     name: "usage",
-    description: "Show session token usage (input / output / total)",
+    description: "Show session token and cost usage when available",
     usage: "/usage",
     example: "/usage",
     kind: CommandKind.BUILT_IN,

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/usage.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/usage.ts
@@ -4,7 +4,10 @@ import { CommandKind, type SlashCommand } from "../types.js";
 function showUsage(ctx: import("../types.js").CommandContext): void {
   const summary = ctx.getUsageSummary();
   const fmt = (n: number) => n.toLocaleString("en-US");
-  const fmtCost = (n: number) => `$${n.toFixed(4)}`;
+  const fmtCost = (n: number) => {
+    const currency = summary.currency?.trim();
+    return currency ? `${n.toFixed(4)} ${currency}` : n.toFixed(4);
+  };
 
   const items = [
     { label: "input_tokens", value: fmt(summary.total_input_tokens) },
@@ -12,6 +15,7 @@ function showUsage(ctx: import("../types.js").CommandContext): void {
     { label: "total_tokens", value: fmt(summary.total_tokens) },
   ];
   if (summary.cost_available && typeof summary.total_cost === "number") {
+    items.push({ label: "cost_source", value: summary.cost_source ?? "provider_reported" });
     items.push({ label: "total_cost", value: fmtCost(summary.total_cost) });
     if (summary.cost_limit != null) {
       items.push({ label: "cost_limit", value: fmtCost(summary.cost_limit) });
@@ -26,7 +30,7 @@ function showUsage(ctx: import("../types.js").CommandContext): void {
         { label: `  output`, value: fmt(entry.output_tokens) },
       );
       if (typeof entry.total_cost === "number") {
-        items.push({ label: `  cost`, value: fmtCost(entry.total_cost) });
+        items.push({ label: `  provider_reported_cost`, value: fmtCost(entry.total_cost) });
       }
     }
   }

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/registry.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/registry.ts
@@ -25,6 +25,7 @@ import { createHarmonyOSProjectInitCommand } from "./builtins/harmonyos-project-
 import { createHooksCommand } from "./builtins/hooks.js";
 import { createKeybindingsCommand } from "./builtins/keybindings.js";
 import { createInitCommand } from "./builtins/init.js";
+import { createLimitCommand } from "./builtins/limit.js";
 import { createModelCommand } from "./builtins/model.js";
 import { createMcpCommand } from "./builtins/mcp.js";
 import { createMemoryCommand } from "./builtins/memory.js";
@@ -88,6 +89,7 @@ export function createBuiltinCommands(options: BuiltinCommandsOptions = {}): Sla
     createBtwCommand(),
     createClearCommand(),
     createInitCommand(),
+    createLimitCommand(),
     createColorCommand(),
     createCompactCommand(),
     createConfigCommand(),

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/types.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/types.ts
@@ -106,8 +106,6 @@ export interface CommandContext {
   getWorkspaceDir: () => string | undefined;
   setInput?: (text: string) => void;
   getUsageSummary: () => SessionUsageSummary;
-  getSessionCostLimit?: () => number | null;
-  setSessionCostLimit?: (limit: number | null) => void;
   enterConfigEditor?: (
     focusKey?: string,
     configPayload?: Record<string, unknown> & { schema?: ConfigItemSchema[] },

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/types.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/types.ts
@@ -106,6 +106,8 @@ export interface CommandContext {
   getWorkspaceDir: () => string | undefined;
   setInput?: (text: string) => void;
   getUsageSummary: () => SessionUsageSummary;
+  getSessionCostLimit?: () => number | null;
+  setSessionCostLimit?: (limit: number | null) => void;
   enterConfigEditor?: (
     focusKey?: string,
     configPayload?: Record<string, unknown> & { schema?: ConfigItemSchema[] },

--- a/jiuwenswarm/channels/tui/frontend/src/ui/app-screen.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/ui/app-screen.ts
@@ -8415,13 +8415,17 @@ export class AppScreen implements Component, Focusable {
   private buildUsageTabItems(): SelectItem[] {
     const summary = this.state.getUsageSummary();
     const fmt = (n: number) => n.toLocaleString("en-US");
-    const fmtCost = (n: number) => `$${n.toFixed(4)}`;
+    const fmtCost = (n: number) => {
+      const currency = summary.currency?.trim();
+      return currency ? `${n.toFixed(4)} ${currency}` : n.toFixed(4);
+    };
     const items: SelectItem[] = [
       { value: "__display__", label: `input_tokens: ${fmt(summary.total_input_tokens)}`, description: "" },
       { value: "__display__", label: `output_tokens: ${fmt(summary.total_output_tokens)}`, description: "" },
       { value: "__display__", label: `total_tokens: ${fmt(summary.total_tokens)}`, description: "" },
     ];
     if (summary.cost_available && typeof summary.total_cost === "number") {
+      items.push({ value: "__display__", label: `cost_source: ${summary.cost_source ?? "provider_reported"}`, description: "" });
       items.push({ value: "__display__", label: `total_cost: ${fmtCost(summary.total_cost)}`, description: "" });
       if (summary.cost_limit != null) {
         items.push({ value: "__display__", label: `cost_limit: ${fmtCost(summary.cost_limit)}`, description: "" });

--- a/jiuwenswarm/channels/tui/frontend/src/ui/app-screen.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/ui/app-screen.ts
@@ -8415,11 +8415,18 @@ export class AppScreen implements Component, Focusable {
   private buildUsageTabItems(): SelectItem[] {
     const summary = this.state.getUsageSummary();
     const fmt = (n: number) => n.toLocaleString("en-US");
+    const fmtCost = (n: number) => `$${n.toFixed(4)}`;
     const items: SelectItem[] = [
       { value: "__display__", label: `input_tokens: ${fmt(summary.total_input_tokens)}`, description: "" },
       { value: "__display__", label: `output_tokens: ${fmt(summary.total_output_tokens)}`, description: "" },
       { value: "__display__", label: `total_tokens: ${fmt(summary.total_tokens)}`, description: "" },
     ];
+    if (summary.cost_available && typeof summary.total_cost === "number") {
+      items.push({ value: "__display__", label: `total_cost: ${fmtCost(summary.total_cost)}`, description: "" });
+      if (summary.cost_limit != null) {
+        items.push({ value: "__display__", label: `cost_limit: ${fmtCost(summary.cost_limit)}`, description: "" });
+      }
+    }
 
     for (const entry of summary.byModel) {
       items.push(
@@ -8427,6 +8434,9 @@ export class AppScreen implements Component, Focusable {
         { value: "__display__", label: `  input`, description: fmt(entry.input_tokens) },
         { value: "__display__", label: `  output`, description: fmt(entry.output_tokens) },
       );
+      if (typeof entry.total_cost === "number") {
+        items.push({ value: "__display__", label: `  cost`, description: fmtCost(entry.total_cost) });
+      }
     }
     return items;
   }

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/ChatPanel.css
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/ChatPanel.css
@@ -67,6 +67,21 @@
   white-space: nowrap;
 }
 
+.chat-panel-header__usage {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 20px;
+  white-space: nowrap;
+}
+
 .chat-panel-header__actions {
   display: flex;
   align-items: center;

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/MessageItem.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/MessageItem.tsx
@@ -653,9 +653,11 @@ export const MessageItem = memo(function MessageItem({
             </span>
             {message.usageSummary.total_cost != null && message.usageSummary.total_cost > 0 && (
               <span>
-                ${message.usageSummary.input_cost?.toFixed(4)} in /{' '}
-                ${message.usageSummary.output_cost?.toFixed(4)} out /{' '}
-                ${message.usageSummary.total_cost.toFixed(4)} total
+                provider-reported{' '}
+                {message.usageSummary.input_cost?.toFixed(4)} in /{' '}
+                {message.usageSummary.output_cost?.toFixed(4)} out /{' '}
+                {message.usageSummary.total_cost.toFixed(4)} total
+                {message.usageSummary.currency ? ` ${message.usageSummary.currency}` : ''}
               </span>
             )}
           </div>

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/index.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/index.tsx
@@ -761,14 +761,19 @@ export function ChatPanel({
   const sessionCostTotal = useMemo(() => {
     let total = 0;
     let available = false;
+    let currency = '';
     for (const message of messages) {
       const cost = message.usageSummary?.total_cost;
       if (typeof cost === 'number' && Number.isFinite(cost)) {
         available = true;
         total += Math.max(0, cost);
+        const reportedCurrency = message.usageSummary?.currency;
+        if (typeof reportedCurrency === 'string' && reportedCurrency.trim()) {
+          currency = reportedCurrency.trim().toUpperCase();
+        }
       }
     }
-    return available ? total : null;
+    return available ? { total, currency } : null;
   }, [messages]);
   const hasConversation = Boolean(isHistoryRestoring || historyPager || hasTimelineContent);
   const historyLoadedPages = historyPager?.loadedPages ?? 0;
@@ -1109,8 +1114,10 @@ export function ChatPanel({
               </div>
             )}
             {sessionCostTotal !== null && (
-              <div className="chat-panel-header__usage" title="Current session cost">
-                ${sessionCostTotal.toFixed(4)}
+              <div className="chat-panel-header__usage" title="Provider-reported current session cost">
+                {sessionCostTotal.currency
+                  ? `${sessionCostTotal.total.toFixed(4)} ${sessionCostTotal.currency}`
+                  : `provider cost ${sessionCostTotal.total.toFixed(4)}`}
               </div>
             )}
           </div>

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/index.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/index.tsx
@@ -758,6 +758,18 @@ export function ChatPanel({
   const stickToBottomUntilStableRef = useRef(false);
   const [isSending, setIsSending] = React.useState(false);
   const hasTimelineContent = messages.length > 0 || toolExecutionOrder.length > 0;
+  const sessionCostTotal = useMemo(() => {
+    let total = 0;
+    let available = false;
+    for (const message of messages) {
+      const cost = message.usageSummary?.total_cost;
+      if (typeof cost === 'number' && Number.isFinite(cost)) {
+        available = true;
+        total += Math.max(0, cost);
+      }
+    }
+    return available ? total : null;
+  }, [messages]);
   const hasConversation = Boolean(isHistoryRestoring || historyPager || hasTimelineContent);
   const historyLoadedPages = historyPager?.loadedPages ?? 0;
   const historyTotalPages = historyPager?.totalPages ?? 0;
@@ -1094,6 +1106,11 @@ export function ChatPanel({
               <div className="chat-panel-header__project" title={sessionProjectName}>
                 <span className="chat-config-icon chat-config-icon--folder" aria-hidden="true" />
                 <span>{sessionProjectName}</span>
+              </div>
+            )}
+            {sessionCostTotal !== null && (
+              <div className="chat-panel-header__usage" title="Current session cost">
+                ${sessionCostTotal.toFixed(4)}
               </div>
             )}
           </div>

--- a/jiuwenswarm/channels/web/frontend/src/features/historyRestore.ts
+++ b/jiuwenswarm/channels/web/frontend/src/features/historyRestore.ts
@@ -640,6 +640,8 @@ function parseHistoryTimelineEntry(
       if (typeof rawUsage.input_cost === 'number') usage.input_cost = rawUsage.input_cost;
       if (typeof rawUsage.output_cost === 'number') usage.output_cost = rawUsage.output_cost;
       if (typeof rawUsage.total_cost === 'number') usage.total_cost = rawUsage.total_cost;
+      if (typeof rawUsage.cost_source === 'string') usage.cost_source = rawUsage.cost_source;
+      if (typeof rawUsage.currency === 'string') usage.currency = rawUsage.currency;
       return { kind: 'usage_summary', at, usage };
     }
     return null;

--- a/jiuwenswarm/channels/web/frontend/src/types/message.ts
+++ b/jiuwenswarm/channels/web/frontend/src/types/message.ts
@@ -27,6 +27,8 @@ export interface UsageSummary {
   input_cost?: number;
   output_cost?: number;
   total_cost?: number;
+  cost_source?: string;
+  currency?: string | null;
 }
 
 export interface FileDownloadItem {

--- a/jiuwenswarm/resources/config.yaml
+++ b/jiuwenswarm/resources/config.yaml
@@ -5,6 +5,15 @@ preferred_language: zh
 setup_guide:
   enabled: true
 
+# Experimental provider-reported session cost visibility.
+# Cost is shown/enforced only when the provider emits supported cost metadata.
+usage_cost:
+  enabled: false
+  mode: provider_reported
+  enforce_limits: false
+  unsupported_provider_behavior: refuse_limit
+  currency: ""
+
 # auto-recap：用户空闲5分钟后自动生成会话摘要（TUI 端）
 auto_recap:
   enabled: true

--- a/jiuwenswarm/server/runtime/agent_adapter/code_agent_rail.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/code_agent_rail.py
@@ -23,6 +23,7 @@ from openjiuwen.harness.tools.base_tool import ToolOutput
 from openjiuwen.harness.workspace.workspace import Workspace
 
 from jiuwenswarm.server.runtime.debug_trace import invoke_subagent_with_trace
+from jiuwenswarm.server.runtime.usage_cost import CostLimitExceededError
 
 if TYPE_CHECKING:
     from openjiuwen.core.session.agent import Session
@@ -333,6 +334,8 @@ class AgentTool(Tool):
                     success=True,
                     data={"output": output, "agent_id": subagent_type},
                 )
+            except CostLimitExceededError:
+                raise
             except Exception as exc:
                 logger.error(f"[AgentTool] Subagent execution failed: type={subagent_type}, error={exc}")
                 raise build_error(
@@ -351,6 +354,8 @@ class AgentTool(Tool):
                 session=parent_session,
                 source_label=f"subagent:custom:{subagent_type}",
             )
+        except CostLimitExceededError:
+            raise
         except Exception as exc:
             logger.error(
                 "[AgentTool] Async subagent '%s' failed: %s", subagent_type, exc

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -8120,11 +8120,13 @@ class JiuWenSwarmDeepAdapter:
             return "0"
 
     @staticmethod
-    def _format_cost_value(value: Any) -> str:
+    def _format_cost_value(value: Any, currency: Any = None) -> str:
         try:
-            return f"${float(value):.4f}"
+            amount = f"{float(value):.4f}"
         except (TypeError, ValueError):
-            return "$0.0000"
+            amount = "0.0000"
+        currency_text = str(currency or "").strip().upper()
+        return f"{amount} {currency_text}" if currency_text else amount
 
     def _format_usage_summary(self, summary: dict[str, Any]) -> str:
         lines = [
@@ -8132,10 +8134,14 @@ class JiuWenSwarmDeepAdapter:
             f"Output tokens: {self._format_count_value(summary.get('output_tokens'))}",
             f"Total tokens: {self._format_count_value(summary.get('total_tokens'))}",
         ]
-        if bool(summary.get("cost_available")):
-            lines.append(f"Total cost: {self._format_cost_value(summary.get('total_cost'))}")
+        if bool(summary.get("cost_feature_enabled")) and bool(summary.get("cost_available")):
+            currency = summary.get("currency")
+            lines.append(f"Cost source: {summary.get('cost_source') or 'provider_reported'}")
+            if currency:
+                lines.append(f"Currency: {currency}")
+            lines.append(f"Total cost: {self._format_cost_value(summary.get('total_cost'), currency)}")
             if summary.get("cost_limit") is not None:
-                lines.append(f"Cost limit: {self._format_cost_value(summary.get('cost_limit'))}")
+                lines.append(f"Cost limit: {self._format_cost_value(summary.get('cost_limit'), currency)}")
         return "\n".join(lines)
 
     def _handle_usage_slash_command(
@@ -8161,18 +8167,25 @@ class JiuWenSwarmDeepAdapter:
 
     def _format_limit_summary(self, summary: dict[str, Any]) -> str:
         limit = summary.get("cost_limit")
-        limit_text = "infinite" if limit is None else self._format_cost_value(limit)
+        currency = summary.get("currency")
+        limit_text = "infinite" if limit is None else self._format_cost_value(limit, currency)
         lines = [f"Cost limit: {limit_text}"]
+        if not bool(summary.get("cost_feature_enabled")):
+            lines.append("Cost visibility is disabled in config.yaml (usage_cost.enabled=false).")
+            return "\n".join(lines)
+        lines.append(f"Cost source: {summary.get('cost_source') or 'unavailable'}")
         if bool(summary.get("cost_available")):
             total = float(summary.get("total_cost", 0.0) or 0.0)
-            lines.append(f"Current cost: {self._format_cost_value(total)}")
+            if currency:
+                lines.append(f"Currency: {currency}")
+            lines.append(f"Current cost: {self._format_cost_value(total, currency)}")
             if limit is not None:
                 remaining = max(0.0, float(limit) - total)
-                lines.append(f"Remaining: {self._format_cost_value(remaining)}")
+                lines.append(f"Remaining: {self._format_cost_value(remaining, currency)}")
+            if not bool(summary.get("limit_enforcement_enabled")):
+                lines.append("Cost limit enforcement is disabled in config.yaml.")
         else:
             lines.append("Current cost: unavailable; provider has not returned cost metadata.")
-            if limit is not None:
-                lines.append("The limit will not be enforced until cost metadata is available.")
         return "\n".join(lines)
 
     def _handle_limit_slash_command(
@@ -8204,11 +8217,18 @@ class JiuWenSwarmDeepAdapter:
                 "output": self._format_limit_summary(summary),
             }
 
-        has_scope = args[0] in {"session", "task"}
+        usage_text = "Usage: /limit [cost <amount>|session cost <amount>|clear|session clear]"
+        has_scope = args[0] == "session"
         offset = 1 if has_scope else 0
-        scope = args[0] if has_scope else "session"
         command = args[offset] if len(args) > offset else ""
-        scope_label = "Current task/session" if scope == "task" else "Session"
+        if args[0] == "task":
+            return {
+                **result_base,
+                "result_type": "error",
+                "display_level": "error",
+                "error": "Task-scoped cost limits are not supported yet; use session scope.",
+                "output": "Task-scoped cost limits are not supported yet; use /limit session cost <amount>.",
+            }
 
         if command == "clear":
             summary = set_session_cost_limit(session_id, None)
@@ -8216,7 +8236,7 @@ class JiuWenSwarmDeepAdapter:
                 **result_base,
                 "result_type": "limit_updated",
                 "usage": summary,
-                "output": f"{scope_label} cost limit cleared (infinite).",
+                "output": "Session cost limit cleared (infinite).",
             }
 
         if command == "cost":
@@ -8231,26 +8251,34 @@ class JiuWenSwarmDeepAdapter:
                     **result_base,
                     "result_type": "error",
                     "display_level": "error",
-                    "error": "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
-                    "output": "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
+                    "error": usage_text,
+                    "output": usage_text,
                 }
-            summary = set_session_cost_limit(session_id, value)
-            suffix = ""
-            if not bool(summary.get("cost_available")):
-                suffix = " It will not be enforced until provider cost metadata is available."
+            try:
+                summary = set_session_cost_limit(session_id, value)
+            except ValueError as exc:
+                current = get_session_cost_summary(session_id)
+                return {
+                    **result_base,
+                    "result_type": "error",
+                    "display_level": "error",
+                    "usage": current,
+                    "error": str(exc),
+                    "output": str(exc),
+                }
             return {
                 **result_base,
                 "result_type": "limit_updated",
                 "usage": summary,
-                "output": f"{scope_label} cost limit set to {self._format_cost_value(value)}.{suffix}",
+                "output": f"Session cost limit set to {self._format_cost_value(value, summary.get('currency'))}.",
             }
 
         return {
             **result_base,
             "result_type": "error",
             "display_level": "error",
-            "error": "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
-            "output": "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
+            "error": usage_text,
+            "output": usage_text,
         }
 
     # Goal capability adapter -------------------------------------------------
@@ -9377,6 +9405,13 @@ class JiuWenSwarmDeepAdapter:
         # deltas plus the terminal chat.final — see ``_assemble_run_answer``.
         run_answer_deltas: list[str] = []
         run_answer_final = ""
+        try:
+            from jiuwenswarm.server.runtime.usage_cost import get_usage_cost_settings
+
+            usage_cost_settings = get_usage_cost_settings(self._config_cache)
+        except Exception:
+            logger.debug("[JiuWenSwarmDeepAdapter] failed to load usage cost settings", exc_info=True)
+            usage_cost_settings = {"enabled": False, "enforce_limits": False}
 
         def _accumulate_usage_metadata(
             usage_meta: dict[str, Any],
@@ -9409,16 +9444,17 @@ class JiuWenSwarmDeepAdapter:
             def _cost_value(name: str) -> float | None:
                 return _number_value(name)
 
-            input_cost = _cost_value("input_cost") or 0.0
-            output_cost = _cost_value("output_cost") or 0.0
-            total_cost = _cost_value("total_cost")
-            if any(_cost_value(name) is not None for name in ("input_cost", "output_cost", "total_cost")):
-                usage_accumulator["cost_available"] = True
-            usage_accumulator["input_cost"] += input_cost
-            usage_accumulator["output_cost"] += output_cost
-            usage_accumulator["total_cost"] += (
-                total_cost if total_cost is not None else input_cost + output_cost
-            ) or 0.0
+            if bool(usage_cost_settings.get("enabled")):
+                input_cost = _cost_value("input_cost") or 0.0
+                output_cost = _cost_value("output_cost") or 0.0
+                total_cost = _cost_value("total_cost")
+                if any(_cost_value(name) is not None for name in ("input_cost", "output_cost", "total_cost")):
+                    usage_accumulator["cost_available"] = True
+                usage_accumulator["input_cost"] += input_cost
+                usage_accumulator["output_cost"] += output_cost
+                usage_accumulator["total_cost"] += (
+                    total_cost if total_cost is not None else input_cost + output_cost
+                ) or 0.0
             try:
                 from jiuwenswarm.server.runtime.usage_cost import add_session_usage
 
@@ -9525,12 +9561,13 @@ class JiuWenSwarmDeepAdapter:
             )
             if self._stream_event_rail is not None:
                 self._stream_event_rail.reset_abort(session_id)
-            try:
-                from jiuwenswarm.server.runtime.usage_cost import set_subagent_usage_sink
+            if bool(usage_cost_settings.get("enabled")):
+                try:
+                    from jiuwenswarm.server.runtime.usage_cost import set_subagent_usage_sink
 
-                usage_sink_token = set_subagent_usage_sink(_accumulate_usage_metadata)
-            except Exception:
-                logger.debug("[JiuWenSwarmDeepAdapter] failed to install usage sink", exc_info=True)
+                    usage_sink_token = set_subagent_usage_sink(_accumulate_usage_metadata)
+                except Exception:
+                    logger.debug("[JiuWenSwarmDeepAdapter] failed to install usage sink", exc_info=True)
             inputs = dict(inputs)
             inputs = self._prepare_multimodal_image_inputs(
                 request,
@@ -9937,6 +9974,7 @@ class JiuWenSwarmDeepAdapter:
                         is_complete=False,
                     )
                     if cost_limit_exceeded_summary is not None:
+                        currency = cost_limit_exceeded_summary.get("currency")
                         yield AgentResponseChunk(
                             request_id=rid,
                             channel_id=cid,
@@ -9944,8 +9982,8 @@ class JiuWenSwarmDeepAdapter:
                                 "event_type": "chat.error",
                                 "error": (
                                     "Cost limit exceeded: "
-                                    f"${float(cost_limit_exceeded_summary.get('total_cost', 0.0)):.4f} > "
-                                    f"${float(cost_limit_exceeded_summary.get('cost_limit', 0.0)):.4f}."
+                                    f"{self._format_cost_value(cost_limit_exceeded_summary.get('total_cost'), currency)} > "
+                                    f"{self._format_cost_value(cost_limit_exceeded_summary.get('cost_limit'), currency)}."
                                 ),
                                 "error_type": "CostLimitExceeded",
                                 "usage": cost_limit_exceeded_summary,
@@ -10300,6 +10338,10 @@ class JiuWenSwarmDeepAdapter:
             summary["input_cost"] = round(usage_accumulator["input_cost"], 6)
             summary["output_cost"] = round(usage_accumulator["output_cost"], 6)
             summary["total_cost"] = round(usage_accumulator["total_cost"], 6)
+            summary["cost_source"] = "provider_reported"
+            currency = usage_cost_settings.get("currency")
+            if currency:
+                summary["currency"] = currency
 
         logger.info(
             "[JiuWenSwarmDeepAdapter] llm_usage summary: request_id=%s session_id=%s usage=%s",

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -213,6 +213,7 @@ from jiuwenswarm.server.runtime.session.session_history import append_history_re
 # 时间戳与 live「答完再入列」对齐。按 session 暂存，跨同 session 的并发 stream 共享。
 _pending_goal_objective_history: dict[str, dict[str, Any]] = {}
 from jiuwenswarm.server.runtime.skill.skill_manager import SkillManager
+from jiuwenswarm.server.runtime.usage_cost import CostLimitExceededError
 from jiuwenswarm.server.runtime.agent_adapter.evolution_helpers import (
     EVOLUTION_ACCEPT_LABELS,
     EVOLUTION_EXECUTE_LABELS,
@@ -8081,6 +8082,14 @@ class JiuWenSwarmDeepAdapter:
 
         stripped = query.strip()
 
+        usage_result = self._handle_usage_slash_command(stripped, session_id)
+        if usage_result is not None:
+            return usage_result
+
+        limit_result = self._handle_limit_slash_command(stripped, session_id)
+        if limit_result is not None:
+            return limit_result
+
         slash_result = await handle_evolution_slash_command(
             stripped,
             EvolutionSlashContext(
@@ -8101,6 +8110,147 @@ class JiuWenSwarmDeepAdapter:
             )
 
         return None
+
+    @staticmethod
+    def _format_count_value(value: Any) -> str:
+        try:
+            return f"{int(value):,}"
+        except (TypeError, ValueError):
+            return "0"
+
+    @staticmethod
+    def _format_cost_value(value: Any) -> str:
+        try:
+            return f"${float(value):.4f}"
+        except (TypeError, ValueError):
+            return "$0.0000"
+
+    def _format_usage_summary(self, summary: dict[str, Any]) -> str:
+        lines = [
+            f"Input tokens: {self._format_count_value(summary.get('input_tokens'))}",
+            f"Output tokens: {self._format_count_value(summary.get('output_tokens'))}",
+            f"Total tokens: {self._format_count_value(summary.get('total_tokens'))}",
+        ]
+        if bool(summary.get("cost_available")):
+            lines.append(f"Total cost: {self._format_cost_value(summary.get('total_cost'))}")
+            if summary.get("cost_limit") is not None:
+                lines.append(f"Cost limit: {self._format_cost_value(summary.get('cost_limit'))}")
+        return "\n".join(lines)
+
+    def _handle_usage_slash_command(
+        self,
+        query: str,
+        session_id: str = "default",
+    ) -> dict[str, Any] | None:
+        text = query.strip()
+        if text != "/usage":
+            return None
+
+        from jiuwenswarm.server.runtime.usage_cost import get_session_cost_summary
+
+        summary = get_session_cost_summary(session_id)
+        return {
+            "result_type": "usage_status",
+            "source": "slash_command",
+            "slash_command": "usage",
+            "display_level": "info",
+            "usage": summary,
+            "output": self._format_usage_summary(summary),
+        }
+
+    def _format_limit_summary(self, summary: dict[str, Any]) -> str:
+        limit = summary.get("cost_limit")
+        limit_text = "infinite" if limit is None else self._format_cost_value(limit)
+        lines = [f"Cost limit: {limit_text}"]
+        if bool(summary.get("cost_available")):
+            total = float(summary.get("total_cost", 0.0) or 0.0)
+            lines.append(f"Current cost: {self._format_cost_value(total)}")
+            if limit is not None:
+                remaining = max(0.0, float(limit) - total)
+                lines.append(f"Remaining: {self._format_cost_value(remaining)}")
+        else:
+            lines.append("Current cost: unavailable; provider has not returned cost metadata.")
+            if limit is not None:
+                lines.append("The limit will not be enforced until cost metadata is available.")
+        return "\n".join(lines)
+
+    def _handle_limit_slash_command(
+        self,
+        query: str,
+        session_id: str = "default",
+    ) -> dict[str, Any] | None:
+        text = query.strip()
+        if text != "/limit" and not text.startswith("/limit "):
+            return None
+
+        from jiuwenswarm.server.runtime.usage_cost import (
+            get_session_cost_summary,
+            set_session_cost_limit,
+        )
+
+        args = text[6:].strip().split()
+        result_base = {
+            "source": "slash_command",
+            "slash_command": "limit",
+            "display_level": "info",
+        }
+        if not args:
+            summary = get_session_cost_summary(session_id)
+            return {
+                **result_base,
+                "result_type": "limit_status",
+                "usage": summary,
+                "output": self._format_limit_summary(summary),
+            }
+
+        has_scope = args[0] in {"session", "task"}
+        offset = 1 if has_scope else 0
+        scope = args[0] if has_scope else "session"
+        command = args[offset] if len(args) > offset else ""
+        scope_label = "Current task/session" if scope == "task" else "Session"
+
+        if command == "clear":
+            summary = set_session_cost_limit(session_id, None)
+            return {
+                **result_base,
+                "result_type": "limit_updated",
+                "usage": summary,
+                "output": f"{scope_label} cost limit cleared (infinite).",
+            }
+
+        if command == "cost":
+            raw_value = args[offset + 1] if len(args) > offset + 1 else ""
+            normalized = raw_value.strip().removeprefix("$")
+            try:
+                value = float(normalized)
+            except ValueError:
+                value = -1.0
+            if value < 0:
+                return {
+                    **result_base,
+                    "result_type": "error",
+                    "display_level": "error",
+                    "error": "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
+                    "output": "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
+                }
+            summary = set_session_cost_limit(session_id, value)
+            suffix = ""
+            if not bool(summary.get("cost_available")):
+                suffix = " It will not be enforced until provider cost metadata is available."
+            return {
+                **result_base,
+                "result_type": "limit_updated",
+                "usage": summary,
+                "output": f"{scope_label} cost limit set to {self._format_cost_value(value)}.{suffix}",
+            }
+
+        return {
+            **result_base,
+            "result_type": "error",
+            "display_level": "error",
+            "error": "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
+            "output": "Usage: /limit [cost <amount>|session cost <amount>|task cost <amount>|clear]",
+        }
 
     # Goal capability adapter -------------------------------------------------
 
@@ -9217,12 +9367,71 @@ class JiuWenSwarmDeepAdapter:
             "input_cost": 0.0,
             "output_cost": 0.0,
             "total_cost": 0.0,
+            "cost_available": False,
         }
+        usage_sink_token = None
+        cost_limit_exceeded_summary: dict[str, Any] | None = None
         emitted_ask_user_request_ids: set[str] = set()
         # The run's final answer for the OTel trace output, kept as the streamed
         # deltas plus the terminal chat.final — see ``_assemble_run_answer``.
         run_answer_deltas: list[str] = []
         run_answer_final = ""
+
+        def _accumulate_usage_metadata(
+            usage_meta: dict[str, Any],
+            source: str | None = None,
+        ) -> dict[str, Any] | None:
+            nonlocal cost_limit_exceeded_summary
+            if not isinstance(usage_meta, dict):
+                return None
+
+            def _number_value(name: str) -> float | None:
+                value = usage_meta.get(name)
+                if isinstance(value, bool):
+                    return None
+                if isinstance(value, (int, float)):
+                    return max(0.0, float(value))
+                return None
+
+            input_tokens = int(_number_value("input_tokens") or 0)
+            output_tokens = int(_number_value("output_tokens") or 0)
+            total_tokens_raw = _number_value("total_tokens")
+            total_tokens = int(total_tokens_raw if total_tokens_raw is not None else input_tokens + output_tokens)
+            usage_accumulator["input_tokens"] += input_tokens
+            usage_accumulator["output_tokens"] += output_tokens
+            usage_accumulator["total_tokens"] += total_tokens
+            # cache_tokens is provider-served prompt cache hits; develop tracks it
+            # apart from input/output and surfaces a hit rate in the usage summary.
+            cache_tokens = int(_number_value("cache_tokens") or 0)
+            usage_accumulator["cache_tokens"] += cache_tokens
+
+            def _cost_value(name: str) -> float | None:
+                return _number_value(name)
+
+            input_cost = _cost_value("input_cost") or 0.0
+            output_cost = _cost_value("output_cost") or 0.0
+            total_cost = _cost_value("total_cost")
+            if any(_cost_value(name) is not None for name in ("input_cost", "output_cost", "total_cost")):
+                usage_accumulator["cost_available"] = True
+            usage_accumulator["input_cost"] += input_cost
+            usage_accumulator["output_cost"] += output_cost
+            usage_accumulator["total_cost"] += (
+                total_cost if total_cost is not None else input_cost + output_cost
+            ) or 0.0
+            try:
+                from jiuwenswarm.server.runtime.usage_cost import add_session_usage
+
+                session_cost = add_session_usage(session_id, usage_meta)
+                if session_cost.get("cost_limit_exceeded"):
+                    cost_limit_exceeded_summary = session_cost
+                    if source != "main":
+                        raise CostLimitExceededError(session_cost)
+                return session_cost
+            except CostLimitExceededError:
+                raise
+            except Exception:
+                logger.debug("[JiuWenSwarmDeepAdapter] failed to record session cost", exc_info=True)
+            return None
 
         def should_skip_duplicate_ask_user(parsed: dict | None) -> bool:
             if not isinstance(parsed, dict):
@@ -9315,6 +9524,12 @@ class JiuWenSwarmDeepAdapter:
             )
             if self._stream_event_rail is not None:
                 self._stream_event_rail.reset_abort(session_id)
+            try:
+                from jiuwenswarm.server.runtime.usage_cost import set_subagent_usage_sink
+
+                usage_sink_token = set_subagent_usage_sink(_accumulate_usage_metadata)
+            except Exception:
+                logger.debug("[JiuWenSwarmDeepAdapter] failed to install usage sink", exc_info=True)
             inputs = dict(inputs)
             inputs = self._prepare_multimodal_image_inputs(
                 request,
@@ -9709,15 +9924,7 @@ class JiuWenSwarmDeepAdapter:
                         else {}
                     )
                     if isinstance(usage_meta, dict):
-                        for token in (
-                            "input_tokens",
-                            "output_tokens",
-                            "total_tokens",
-                            "cache_tokens",
-                        ):
-                            usage_accumulator[token] += usage_meta.get(token, 0) or 0
-                        for cost in ("input_cost", "output_cost", "total_cost"):
-                            usage_accumulator[cost] += usage_meta.get(cost, 0.0) or 0.0
+                        _accumulate_usage_metadata(usage_meta, "main")
                     yield AgentResponseChunk(
                         request_id=rid,
                         channel_id=cid,
@@ -9728,6 +9935,28 @@ class JiuWenSwarmDeepAdapter:
                         },
                         is_complete=False,
                     )
+                    if cost_limit_exceeded_summary is not None:
+                        yield AgentResponseChunk(
+                            request_id=rid,
+                            channel_id=cid,
+                            payload={
+                                "event_type": "chat.error",
+                                "error": (
+                                    "Cost limit exceeded: "
+                                    f"${float(cost_limit_exceeded_summary.get('total_cost', 0.0)):.4f} > "
+                                    f"${float(cost_limit_exceeded_summary.get('cost_limit', 0.0)):.4f}."
+                                ),
+                                "error_type": "CostLimitExceeded",
+                                "usage": cost_limit_exceeded_summary,
+                            },
+                            is_complete=False,
+                        )
+                        try:
+                            if self._instance is not None:
+                                await self._instance.abort()
+                        except Exception:
+                            logger.debug("[JiuWenSwarmDeepAdapter] cost-limit abort failed", exc_info=True)
+                        break
                     continue
 
                 if chunk_type == "llm_reasoning":
@@ -9963,6 +10192,32 @@ class JiuWenSwarmDeepAdapter:
             if _debug_logger is not None:
                 _debug_logger.end_run(status="cancelled")
             raise
+        except CostLimitExceededError as exc:
+            cost_limit_exceeded_summary = exc.summary
+            logger.info(
+                "[JiuWenSwarmDeepAdapter] cost limit exceeded: request_id=%s session_id=%s usage=%s",
+                rid,
+                session_id,
+                cost_limit_exceeded_summary,
+            )
+            if _debug_logger is not None:
+                _debug_logger.end_run(status="cancelled")
+            yield AgentResponseChunk(
+                request_id=rid,
+                channel_id=cid,
+                payload={
+                    "event_type": "chat.error",
+                    "error": str(exc),
+                    "error_type": "CostLimitExceeded",
+                    "usage": cost_limit_exceeded_summary,
+                },
+                is_complete=False,
+            )
+            try:
+                if self._instance is not None:
+                    await self._instance.abort()
+            except Exception:
+                logger.debug("[JiuWenSwarmDeepAdapter] cost-limit abort failed", exc_info=True)
         except Exception as exc:
             logger.exception("[JiuWenSwarmDeepAdapter] 流式任务异常: %s", exc)
             if _debug_logger is not None:
@@ -10002,6 +10257,13 @@ class JiuWenSwarmDeepAdapter:
                 )
 
                 reset_current_multimodal_image_files(image_files_token)
+            if usage_sink_token is not None:
+                try:
+                    from jiuwenswarm.server.runtime.usage_cost import reset_subagent_usage_sink
+
+                    reset_subagent_usage_sink(usage_sink_token)
+                except Exception:
+                    logger.debug("[JiuWenSwarmDeepAdapter] failed to reset usage sink", exc_info=True)
             if interaction_stream is not None:
                 try:
                     await interaction_stream.close(
@@ -10033,11 +10295,9 @@ class JiuWenSwarmDeepAdapter:
             cache_tokens = usage_accumulator["cache_tokens"]
             summary["cache_tokens"] = cache_tokens
             summary["cache_hit_rate"] = f"{cache_tokens / input_tokens:.1%}"
-        if usage_accumulator["input_cost"] > 0:
+        if usage_accumulator["cost_available"]:
             summary["input_cost"] = round(usage_accumulator["input_cost"], 6)
-        if usage_accumulator["output_cost"] > 0:
             summary["output_cost"] = round(usage_accumulator["output_cost"], 6)
-        if usage_accumulator["total_cost"] > 0:
             summary["total_cost"] = round(usage_accumulator["total_cost"], 6)
 
         logger.info(
@@ -10082,7 +10342,7 @@ class JiuWenSwarmDeepAdapter:
             except Exception:
                 logger.debug("[JiuWenSwarmDeepAdapter] ContextUtils.resolve_context_max fallback failed", exc_info=True)
 
-        if usage_accumulator["total_tokens"] > 0:
+        if usage_accumulator["total_tokens"] > 0 or usage_accumulator["cost_available"]:
             payload: dict[str, Any] = {
                 "event_type": "chat.usage_summary",
                 "session_id": session_id,

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -10000,8 +10000,16 @@ class JiuWenSwarmDeepAdapter:
                                 "event_type": "chat.error",
                                 "error": (
                                     "Cost limit exceeded: "
-                                    f"{self._format_cost_value(cost_limit_exceeded_summary.get('total_cost'), currency)} > "
-                                    f"{self._format_cost_value(cost_limit_exceeded_summary.get('cost_limit'), currency)}."
+                                    + self._format_cost_value(
+                                        cost_limit_exceeded_summary.get("total_cost"),
+                                        currency,
+                                    )
+                                    + " > "
+                                    + self._format_cost_value(
+                                        cost_limit_exceeded_summary.get("cost_limit"),
+                                        currency,
+                                    )
+                                    + "."
                                 ),
                                 "error_type": "CostLimitExceeded",
                                 "usage": cost_limit_exceeded_summary,

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -13,6 +13,7 @@ import copy
 import hashlib
 import json
 import logging
+import math
 import os
 import platform
 import re
@@ -8225,7 +8226,7 @@ class JiuWenSwarmDeepAdapter:
                 value = float(normalized)
             except ValueError:
                 value = -1.0
-            if value < 0:
+            if not math.isfinite(value) or value < 0:
                 return {
                     **result_base,
                     "result_type": "error",

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -214,7 +214,7 @@ from jiuwenswarm.server.runtime.session.session_history import append_history_re
 # 时间戳与 live「答完再入列」对齐。按 session 暂存，跨同 session 的并发 stream 共享。
 _pending_goal_objective_history: dict[str, dict[str, Any]] = {}
 from jiuwenswarm.server.runtime.skill.skill_manager import SkillManager
-from jiuwenswarm.server.runtime.usage_cost import CostLimitExceededError
+from jiuwenswarm.server.runtime.usage_cost import CostLimitExceededError, raise_if_session_cost_limit_exceeded
 from jiuwenswarm.server.runtime.agent_adapter.evolution_helpers import (
     EVOLUTION_ACCEPT_LABELS,
     EVOLUTION_EXECUTE_LABELS,
@@ -9378,6 +9378,24 @@ class JiuWenSwarmDeepAdapter:
                         is_complete=True,
                     )
                 return
+
+        try:
+            raise_if_session_cost_limit_exceeded(session_id)
+        except CostLimitExceededError as exc:
+            yield AgentResponseChunk(
+                request_id=request.request_id,
+                channel_id=request.channel_id,
+                payload={
+                    "event_type": "chat.error",
+                    "error": str(exc),
+                    "error_type": "CostLimitExceeded",
+                    "usage": exc.summary,
+                },
+                is_complete=True,
+            )
+            return
+        except Exception:
+            logger.debug("[JiuWenSwarmDeepAdapter] cost-limit preflight failed", exc_info=True)
 
         has_streamed_content = False
         accumulated_text = ""

--- a/jiuwenswarm/server/runtime/debug_trace/subagent_capture.py
+++ b/jiuwenswarm/server/runtime/debug_trace/subagent_capture.py
@@ -59,6 +59,7 @@ async def invoke_subagent_with_trace(
         get_debug_trace_logger,
         get_debug_trace_logger_for_session,
     )
+    from jiuwenswarm.server.runtime.usage_cost import get_subagent_usage_sink
 
     dbg = get_debug_trace_logger()
     if dbg is None:
@@ -68,13 +69,16 @@ async def invoke_subagent_with_trace(
         sid = session.get_session_id() if hasattr(session, "get_session_id") else None
         if sid:
             dbg = get_debug_trace_logger_for_session(sid)
-    if dbg is None or not dbg.captures_subagent_flow():
-        # No debug run, or capture disabled — original path, unchanged.
+    usage_sink = get_subagent_usage_sink()
+    captures_debug = dbg is not None and dbg.captures_subagent_flow()
+    if not captures_debug and usage_sink is None:
+        # No debug run and no parent usage sink — original path, unchanged.
         return await subagent.invoke(inputs, session=session)
 
     output_parts: list[str] = []
     result: dict | None = None
-    dbg.begin_subagent(source=source_label, prompt=inputs.get("query", "") or "")
+    if captures_debug:
+        dbg.begin_subagent(source=source_label, prompt=inputs.get("query", "") or "")
     try:
         # Drain the subagent's stream from an ISOLATED session (session=None ->
         # ReActAgent.stream auto-creates one from inputs.conversation_id). Passing
@@ -85,16 +89,34 @@ async def invoke_subagent_with_trace(
         # The isolated session is drained only by this loop, so tagging is clean
         # and nothing leaks into the parent (TUI) stream.
         async for chunk in subagent.stream(inputs, session=None):
-            dbg.feed_subagent(source=source_label, chunk=chunk)
+            if captures_debug:
+                dbg.feed_subagent(source=source_label, chunk=chunk)
+            if usage_sink is not None:
+                usage_meta = _usage_metadata_from_chunk(chunk)
+                if usage_meta is not None:
+                    usage_sink(usage_meta, source_label)
             reduced = _reduce_stream_chunk(chunk, output_parts)
             if reduced is not None:
                 result = reduced
     finally:
-        dbg.end_subagent(source=source_label)
+        if captures_debug:
+            dbg.end_subagent(source=source_label)
 
     if result is None:
         result = {"output": "".join(output_parts), "result_type": "answer"}
     return result
+
+
+def _usage_metadata_from_chunk(chunk: Any) -> dict | None:
+    chunk_type = getattr(chunk, "type", None)
+    payload = getattr(chunk, "payload", None)
+    if isinstance(chunk, dict):
+        chunk_type = chunk.get("type", chunk_type)
+        payload = chunk.get("payload", payload)
+    if chunk_type != "llm_usage" or not isinstance(payload, dict):
+        return None
+    usage = payload.get("usage_metadata")
+    return usage if isinstance(usage, dict) else None
 
 
 def _reduce_stream_chunk(chunk: Any, output_parts: list[str]) -> dict | None:

--- a/jiuwenswarm/server/runtime/debug_trace/task_tool_patch.py
+++ b/jiuwenswarm/server/runtime/debug_trace/task_tool_patch.py
@@ -69,8 +69,12 @@ def apply_task_tool_debug_patch() -> None:
         from jiuwenswarm.server.runtime.debug_trace.context import (
             get_debug_trace_logger_for_session,
         )
+        from jiuwenswarm.server.runtime.usage_cost import (
+            CostLimitExceededError,
+            get_subagent_usage_sink,
+        )
 
-        # Not capturing -> pristine original SDK path, unchanged.
+        # Not capturing and no parent usage sink -> pristine original SDK path, unchanged.
         dbg = get_debug_trace_logger()
         if dbg is None:
             # TaskTool.invoke runs in the DeepAgent's supervisor task (created at
@@ -85,7 +89,7 @@ def apply_task_tool_debug_patch() -> None:
                         "[TaskTool] (debug) recovered trace logger via session "
                         "registry: %s", parent_session.get_session_id(),
                     )
-        if dbg is None or not dbg.captures_subagent_flow():
+        if (dbg is None or not dbg.captures_subagent_flow()) and get_subagent_usage_sink() is None:
             return await _orig_invoke(self, inputs, **kwargs)
 
         parent_session = kwargs.get("session", None)
@@ -142,6 +146,8 @@ def apply_task_tool_debug_patch() -> None:
                 data={"output": output, "agent_id": subagent.card.id},
                 error=None,
             )
+        except CostLimitExceededError:
+            raise
         except Exception as exc:
             logger.error(
                 "[TaskTool] Subagent: %s execution failed, error=%s",

--- a/jiuwenswarm/server/runtime/session/session_manager.py
+++ b/jiuwenswarm/server/runtime/session/session_manager.py
@@ -132,6 +132,12 @@ class SessionManager:
             )
         )
 
+    @staticmethod
+    def _clear_session_cost(session_id: str) -> None:
+        from jiuwenswarm.server.runtime.usage_cost import clear_session_cost
+
+        clear_session_cost(session_id)
+
     async def close_session(
         self,
         session_id: str,
@@ -196,6 +202,7 @@ class SessionManager:
                     len(pending),
                 )
 
+        self._clear_session_cost(session_id)
         return had_runtime
 
     async def close_all_sessions(self) -> None:
@@ -281,6 +288,7 @@ class SessionManager:
                         self._session_tasks.pop(session_id, None)
                     if self._session_processors.get(session_id) is processor:
                         self._session_processors.pop(session_id, None)
+                    self._clear_session_cost(session_id)
                     logger.info(
                         "[SessionManager] Session 任务处理器已关闭: session_id=%s",
                         session_id,

--- a/jiuwenswarm/server/runtime/usage_cost.py
+++ b/jiuwenswarm/server/runtime/usage_cost.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextvars import ContextVar, Token
+import math
 from threading import Lock
 from typing import Any, Callable
 
@@ -123,5 +124,8 @@ def set_session_cost_limit(session_id: str | None, limit: float | None) -> dict[
         if limit is None:
             _SESSION_COST_LIMITS.pop(key, None)
         else:
-            _SESSION_COST_LIMITS[key] = max(0.0, float(limit))
+            value = float(limit)
+            if not math.isfinite(value):
+                raise ValueError("cost limit must be finite")
+            _SESSION_COST_LIMITS[key] = max(0.0, value)
     return get_session_cost_summary(key)

--- a/jiuwenswarm/server/runtime/usage_cost.py
+++ b/jiuwenswarm/server/runtime/usage_cost.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from threading import Lock
+from typing import Any, Callable
+
+
+UsageSink = Callable[[dict[str, Any], str | None], dict[str, Any] | None]
+
+_SUBAGENT_USAGE_SINK: ContextVar[UsageSink | None] = ContextVar(
+    "jiuwenswarm_subagent_usage_sink",
+    default=None,
+)
+_SESSION_COST_LOCK = Lock()
+_SESSION_COST_TOTALS: dict[str, dict[str, float | bool]] = {}
+_SESSION_COST_LIMITS: dict[str, float] = {}
+
+
+class CostLimitExceededError(RuntimeError):
+    def __init__(self, summary: dict[str, Any]):
+        self.summary = summary
+        total_cost = float(summary.get("total_cost", 0.0) or 0.0)
+        cost_limit = float(summary.get("cost_limit", 0.0) or 0.0)
+        super().__init__(f"Cost limit exceeded: ${total_cost:.4f} > ${cost_limit:.4f}.")
+
+
+def set_subagent_usage_sink(sink: UsageSink | None) -> Token[UsageSink | None]:
+    return _SUBAGENT_USAGE_SINK.set(sink)
+
+
+def reset_subagent_usage_sink(token: Token[UsageSink | None]) -> None:
+    _SUBAGENT_USAGE_SINK.reset(token)
+
+
+def get_subagent_usage_sink() -> UsageSink | None:
+    return _SUBAGENT_USAGE_SINK.get()
+
+
+def _session_key(session_id: str | None) -> str:
+    return (session_id or "default").strip() or "default"
+
+
+def _cost_value(usage: dict[str, Any], name: str) -> float | None:
+    value = usage.get(name)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return max(0.0, float(value))
+    return None
+
+
+def add_session_usage(session_id: str | None, usage: dict[str, Any]) -> dict[str, Any]:
+    """Accumulate provider cost metadata for a session and return the summary."""
+    key = _session_key(session_id)
+    input_tokens = _token_value(usage, "input_tokens") or 0.0
+    output_tokens = _token_value(usage, "output_tokens") or 0.0
+    total_tokens_raw = _token_value(usage, "total_tokens")
+    total_tokens = total_tokens_raw if total_tokens_raw is not None else input_tokens + output_tokens
+    input_cost_raw = _cost_value(usage, "input_cost")
+    output_cost_raw = _cost_value(usage, "output_cost")
+    total_cost_raw = _cost_value(usage, "total_cost")
+    cost_available = any(v is not None for v in (input_cost_raw, output_cost_raw, total_cost_raw))
+    input_cost = input_cost_raw or 0.0
+    output_cost = output_cost_raw or 0.0
+    total_cost = total_cost_raw if total_cost_raw is not None else input_cost + output_cost
+    with _SESSION_COST_LOCK:
+        current = _SESSION_COST_TOTALS.setdefault(
+            key,
+            {
+                "input_tokens": 0.0,
+                "output_tokens": 0.0,
+                "total_tokens": 0.0,
+                "input_cost": 0.0,
+                "output_cost": 0.0,
+                "total_cost": 0.0,
+                "cost_available": False,
+            },
+        )
+        current["input_tokens"] = float(current.get("input_tokens", 0.0)) + input_tokens
+        current["output_tokens"] = float(current.get("output_tokens", 0.0)) + output_tokens
+        current["total_tokens"] = float(current.get("total_tokens", 0.0)) + total_tokens
+        if cost_available:
+            current["cost_available"] = True
+            current["input_cost"] = float(current.get("input_cost", 0.0)) + input_cost
+            current["output_cost"] = float(current.get("output_cost", 0.0)) + output_cost
+            current["total_cost"] = float(current.get("total_cost", 0.0)) + total_cost
+    return get_session_cost_summary(key)
+
+
+def get_session_cost_summary(session_id: str | None) -> dict[str, Any]:
+    key = _session_key(session_id)
+    with _SESSION_COST_LOCK:
+        current = dict(_SESSION_COST_TOTALS.get(key) or {})
+        limit = _SESSION_COST_LIMITS.get(key)
+    cost_available = bool(current.get("cost_available"))
+    total_cost = float(current.get("total_cost", 0.0) or 0.0)
+    return {
+        "session_id": key,
+        "input_tokens": int(current.get("input_tokens", 0.0) or 0.0),
+        "output_tokens": int(current.get("output_tokens", 0.0) or 0.0),
+        "total_tokens": int(current.get("total_tokens", 0.0) or 0.0),
+        "cost_available": cost_available,
+        "input_cost": round(float(current.get("input_cost", 0.0) or 0.0), 6),
+        "output_cost": round(float(current.get("output_cost", 0.0) or 0.0), 6),
+        "total_cost": round(total_cost, 6),
+        "cost_limit": round(limit, 6) if limit is not None else None,
+        "cost_limit_exceeded": cost_available and limit is not None and total_cost > limit,
+    }
+
+
+def _token_value(usage: dict[str, Any], name: str) -> float | None:
+    value = usage.get(name)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return max(0.0, float(value))
+    return None
+
+
+def set_session_cost_limit(session_id: str | None, limit: float | None) -> dict[str, Any]:
+    key = _session_key(session_id)
+    with _SESSION_COST_LOCK:
+        if limit is None:
+            _SESSION_COST_LIMITS.pop(key, None)
+        else:
+            _SESSION_COST_LIMITS[key] = max(0.0, float(limit))
+    return get_session_cost_summary(key)

--- a/jiuwenswarm/server/runtime/usage_cost.py
+++ b/jiuwenswarm/server/runtime/usage_cost.py
@@ -17,12 +17,60 @@ _SESSION_COST_TOTALS: dict[str, dict[str, float | bool]] = {}
 _SESSION_COST_LIMITS: dict[str, float] = {}
 
 
+def _bool_value(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default
+
+
+def get_usage_cost_settings(config: dict[str, Any] | None = None) -> dict[str, Any]:
+    if config is None:
+        try:
+            from jiuwenswarm.common.config import get_config
+
+            config = get_config()
+        except Exception:
+            config = {}
+    raw = config.get("usage_cost", {}) if isinstance(config, dict) else {}
+    section = raw if isinstance(raw, dict) else {}
+    mode = str(section.get("mode") or "provider_reported").strip() or "provider_reported"
+    currency_raw = section.get("currency")
+    currency = str(currency_raw).strip().upper() if currency_raw is not None else ""
+    enabled = _bool_value(section.get("enabled"), False) and mode == "provider_reported"
+    enforce_limits = enabled and _bool_value(section.get("enforce_limits"), False)
+    unsupported = str(section.get("unsupported_provider_behavior") or "refuse_limit").strip().lower()
+    return {
+        "enabled": enabled,
+        "mode": mode,
+        "enforce_limits": enforce_limits,
+        "unsupported_provider_behavior": unsupported or "refuse_limit",
+        "currency": currency or None,
+    }
+
+
+def is_usage_cost_enabled(config: dict[str, Any] | None = None) -> bool:
+    return bool(get_usage_cost_settings(config).get("enabled"))
+
+
+def is_usage_cost_limit_enforcement_enabled(config: dict[str, Any] | None = None) -> bool:
+    return bool(get_usage_cost_settings(config).get("enforce_limits"))
+
+
 class CostLimitExceededError(RuntimeError):
     def __init__(self, summary: dict[str, Any]):
         self.summary = summary
         total_cost = float(summary.get("total_cost", 0.0) or 0.0)
         cost_limit = float(summary.get("cost_limit", 0.0) or 0.0)
-        super().__init__(f"Cost limit exceeded: ${total_cost:.4f} > ${cost_limit:.4f}.")
+        currency = str(summary.get("currency") or "").strip().upper()
+        total_text = f"{total_cost:.4f} {currency}" if currency else f"{total_cost:.4f}"
+        limit_text = f"{cost_limit:.4f} {currency}" if currency else f"{cost_limit:.4f}"
+        super().__init__(f"Cost limit exceeded: {total_text} > {limit_text}.")
 
 
 def set_subagent_usage_sink(sink: UsageSink | None) -> Token[UsageSink | None]:
@@ -53,6 +101,7 @@ def _cost_value(usage: dict[str, Any], name: str) -> float | None:
 def add_session_usage(session_id: str | None, usage: dict[str, Any]) -> dict[str, Any]:
     """Accumulate provider cost metadata for a session and return the summary."""
     key = _session_key(session_id)
+    settings = get_usage_cost_settings()
     input_tokens = _token_value(usage, "input_tokens") or 0.0
     output_tokens = _token_value(usage, "output_tokens") or 0.0
     total_tokens_raw = _token_value(usage, "total_tokens")
@@ -60,7 +109,9 @@ def add_session_usage(session_id: str | None, usage: dict[str, Any]) -> dict[str
     input_cost_raw = _cost_value(usage, "input_cost")
     output_cost_raw = _cost_value(usage, "output_cost")
     total_cost_raw = _cost_value(usage, "total_cost")
-    cost_available = any(v is not None for v in (input_cost_raw, output_cost_raw, total_cost_raw))
+    cost_available = bool(settings.get("enabled")) and any(
+        v is not None for v in (input_cost_raw, output_cost_raw, total_cost_raw)
+    )
     input_cost = input_cost_raw or 0.0
     output_cost = output_cost_raw or 0.0
     total_cost = total_cost_raw if total_cost_raw is not None else input_cost + output_cost
@@ -90,22 +141,30 @@ def add_session_usage(session_id: str | None, usage: dict[str, Any]) -> dict[str
 
 def get_session_cost_summary(session_id: str | None) -> dict[str, Any]:
     key = _session_key(session_id)
+    settings = get_usage_cost_settings()
     with _SESSION_COST_LOCK:
         current = dict(_SESSION_COST_TOTALS.get(key) or {})
         limit = _SESSION_COST_LIMITS.get(key)
-    cost_available = bool(current.get("cost_available"))
-    total_cost = float(current.get("total_cost", 0.0) or 0.0)
+    feature_enabled = bool(settings.get("enabled"))
+    cost_available = feature_enabled and bool(current.get("cost_available"))
+    total_cost = float(current.get("total_cost", 0.0) or 0.0) if cost_available else 0.0
+    enforcement_enabled = bool(settings.get("enforce_limits"))
     return {
         "session_id": key,
         "input_tokens": int(current.get("input_tokens", 0.0) or 0.0),
         "output_tokens": int(current.get("output_tokens", 0.0) or 0.0),
         "total_tokens": int(current.get("total_tokens", 0.0) or 0.0),
+        "cost_feature_enabled": feature_enabled,
         "cost_available": cost_available,
-        "input_cost": round(float(current.get("input_cost", 0.0) or 0.0), 6),
-        "output_cost": round(float(current.get("output_cost", 0.0) or 0.0), 6),
+        "cost_source": "provider_reported" if cost_available else "unavailable",
+        "currency": settings.get("currency"),
+        "input_cost": round(float(current.get("input_cost", 0.0) or 0.0), 6) if cost_available else 0.0,
+        "output_cost": round(float(current.get("output_cost", 0.0) or 0.0), 6) if cost_available else 0.0,
         "total_cost": round(total_cost, 6),
         "cost_limit": round(limit, 6) if limit is not None else None,
-        "cost_limit_exceeded": cost_available and limit is not None and total_cost > limit,
+        "limit_supported": cost_available and enforcement_enabled,
+        "limit_enforcement_enabled": enforcement_enabled,
+        "cost_limit_exceeded": cost_available and enforcement_enabled and limit is not None and total_cost > limit,
     }
 
 
@@ -128,10 +187,19 @@ def _token_value(usage: dict[str, Any], name: str) -> float | None:
 
 def set_session_cost_limit(session_id: str | None, limit: float | None) -> dict[str, Any]:
     key = _session_key(session_id)
+    summary = get_session_cost_summary(key)
     with _SESSION_COST_LOCK:
         if limit is None:
             _SESSION_COST_LIMITS.pop(key, None)
         else:
+            if not bool(summary.get("cost_feature_enabled")):
+                raise ValueError("usage cost is disabled")
+            if not bool(summary.get("limit_enforcement_enabled")):
+                raise ValueError("cost limit enforcement is disabled")
+            if not bool(summary.get("cost_available")):
+                raise ValueError(
+                    "cost limit unavailable: provider has not reported supported cost metadata"
+                )
             value = float(limit)
             if not math.isfinite(value):
                 raise ValueError("cost limit must be finite")

--- a/jiuwenswarm/server/runtime/usage_cost.py
+++ b/jiuwenswarm/server/runtime/usage_cost.py
@@ -168,6 +168,14 @@ def get_session_cost_summary(session_id: str | None) -> dict[str, Any]:
     }
 
 
+def raise_if_session_cost_limit_exceeded(session_id: str | None) -> dict[str, Any]:
+    """Return the current summary, or raise when the session is already over limit."""
+    summary = get_session_cost_summary(session_id)
+    if bool(summary.get("cost_limit_exceeded")):
+        raise CostLimitExceededError(summary)
+    return summary
+
+
 def clear_session_cost(session_id: str | None) -> None:
     """Clear accumulated cost totals and limits for a finished session."""
     key = _session_key(session_id)

--- a/jiuwenswarm/server/runtime/usage_cost.py
+++ b/jiuwenswarm/server/runtime/usage_cost.py
@@ -109,6 +109,14 @@ def get_session_cost_summary(session_id: str | None) -> dict[str, Any]:
     }
 
 
+def clear_session_cost(session_id: str | None) -> None:
+    """Clear accumulated cost totals and limits for a finished session."""
+    key = _session_key(session_id)
+    with _SESSION_COST_LOCK:
+        _SESSION_COST_TOTALS.pop(key, None)
+        _SESSION_COST_LIMITS.pop(key, None)
+
+
 def _token_value(usage: dict[str, Any], name: str) -> float | None:
     value = usage.get(name)
     if isinstance(value, bool):

--- a/tests/unit/agentserver/test_usage_cost.py
+++ b/tests/unit/agentserver/test_usage_cost.py
@@ -3,9 +3,11 @@ from uuid import uuid4
 import pytest
 
 from jiuwenswarm.server.runtime.usage_cost import (
+    CostLimitExceededError,
     add_session_usage,
     clear_session_cost,
     get_session_cost_summary,
+    raise_if_session_cost_limit_exceeded,
     set_session_cost_limit,
 )
 
@@ -68,6 +70,9 @@ def test_cost_totals_are_derived_from_input_and_output_cost() -> None:
     summary = set_session_cost_limit(session_id, 0.01)
     assert summary["cost_limit_exceeded"] is True
 
+    with pytest.raises(CostLimitExceededError):
+        raise_if_session_cost_limit_exceeded(session_id)
+
 
 def test_explicit_total_cost_takes_precedence_and_limit_can_clear() -> None:
     session_id = _sid()
@@ -87,6 +92,7 @@ def test_explicit_total_cost_takes_precedence_and_limit_can_clear() -> None:
     assert summary["total_cost"] == 0.75
 
     set_session_cost_limit(session_id, 1.0)
+    assert raise_if_session_cost_limit_exceeded(session_id)["cost_limit_exceeded"] is False
     cleared = set_session_cost_limit(session_id, None)
     assert cleared["cost_limit"] is None
     assert get_session_cost_summary(session_id)["cost_limit_exceeded"] is False

--- a/tests/unit/agentserver/test_usage_cost.py
+++ b/tests/unit/agentserver/test_usage_cost.py
@@ -4,6 +4,7 @@ import pytest
 
 from jiuwenswarm.server.runtime.usage_cost import (
     add_session_usage,
+    clear_session_cost,
     get_session_cost_summary,
     set_session_cost_limit,
 )
@@ -78,3 +79,18 @@ def test_cost_limit_rejects_non_finite_values() -> None:
     for value in ("inf", "nan"):
         with pytest.raises(ValueError):
             set_session_cost_limit(_sid(), float(value))
+
+
+def test_clear_session_cost_removes_totals_and_limit() -> None:
+    session_id = _sid()
+
+    set_session_cost_limit(session_id, 0.01)
+    add_session_usage(session_id, {"input_tokens": 1, "total_cost": 0.02})
+
+    clear_session_cost(session_id)
+    summary = get_session_cost_summary(session_id)
+
+    assert summary["input_tokens"] == 0
+    assert summary["total_cost"] == 0.0
+    assert summary["cost_limit"] is None
+    assert summary["cost_available"] is False

--- a/tests/unit/agentserver/test_usage_cost.py
+++ b/tests/unit/agentserver/test_usage_cost.py
@@ -14,10 +14,26 @@ def _sid() -> str:
     return f"usage-cost-test-{uuid4().hex}"
 
 
-def test_cost_limit_is_ignored_until_provider_cost_metadata_exists() -> None:
+@pytest.fixture(autouse=True)
+def _enable_usage_cost(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config",
+        lambda: {
+            "usage_cost": {
+                "enabled": True,
+                "mode": "provider_reported",
+                "enforce_limits": True,
+                "unsupported_provider_behavior": "refuse_limit",
+                "currency": "USD",
+            }
+        },
+        raising=False,
+    )
+
+
+def test_cost_limit_is_refused_until_provider_cost_metadata_exists() -> None:
     session_id = _sid()
 
-    set_session_cost_limit(session_id, 0.01)
     summary = add_session_usage(
         session_id,
         {"input_tokens": 10, "output_tokens": 5},
@@ -27,14 +43,14 @@ def test_cost_limit_is_ignored_until_provider_cost_metadata_exists() -> None:
     assert summary["output_tokens"] == 5
     assert summary["total_tokens"] == 15
     assert summary["cost_available"] is False
-    assert summary["cost_limit"] == 0.01
     assert summary["cost_limit_exceeded"] is False
+    with pytest.raises(ValueError, match="provider has not reported"):
+        set_session_cost_limit(session_id, 0.01)
 
 
 def test_cost_totals_are_derived_from_input_and_output_cost() -> None:
     session_id = _sid()
 
-    set_session_cost_limit(session_id, 0.01)
     summary = add_session_usage(
         session_id,
         {
@@ -49,13 +65,13 @@ def test_cost_totals_are_derived_from_input_and_output_cost() -> None:
     assert summary["input_cost"] == 0.006
     assert summary["output_cost"] == 0.006
     assert summary["total_cost"] == 0.012
+    summary = set_session_cost_limit(session_id, 0.01)
     assert summary["cost_limit_exceeded"] is True
 
 
 def test_explicit_total_cost_takes_precedence_and_limit_can_clear() -> None:
     session_id = _sid()
 
-    set_session_cost_limit(session_id, 1.0)
     summary = add_session_usage(
         session_id,
         {
@@ -70,6 +86,7 @@ def test_explicit_total_cost_takes_precedence_and_limit_can_clear() -> None:
     assert summary["total_tokens"] == 9
     assert summary["total_cost"] == 0.75
 
+    set_session_cost_limit(session_id, 1.0)
     cleared = set_session_cost_limit(session_id, None)
     assert cleared["cost_limit"] is None
     assert get_session_cost_summary(session_id)["cost_limit_exceeded"] is False
@@ -77,15 +94,17 @@ def test_explicit_total_cost_takes_precedence_and_limit_can_clear() -> None:
 
 def test_cost_limit_rejects_non_finite_values() -> None:
     for value in ("inf", "nan"):
+        session_id = _sid()
+        add_session_usage(session_id, {"total_cost": 0.01})
         with pytest.raises(ValueError):
-            set_session_cost_limit(_sid(), float(value))
+            set_session_cost_limit(session_id, float(value))
 
 
 def test_clear_session_cost_removes_totals_and_limit() -> None:
     session_id = _sid()
 
-    set_session_cost_limit(session_id, 0.01)
     add_session_usage(session_id, {"input_tokens": 1, "total_cost": 0.02})
+    set_session_cost_limit(session_id, 0.01)
 
     clear_session_cost(session_id)
     summary = get_session_cost_summary(session_id)
@@ -94,3 +113,21 @@ def test_clear_session_cost_removes_totals_and_limit() -> None:
     assert summary["total_cost"] == 0.0
     assert summary["cost_limit"] is None
     assert summary["cost_available"] is False
+
+
+def test_cost_feature_disabled_hides_provider_cost_and_refuses_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config",
+        lambda: {"usage_cost": {"enabled": False}},
+    )
+    session_id = _sid()
+
+    summary = add_session_usage(session_id, {"input_tokens": 1, "total_cost": 0.02})
+
+    assert summary["cost_feature_enabled"] is False
+    assert summary["cost_available"] is False
+    assert summary["total_cost"] == 0.0
+    with pytest.raises(ValueError, match="disabled"):
+        set_session_cost_limit(session_id, 0.01)

--- a/tests/unit/agentserver/test_usage_cost.py
+++ b/tests/unit/agentserver/test_usage_cost.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+import pytest
+
 from jiuwenswarm.server.runtime.usage_cost import (
     add_session_usage,
     get_session_cost_summary,
@@ -70,3 +72,9 @@ def test_explicit_total_cost_takes_precedence_and_limit_can_clear() -> None:
     cleared = set_session_cost_limit(session_id, None)
     assert cleared["cost_limit"] is None
     assert get_session_cost_summary(session_id)["cost_limit_exceeded"] is False
+
+
+def test_cost_limit_rejects_non_finite_values() -> None:
+    for value in ("inf", "nan"):
+        with pytest.raises(ValueError):
+            set_session_cost_limit(_sid(), float(value))

--- a/tests/unit/agentserver/test_usage_cost.py
+++ b/tests/unit/agentserver/test_usage_cost.py
@@ -1,0 +1,72 @@
+from uuid import uuid4
+
+from jiuwenswarm.server.runtime.usage_cost import (
+    add_session_usage,
+    get_session_cost_summary,
+    set_session_cost_limit,
+)
+
+
+def _sid() -> str:
+    return f"usage-cost-test-{uuid4().hex}"
+
+
+def test_cost_limit_is_ignored_until_provider_cost_metadata_exists() -> None:
+    session_id = _sid()
+
+    set_session_cost_limit(session_id, 0.01)
+    summary = add_session_usage(
+        session_id,
+        {"input_tokens": 10, "output_tokens": 5},
+    )
+
+    assert summary["input_tokens"] == 10
+    assert summary["output_tokens"] == 5
+    assert summary["total_tokens"] == 15
+    assert summary["cost_available"] is False
+    assert summary["cost_limit"] == 0.01
+    assert summary["cost_limit_exceeded"] is False
+
+
+def test_cost_totals_are_derived_from_input_and_output_cost() -> None:
+    session_id = _sid()
+
+    set_session_cost_limit(session_id, 0.01)
+    summary = add_session_usage(
+        session_id,
+        {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "input_cost": 0.006,
+            "output_cost": 0.006,
+        },
+    )
+
+    assert summary["cost_available"] is True
+    assert summary["input_cost"] == 0.006
+    assert summary["output_cost"] == 0.006
+    assert summary["total_cost"] == 0.012
+    assert summary["cost_limit_exceeded"] is True
+
+
+def test_explicit_total_cost_takes_precedence_and_limit_can_clear() -> None:
+    session_id = _sid()
+
+    set_session_cost_limit(session_id, 1.0)
+    summary = add_session_usage(
+        session_id,
+        {
+            "input_tokens": 3,
+            "output_tokens": 4,
+            "total_tokens": 9,
+            "input_cost": 0.2,
+            "output_cost": 0.2,
+            "total_cost": 0.75,
+        },
+    )
+    assert summary["total_tokens"] == 9
+    assert summary["total_cost"] == 0.75
+
+    cleared = set_session_cost_limit(session_id, None)
+    assert cleared["cost_limit"] is None
+    assert get_session_cost_summary(session_id)["cost_limit_exceeded"] is False

--- a/tests/unit_tests/agentserver/test_session_manager_lifecycle.py
+++ b/tests/unit_tests/agentserver/test_session_manager_lifecycle.py
@@ -9,6 +9,11 @@ import asyncio
 import pytest
 
 from jiuwenswarm.server.runtime.session.session_manager import SessionManager
+from jiuwenswarm.server.runtime.usage_cost import (
+    add_session_usage,
+    get_session_cost_summary,
+    set_session_cost_limit,
+)
 
 
 async def _wait_until_idle(manager: SessionManager, session_id: str) -> None:
@@ -49,6 +54,40 @@ async def test_close_session_releases_idle_processor_state() -> None:
         if not processor.done():
             processor.cancel()
         await asyncio.gather(processor, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_close_session_clears_usage_cost_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config",
+        lambda: {
+            "usage_cost": {
+                "enabled": True,
+                "mode": "provider_reported",
+                "enforce_limits": True,
+            }
+        },
+        raising=False,
+    )
+    manager = SessionManager()
+    completed = asyncio.Event()
+    session_id = "tui_cost_cleanup"
+
+    async def quick_task() -> None:
+        completed.set()
+
+    add_session_usage(session_id, {"total_cost": 0.02})
+    set_session_cost_limit(session_id, 0.03)
+
+    await manager.submit_task(session_id, quick_task)
+    await asyncio.wait_for(completed.wait(), timeout=1)
+    await _wait_until_idle(manager, session_id)
+    assert await manager.close_session(session_id) is True
+
+    summary = get_session_cost_summary(session_id)
+    assert summary["total_cost"] == 0.0
+    assert summary["cost_limit"] is None
+    assert summary["cost_available"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Paired: [GitHub #1759](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1759) ↔ [GitCode !4256](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4256)

# Related Issue:
#1760 

## Summary
- track session/task cost totals for main and subagent usage when providers return cost metadata
- add /usage cost display and /limit command support in TUI and Web
- ignore cost display/enforcement when provider metadata does not include cost

## Validation
- python -m py_compile jiuwenswarm/server/runtime/usage_cost.py jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
- pytest -o addopts='' tests/unit/agentserver/test_usage_cost.py
- cd jiuwenswarm/channels/tui/frontend && npm run typecheck
- cd jiuwenswarm/channels/tui/frontend && npm run build
- cd jiuwenswarm/channels/tui/frontend && npm test
- cd jiuwenswarm/channels/web/frontend && npm run build

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1760
- Fixes #1784
<!-- /bot1-related-issues -->
