### PR TITLE
fix(rail): 按 Agent 实例隔离用户 Rail 注册状态

### DIFF
--- a/jiuwenswarm/agents/harness/common/plugins/rail_manager.py
+++ b/jiuwenswarm/agents/harness/common/plugins/rail_manager.py
@@ -4,12 +4,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import importlib.util
 import json
 import logging
 import shutil
 import sys
+import threading
 import weakref
 from dataclasses import dataclass
 from pathlib import Path
@@ -84,11 +86,16 @@ class RailManager:
         # 注册状态必须按 DeepAgent 实例隔离。agent 模式会先创建模板 Agent，
         # 再为每个 session 创建独立 Agent；若只用全局名称集合，后者会被误判为
         # “已注册”而跳过。弱引用避免 session Agent 回收后被管理器持有。
-        self._agent_rail_instances: weakref.WeakKeyDictionary[
-            Any, dict[str, Any]
-        ] = weakref.WeakKeyDictionary()
+        self._agent_rail_instances: weakref.WeakKeyDictionary[Any, dict[str, Any]] = (
+            weakref.WeakKeyDictionary()
+        )
+        # Rail class 与实例分开缓存：不同 Agent 需要独立实例，但扩展模块只应加载一次。
+        self._rail_classes: dict[str, type] = {}
+        self._rail_class_lock = threading.RLock()
         # 缓存已加载的 rail 实例，确保同一个 rail 只实例化一次
         self._rail_instances: dict[str, Any] = {}
+        # 串行化注册、注销与删除，避免删除过程中又有新 Agent 注册同一扩展。
+        self._lifecycle_lock = asyncio.Lock()
 
         self._initialized = True
         logger.info("[RailManager] 初始化完成，扩展目录: %s", self._extensions_dir)
@@ -113,10 +120,7 @@ class RailManager:
     def _save_config(self) -> None:
         """保存扩展信息到配置文件."""
         try:
-            data = {
-                name: ext.to_dict()
-                for name, ext in self._extensions.items()
-            }
+            data = {name: ext.to_dict() for name, ext in self._extensions.items()}
             with open(self._config_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
             logger.debug("[RailManager] 保存配置文件成功")
@@ -176,7 +180,9 @@ class RailManager:
             if dest_path.exists():
                 shutil.rmtree(dest_path)
             shutil.copytree(source_path, dest_path)
-            logger.info("[RailManager] 复制文件夹成功: %s -> %s", source_path, dest_path)
+            logger.info(
+                "[RailManager] 复制文件夹成功: %s -> %s", source_path, dest_path
+            )
         except Exception as e:
             logger.error("[RailManager] 复制文件夹失败: %s", e)
             raise
@@ -280,7 +286,7 @@ class RailManager:
         import re
 
         # 尝试匹配 priority: int = XX
-        pattern = r'priority\s*:\s*int\s*=\s*(\d+)'
+        pattern = r"priority\s*:\s*int\s*=\s*(\d+)"
         match = re.search(pattern, file_str)
         if match:
             return int(match.group(1))
@@ -301,8 +307,11 @@ class RailManager:
         self._registered_rails = names
         return names.copy()
 
-    def delete_extension(self, name: str) -> bool:
+    async def delete_extension(self, name: str) -> bool:
         """删除一个扩展（整个文件夹）.
+
+        删除磁盘文件和配置前，会先从所有仍存活的 Agent 注销对应 Rail。
+        任一注销失败时保留扩展与失败 Agent 的实例记录，便于重试。
 
         Args:
             name: 扩展名称
@@ -312,40 +321,66 @@ class RailManager:
 
         Raises:
             ValueError: 扩展不存在
+            RuntimeError: 扩展无法从一个或多个 Agent 注销
         """
-        if name not in self._extensions:
-            raise ValueError(f"扩展 '{name}' 不存在")
+        async with self._lifecycle_lock:
+            if name not in self._extensions:
+                raise ValueError(f"扩展 '{name}' 不存在")
+            await self._unregister_extension_from_agents(name)
 
-        # 如果扩展已注册，从已注册集合中移除
-        if name in self._registered_rails:
             self._registered_rails.discard(name)
-            logger.info("[RailManager] 扩展 '%s' 从已注册集合中移除", name)
-        for rails_by_name in self._agent_rail_instances.values():
-            rails_by_name.pop(name, None)
+            self.invalidate_rail_cache(name)
 
-        # 清除缓存的实例
-        if name in self._rail_instances:
-            del self._rail_instances[name]
-            logger.info("[RailManager] 扩展 '%s' 的缓存实例已清除", name)
+            # 删除整个文件夹
+            folder_path = self._extensions_dir / name
+            if folder_path.exists():
+                try:
+                    if folder_path.is_dir():
+                        shutil.rmtree(folder_path)
+                    else:
+                        folder_path.unlink()
+                except Exception as e:
+                    logger.error("[RailManager] 删除文件夹失败: %s", e)
+                    raise
 
-        # 删除整个文件夹
-        folder_path = self._extensions_dir / name
-        if folder_path.exists():
+            # 删除扩展记录
+            del self._extensions[name]
+            self._save_config()
+
+            logger.info("[RailManager] 删除扩展成功: %s", name)
+            return True
+
+    async def _unregister_extension_from_agents(self, name: str) -> None:
+        """从所有活跃 Agent 注销扩展，且仅在成功后移除实例记录."""
+        registrations = [
+            (agent, rails_by_name[name])
+            for agent, rails_by_name in list(self._agent_rail_instances.items())
+            if name in rails_by_name
+        ]
+        failures: list[Exception] = []
+
+        for agent, rail_instance in registrations:
             try:
-                if folder_path.is_dir():
-                    shutil.rmtree(folder_path)
-                else:
-                    folder_path.unlink()
-            except Exception as e:
-                logger.error("[RailManager] 删除文件夹失败: %s", e)
-                raise
+                await agent.unregister_rail(rail_instance)
+            except Exception as exc:  # noqa: BLE001
+                failures.append(exc)
+                logger.error(
+                    "[RailManager] 从 Agent 注销扩展失败: %s, agent_id=%s, 错误: %s",
+                    name,
+                    id(agent),
+                    exc,
+                )
+                continue
 
-        # 删除扩展记录
-        del self._extensions[name]
-        self._save_config()
+            rails_by_name = self._agent_rail_instances.get(agent)
+            if rails_by_name is not None and rails_by_name.get(name) is rail_instance:
+                del rails_by_name[name]
 
-        logger.info("[RailManager] 删除扩展成功: %s", name)
-        return True
+        self.get_registered_rail_names()
+        if failures:
+            raise RuntimeError(
+                f"扩展 '{name}' 无法从 {len(failures)} 个 Agent 注销，已保留扩展以便重试"
+            ) from failures[0]
 
     def toggle_extension(self, name: str, enabled: bool) -> dict:
         """切换扩展的启用状态（仅更新配置文件）.
@@ -393,15 +428,24 @@ class RailManager:
         Raises:
             ValueError: 扩展不存在或未设置 agent 实例
         """
-        if name not in self._extensions:
-            raise ValueError(f"扩展 '{name}' 不存在")
-
         target_agent = (
             agent_instance if agent_instance is not None else self._agent_instance
         )
         if target_agent is None:
             raise ValueError("DeepAgent 实例未设置，请先调用 set_agent_instance()")
 
+        async with self._lifecycle_lock:
+            if name not in self._extensions:
+                raise ValueError(f"扩展 '{name}' 不存在")
+            await self._hot_reload_rail_for_agent(name, enabled, target_agent)
+
+    async def _hot_reload_rail_for_agent(
+        self,
+        name: str,
+        enabled: bool,
+        target_agent: Any,
+    ) -> None:
+        """在生命周期锁内为单个 Agent 注册或注销 Rail."""
         rails_by_name = self._agent_rail_instances.setdefault(target_agent, {})
 
         if enabled:
@@ -425,9 +469,7 @@ class RailManager:
         else:
             # 关闭：注销 rail
             if name not in rails_by_name:
-                logger.warning(
-                    "[RailManager] 扩展 %s 未在当前 Agent 注册，跳过", name
-                )
+                logger.warning("[RailManager] 扩展 %s 未在当前 Agent 注册，跳过", name)
                 return
 
             try:
@@ -499,8 +541,53 @@ class RailManager:
 
         return self._load_rail_instance_impl(name)
 
+    def invalidate_rail_cache(self, name: str) -> None:
+        """清除扩展的 class、主实例与动态模块缓存，供真正代码重载使用."""
+        with self._rail_class_lock:
+            class_removed = self._rail_classes.pop(name, None) is not None
+            instance_removed = self._rail_instances.pop(name, None) is not None
+
+            module_roots = (
+                f"jiuwenswarm_rail_extension_{name}",
+                f"rail_extension_{name}",
+            )
+            removed_modules = 0
+            for module_name in tuple(sys.modules):
+                if any(
+                    module_name == root or module_name.startswith(f"{root}.")
+                    for root in module_roots
+                ):
+                    sys.modules.pop(module_name, None)
+                    removed_modules += 1
+
+        if class_removed or instance_removed or removed_modules:
+            logger.info(
+                "[RailManager] 扩展 '%s' 缓存已清除: class=%s, instance=%s, modules=%d",
+                name,
+                class_removed,
+                instance_removed,
+                removed_modules,
+            )
+
     def _load_rail_class(self, name: str) -> type:
-        """加载 Rail 类（不实例化，不缓存）."""
+        """加载并缓存 Rail 类，避免创建独立实例时重复执行扩展模块."""
+        with self._rail_class_lock:
+            if name in self._rail_classes:
+                logger.debug("[RailManager] 返回缓存的 Rail 类: %s", name)
+                return self._rail_classes[name]
+
+            try:
+                rail_class = self._load_rail_class_uncached(name)
+            except Exception:
+                # 避免失败的包导入在 sys.modules 中留下半初始化模块，阻塞后续重试。
+                self.invalidate_rail_cache(name)
+                raise
+            self._rail_classes[name] = rail_class
+            logger.info("[RailManager] 加载并缓存 Rail 类成功: %s", name)
+            return rail_class
+
+    def _load_rail_class_uncached(self, name: str) -> type:
+        """从扩展目录执行模块并返回 Rail 类，不读取或写入 class 缓存."""
         extension = self._extensions[name]
 
         folder_path = self._extensions_dir / name
@@ -525,13 +612,18 @@ class RailManager:
                 package_spec.loader.exec_module(package_module)
 
                 module_name = f"{package_name}.rail"
-                rail_spec = importlib.util.spec_from_file_location(module_name, plugin_file)
-                if rail_spec is None or rail_spec.loader is None:
-                    raise ValueError(f"无法加载 Rail 模块: {name}")
+                module = sys.modules.get(module_name)
+                if module is None:
+                    rail_spec = importlib.util.spec_from_file_location(
+                        module_name,
+                        plugin_file,
+                    )
+                    if rail_spec is None or rail_spec.loader is None:
+                        raise ValueError(f"无法加载 Rail 模块: {name}")
 
-                module = importlib.util.module_from_spec(rail_spec)
-                sys.modules[module_name] = module
-                rail_spec.loader.exec_module(module)
+                    module = importlib.util.module_from_spec(rail_spec)
+                    sys.modules[module_name] = module
+                    rail_spec.loader.exec_module(module)
             else:
                 spec = importlib.util.spec_from_file_location(
                     f"rail_extension_{name}", plugin_file
@@ -571,7 +663,7 @@ class RailManager:
         return rail_instance
 
     def create_fresh_rail_instance(self, name: str) -> Any:
-        """为 team 子 agent 创建独立的 rail 实例（不使用缓存，每次返回新实例）.
+        """从缓存的 Rail class 创建独立实例（不复用实例）.
 
         Args:
             name: 扩展名称
@@ -588,7 +680,7 @@ class RailManager:
 
         rail_class = self._load_rail_class(name)
         rail_instance = rail_class()
-        logger.debug("[RailManager] 创建新 Rail 实例（team 专用）: %s -> %s", name, rail_instance)
+        logger.debug("[RailManager] 创建独立 Rail 实例: %s -> %s", name, rail_instance)
         return rail_instance
 
 

--- a/jiuwenswarm/agents/harness/common/plugins/rail_manager.py
+++ b/jiuwenswarm/agents/harness/common/plugins/rail_manager.py
@@ -10,6 +10,7 @@ import json
 import logging
 import shutil
 import sys
+import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List
@@ -80,6 +81,12 @@ class RailManager:
         self._registered_rails: set[str] = set()
         # DeepAgent 实例引用，用于 register/unregister
         self._agent_instance: Any = None
+        # 注册状态必须按 DeepAgent 实例隔离。agent 模式会先创建模板 Agent，
+        # 再为每个 session 创建独立 Agent；若只用全局名称集合，后者会被误判为
+        # “已注册”而跳过。弱引用避免 session Agent 回收后被管理器持有。
+        self._agent_rail_instances: weakref.WeakKeyDictionary[
+            Any, dict[str, Any]
+        ] = weakref.WeakKeyDictionary()
         # 缓存已加载的 rail 实例，确保同一个 rail 只实例化一次
         self._rail_instances: dict[str, Any] = {}
 
@@ -286,7 +293,13 @@ class RailManager:
         Returns:
             已注册的 rail 名称集合的副本
         """
-        return self._registered_rails.copy()
+        names = {
+            name
+            for rails_by_name in self._agent_rail_instances.values()
+            for name in rails_by_name
+        }
+        self._registered_rails = names
+        return names.copy()
 
     def delete_extension(self, name: str) -> bool:
         """删除一个扩展（整个文件夹）.
@@ -307,6 +320,8 @@ class RailManager:
         if name in self._registered_rails:
             self._registered_rails.discard(name)
             logger.info("[RailManager] 扩展 '%s' 从已注册集合中移除", name)
+        for rails_by_name in self._agent_rail_instances.values():
+            rails_by_name.pop(name, None)
 
         # 清除缓存的实例
         if name in self._rail_instances:
@@ -359,12 +374,21 @@ class RailManager:
         self._agent_instance = agent_instance
         logger.info("[RailManager] DeepAgent 实例已设置")
 
-    async def hot_reload_rail(self, name: str, enabled: bool) -> None:
+    async def hot_reload_rail(
+        self,
+        name: str,
+        enabled: bool,
+        *,
+        agent_instance: Any | None = None,
+    ) -> None:
         """热更新 rail：根据 enabled 状态注册或注销 rail 实例.
 
         Args:
             name: 扩展名称
             enabled: 是否启用
+            agent_instance: 显式目标 DeepAgent。省略时兼容使用
+                ``set_agent_instance()`` 设置的实例。并发创建 session Agent
+                时应显式传入，避免目标串线。
 
         Raises:
             ValueError: 扩展不存在或未设置 agent 实例
@@ -372,18 +396,27 @@ class RailManager:
         if name not in self._extensions:
             raise ValueError(f"扩展 '{name}' 不存在")
 
-        if self._agent_instance is None:
+        target_agent = (
+            agent_instance if agent_instance is not None else self._agent_instance
+        )
+        if target_agent is None:
             raise ValueError("DeepAgent 实例未设置，请先调用 set_agent_instance()")
+
+        rails_by_name = self._agent_rail_instances.setdefault(target_agent, {})
 
         if enabled:
             # 开启：注册 rail
-            if name in self._registered_rails:
-                logger.warning("[RailManager] 扩展 '%s' 已注册，跳过", name)
+            if name in rails_by_name:
+                logger.warning(
+                    "[RailManager] 扩展 '%s' 已在当前 Agent 注册，跳过", name
+                )
                 return
 
             try:
-                rail_instance = self.load_rail_instance_without_enabled_check(name)
-                await self._agent_instance.register_rail(rail_instance)
+                # Rail 可持有会话上下文、工具注册状态等实例字段，不能跨 Agent 复用。
+                rail_instance = self.create_fresh_rail_instance(name)
+                await target_agent.register_rail(rail_instance)
+                rails_by_name[name] = rail_instance
                 self._registered_rails.add(name)
                 logger.info("[RailManager] 成功注册 rail 扩展: %s", name)
             except Exception as e:
@@ -391,22 +424,36 @@ class RailManager:
                 raise
         else:
             # 关闭：注销 rail
-            if name not in self._registered_rails:
-                logger.warning("[RailManager] 扩展 %s 未注册，跳过", name)
+            if name not in rails_by_name:
+                logger.warning(
+                    "[RailManager] 扩展 %s 未在当前 Agent 注册，跳过", name
+                )
                 return
 
             try:
-                rail_instance = self.load_rail_instance_without_enabled_check(name)
-                await self._agent_instance.unregister_rail(rail_instance)
-                self._registered_rails.discard(name)
+                rail_instance = rails_by_name[name]
+                await target_agent.unregister_rail(rail_instance)
+                del rails_by_name[name]
+                if not any(
+                    name in registered
+                    for registered in self._agent_rail_instances.values()
+                ):
+                    self._registered_rails.discard(name)
                 logger.info("[RailManager] 成功注销 rail 扩展: %s", name)
             except Exception as e:
                 logger.error("[RailManager] 注销 rail 扩展失败: %s, 错误: %s", name, e)
                 raise
 
-    def is_rail_registered(self, name: str) -> bool:
+    def is_rail_registered(
+        self,
+        name: str,
+        *,
+        agent_instance: Any | None = None,
+    ) -> bool:
         """检查 rail 是否已注册."""
-        return name in self._registered_rails
+        if agent_instance is not None:
+            return name in self._agent_rail_instances.get(agent_instance, {})
+        return name in self.get_registered_rail_names()
 
     def get_extensions(self) -> List[dict]:
         """获取所有扩展列表."""

--- a/jiuwenswarm/agents/swarm/providers/member_rails.py
+++ b/jiuwenswarm/agents/swarm/providers/member_rails.py
@@ -409,9 +409,7 @@ def _build_plugin_rails(
     rails: list[Any] = []
     for rail_name in rail_manager.get_registered_rail_names():
         try:
-            rail_instance = rail_manager.load_rail_instance_without_enabled_check(
-                rail_name,
-            )
+            rail_instance = rail_manager.create_fresh_rail_instance(rail_name)
             if rail_instance is not None:
                 rails.append(rail_instance)
         except Exception as exc:

--- a/jiuwenswarm/server/agent_ws_server.py
+++ b/jiuwenswarm/server/agent_ws_server.py
@@ -7263,7 +7263,7 @@ class AgentWebSocketServer:
                 raise ValueError("缺少 name 参数")
 
             manager = get_rail_manager()
-            manager.delete_extension(name)
+            await manager.delete_extension(name)
 
             resp = AgentResponse(
                 request_id=request.request_id,

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -5422,7 +5422,11 @@ class JiuWenSwarmDeepAdapter:
             for ext in extensions:
                 if ext["enabled"]:
                     try:
-                        await manager.hot_reload_rail(ext["name"], True)
+                        await manager.hot_reload_rail(
+                            ext["name"],
+                            True,
+                            agent_instance=self._instance,
+                        )
                     except Exception as e:
                         logger.error(
                             "[JiuWenSwarmDeepAdapter] 用户 Rail 扩展加载失败: %s, 错误: %s",

--- a/tests/unit_tests/test_rail_manager.py
+++ b/tests/unit_tests/test_rail_manager.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from jiuwenswarm.agents.harness.common.plugins import rail_manager as rail_manager_module
+from jiuwenswarm.agents.harness.common.plugins.rail_manager import (
+    RailExtension,
+    RailManager,
+)
+
+_RAIL_NAME = "sample_rail"
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.registered: list[Any] = []
+        self.unregistered: list[Any] = []
+
+    async def register_rail(self, rail: Any) -> None:
+        self.registered.append(rail)
+
+    async def unregister_rail(self, rail: Any) -> None:
+        self.unregistered.append(rail)
+
+
+@pytest.fixture
+def rail_manager(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> RailManager:
+    monkeypatch.setattr(
+        rail_manager_module,
+        "get_agent_workspace_dir",
+        lambda: tmp_path,
+    )
+    RailManager._instance = None
+    manager = RailManager()
+    manager._extensions = {
+        _RAIL_NAME: RailExtension(
+            name=_RAIL_NAME,
+            class_name="SampleRail",
+            enabled=True,
+        )
+    }
+    yield manager
+    RailManager._instance = None
+
+
+@pytest.mark.asyncio
+async def test_hot_reload_registration_is_scoped_per_agent(
+    rail_manager: RailManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[object] = []
+
+    def _fresh(_name: str) -> object:
+        rail = object()
+        created.append(rail)
+        return rail
+
+    monkeypatch.setattr(rail_manager, "create_fresh_rail_instance", _fresh)
+    template_agent = _FakeAgent()
+    session_agent = _FakeAgent()
+
+    await rail_manager.hot_reload_rail(
+        _RAIL_NAME,
+        True,
+        agent_instance=template_agent,
+    )
+    await rail_manager.hot_reload_rail(
+        _RAIL_NAME,
+        True,
+        agent_instance=session_agent,
+    )
+    await rail_manager.hot_reload_rail(
+        _RAIL_NAME,
+        True,
+        agent_instance=session_agent,
+    )
+
+    assert len(created) == 2
+    assert template_agent.registered == [created[0]]
+    assert session_agent.registered == [created[1]]
+    assert created[0] is not created[1]
+    assert rail_manager.is_rail_registered(
+        _RAIL_NAME,
+        agent_instance=template_agent,
+    )
+    assert rail_manager.is_rail_registered(
+        _RAIL_NAME,
+        agent_instance=session_agent,
+    )
+
+    await rail_manager.hot_reload_rail(
+        _RAIL_NAME,
+        False,
+        agent_instance=template_agent,
+    )
+    assert template_agent.unregistered == [created[0]]
+    assert rail_manager.is_rail_registered(_RAIL_NAME)
+
+    await rail_manager.hot_reload_rail(
+        _RAIL_NAME,
+        False,
+        agent_instance=session_agent,
+    )
+    assert session_agent.unregistered == [created[1]]
+    assert not rail_manager.is_rail_registered(_RAIL_NAME)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_agents_do_not_share_hot_reload_target(
+    rail_manager: RailManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        rail_manager,
+        "create_fresh_rail_instance",
+        lambda _name: object(),
+    )
+    first = _FakeAgent()
+    second = _FakeAgent()
+
+    await asyncio.gather(
+        rail_manager.hot_reload_rail(
+            _RAIL_NAME,
+            True,
+            agent_instance=first,
+        ),
+        rail_manager.hot_reload_rail(
+            _RAIL_NAME,
+            True,
+            agent_instance=second,
+        ),
+    )
+
+    assert len(first.registered) == 1
+    assert len(second.registered) == 1
+    assert first.registered[0] is not second.registered[0]

--- a/tests/unit_tests/test_rail_manager.py
+++ b/tests/unit_tests/test_rail_manager.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 from typing import Any
 
 import pytest
 
-from jiuwenswarm.agents.harness.common.plugins import rail_manager as rail_manager_module
+from jiuwenswarm.agents.harness.common.plugins import (
+    rail_manager as rail_manager_module,
+)
 from jiuwenswarm.agents.harness.common.plugins.rail_manager import (
     RailExtension,
     RailManager,
@@ -24,6 +27,12 @@ class _FakeAgent:
 
     async def unregister_rail(self, rail: Any) -> None:
         self.unregistered.append(rail)
+
+
+class _FailingUnregisterAgent(_FakeAgent):
+    async def unregister_rail(self, rail: Any) -> None:
+        self.unregistered.append(rail)
+        raise RuntimeError("unregister failed")
 
 
 @pytest.fixture
@@ -140,3 +149,155 @@ async def test_concurrent_agents_do_not_share_hot_reload_target(
     assert len(first.registered) == 1
     assert len(second.registered) == 1
     assert first.registered[0] is not second.registered[0]
+
+
+@pytest.mark.asyncio
+async def test_repeated_set_agent_instance_keeps_registration_idempotent(
+    rail_manager: RailManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[object] = []
+
+    def _fresh(_name: str) -> object:
+        rail = object()
+        created.append(rail)
+        return rail
+
+    monkeypatch.setattr(rail_manager, "create_fresh_rail_instance", _fresh)
+    agent = _FakeAgent()
+
+    rail_manager.set_agent_instance(agent)
+    await rail_manager.hot_reload_rail(_RAIL_NAME, True)
+    rail_manager.set_agent_instance(agent)
+    await rail_manager.hot_reload_rail(_RAIL_NAME, True)
+
+    assert len(created) == 1
+    assert agent.registered == created
+
+
+def test_fresh_instances_reuse_cached_class_until_invalidated(
+    rail_manager: RailManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded_classes: list[type] = []
+
+    def _load_uncached(_name: str) -> type:
+        rail_class = type("SampleRail", (), {})
+        loaded_classes.append(rail_class)
+        return rail_class
+
+    monkeypatch.setattr(rail_manager, "_load_rail_class_uncached", _load_uncached)
+
+    first = rail_manager.create_fresh_rail_instance(_RAIL_NAME)
+    second = rail_manager.create_fresh_rail_instance(_RAIL_NAME)
+
+    assert first is not second
+    assert type(first) is type(second)
+    assert len(loaded_classes) == 1
+
+    rail_manager._rail_instances[_RAIL_NAME] = object()
+    rail_manager.invalidate_rail_cache(_RAIL_NAME)
+    third = rail_manager.create_fresh_rail_instance(_RAIL_NAME)
+
+    assert type(third) is not type(first)
+    assert len(loaded_classes) == 2
+    assert _RAIL_NAME not in rail_manager._rail_instances
+
+
+def test_package_module_executes_once_until_cache_is_invalidated(
+    rail_manager: RailManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    extension_dir = rail_manager._extensions_dir / _RAIL_NAME
+    extension_dir.mkdir()
+    (extension_dir / "__init__.py").write_text(
+        "from .rail import SampleRail\n",
+        encoding="utf-8",
+    )
+    (extension_dir / "rail.py").write_text(
+        "import builtins\n"
+        "builtins._rail_test_exec_count += 1\n"
+        "class SampleRail:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(builtins, "_rail_test_exec_count", 0, raising=False)
+
+    try:
+        first = rail_manager.create_fresh_rail_instance(_RAIL_NAME)
+        second = rail_manager.create_fresh_rail_instance(_RAIL_NAME)
+
+        assert first is not second
+        assert type(first) is type(second)
+        assert getattr(builtins, "_rail_test_exec_count") == 1
+
+        rail_manager.invalidate_rail_cache(_RAIL_NAME)
+        third = rail_manager.create_fresh_rail_instance(_RAIL_NAME)
+
+        assert type(third) is not type(first)
+        assert getattr(builtins, "_rail_test_exec_count") == 2
+    finally:
+        rail_manager.invalidate_rail_cache(_RAIL_NAME)
+
+
+@pytest.mark.asyncio
+async def test_delete_extension_unregisters_every_agent_before_removal(
+    rail_manager: RailManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        rail_manager,
+        "create_fresh_rail_instance",
+        lambda _name: object(),
+    )
+    first = _FakeAgent()
+    second = _FakeAgent()
+    await rail_manager.hot_reload_rail(_RAIL_NAME, True, agent_instance=first)
+    await rail_manager.hot_reload_rail(_RAIL_NAME, True, agent_instance=second)
+    rail_manager._rail_classes[_RAIL_NAME] = type("SampleRail", (), {})
+    rail_manager._rail_instances[_RAIL_NAME] = object()
+
+    assert await rail_manager.delete_extension(_RAIL_NAME) is True
+
+    assert first.unregistered == first.registered
+    assert second.unregistered == second.registered
+    assert _RAIL_NAME not in rail_manager._extensions
+    assert _RAIL_NAME not in rail_manager._rail_classes
+    assert _RAIL_NAME not in rail_manager._rail_instances
+    assert not rail_manager.is_rail_registered(_RAIL_NAME)
+
+
+@pytest.mark.asyncio
+async def test_delete_extension_preserves_failed_registration_for_retry(
+    rail_manager: RailManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        rail_manager,
+        "create_fresh_rail_instance",
+        lambda _name: object(),
+    )
+    healthy = _FakeAgent()
+    failing = _FailingUnregisterAgent()
+    await rail_manager.hot_reload_rail(_RAIL_NAME, True, agent_instance=healthy)
+    await rail_manager.hot_reload_rail(_RAIL_NAME, True, agent_instance=failing)
+    rail_manager._rail_classes[_RAIL_NAME] = type("SampleRail", (), {})
+    cached_instance = object()
+    rail_manager._rail_instances[_RAIL_NAME] = cached_instance
+
+    with pytest.raises(RuntimeError, match="已保留扩展以便重试"):
+        await rail_manager.delete_extension(_RAIL_NAME)
+
+    assert healthy.unregistered == healthy.registered
+    assert failing.unregistered == failing.registered
+    assert not rail_manager.is_rail_registered(
+        _RAIL_NAME,
+        agent_instance=healthy,
+    )
+    assert rail_manager.is_rail_registered(
+        _RAIL_NAME,
+        agent_instance=failing,
+    )
+    assert _RAIL_NAME in rail_manager._extensions
+    assert _RAIL_NAME in rail_manager._rail_classes
+    assert rail_manager._rail_instances[_RAIL_NAME] is cached_instance


### PR DESCRIPTION
Paired: [GitHub #1907](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1907) ↔ [GitCode !4334](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4334)

/kind bug

## 问题现象

Agent 模式会先创建模板 Agent，再按会话创建独立 Agent。用户 Rail 在模板 Agent 注册后，会话 Agent 可能被误判为已经注册而跳过，导致实际请求未执行对应 Rail 钩子。

## 问题根因

`RailManager` 以扩展名维护全局注册状态并复用单一 Rail 实例，无法表达“同一扩展在不同 Agent 实例上分别注册”的生命周期。

并发创建会话 Agent 时，依赖共享的当前 Agent 引用也存在注册目标串线的风险。

## 修改方案

- 按 Agent 实例隔离 Rail 注册状态，并通过弱引用避免阻止会话 Agent 回收。
- 每个 Agent 创建独立的 Rail 实例，同一 Agent 内重复加载保持幂等。
- 注册和注销时支持显式传入目标 Agent，同时保留原有调用方式以兼容现有代码。
- 会话 Agent 加载用户 Rail 时显式传递自身实例。
- 组装成员 Agent 的用户 Rail 时使用独立实例，避免跨 Agent 共享可变状态。
- 增加单 Agent 幂等、多 Agent 隔离及并发注册测试。

## 验证结果

- `uv run pytest -q --no-cov tests/unit_tests/test_rail_manager.py`
  - 2 passed
- Python 语法编译检查通过。
- Ruff 致命错误检查通过。
- 真实服务链路验证通过：模板 Agent 与会话 Agent 均完成独立注册，实际会话请求成功执行 Rail 并完成模型响应。

## 兼容性与影响

- 不涉及对外 API 变更。
- 不新增或升级第三方依赖。
- 不涉及官网文档修改。
- 未显式传入 Agent 的现有调用仍使用原有兼容路径。

## 关联 Issue

暂无。

## Self-checklist

- [ ] **设计**：尚未经过 Maintainer 评审，等待 PR 审查。
- [x] **测试**：新增测试已随本 PR 提交，并完成定向回归。
- [x] **验证**：已包含单元测试、静态检查和真实调用链路验证结果。
- [x] **接口**：不涉及对外接口变更。
- [x] **文档**：不涉及官网文档修改。
