### PR TITLE
fix(search): keep explicit free-search env opt-in across process start

### DIFF
--- a/jiuwenswarm/app.py
+++ b/jiuwenswarm/app.py
@@ -23,13 +23,13 @@ from jiuwenswarm.common.media_capability_config import (
     migrate_media_capability_switches,
 )
 from jiuwenswarm.common.utils import (
+    apply_free_search_runtime_defaults,
     cleanup_team_files,
     ensure_config_migrated_from_template,
     ensure_default_builtin_skills,
     get_env_file,
     get_user_workspace_dir,
     prepare_workspace,
-    reset_free_search_runtime_flags,
 )
 
 # Record the parsed dotenv path for subprocess spawning
@@ -65,7 +65,7 @@ ensure_default_builtin_skills()
 _env_file = get_env_file()
 load_dotenv_runtime(dotenv_path=_env_file, override=True)
 migrate_media_capability_switches(_env_file)
-reset_free_search_runtime_flags()
+apply_free_search_runtime_defaults()
 
 
 def main() -> None:

--- a/jiuwenswarm/common/utils.py
+++ b/jiuwenswarm/common/utils.py
@@ -2463,10 +2463,14 @@ def env_url(name: str, default: str) -> str:
     return os.environ.get(name, "").strip() or default
 
 
-def reset_free_search_runtime_flags() -> None:
-    """Start each process with free-search engines disabled unless reopened via config UI."""
-    os.environ["FREE_SEARCH_DDG_ENABLED"] = "false"
-    os.environ["FREE_SEARCH_BING_ENABLED"] = "false"
+def apply_free_search_runtime_defaults() -> None:
+    """Disable free-search engines for this process unless the flags are already set.
+
+    A value from ``.env``, the config UI, or the shell environment wins, so an
+    explicit opt-in survives process start.
+    """
+    os.environ.setdefault("FREE_SEARCH_DDG_ENABLED", "false")
+    os.environ.setdefault("FREE_SEARCH_BING_ENABLED", "false")
 
 
 def get_config_file() -> Path:

--- a/jiuwenswarm/gateway/app_gateway.py
+++ b/jiuwenswarm/gateway/app_gateway.py
@@ -51,6 +51,7 @@ from jiuwenswarm.common.security.ws_origin import get_header_value
 from jiuwenswarm.gateway.routing.route_binding import GatewayRouteBinding
 from jiuwenswarm.common.debug_dump import install_async_dump_handler
 from jiuwenswarm.common.utils import (
+    apply_free_search_runtime_defaults,
     ensure_config_migrated_from_template,
     ensure_default_builtin_skills,
     get_cron_jobs_path,
@@ -58,7 +59,6 @@ from jiuwenswarm.common.utils import (
     get_root_dir,
     get_user_workspace_dir,
     prepare_workspace,
-    reset_free_search_runtime_flags,
 )
 from jiuwenswarm.common.e2a.gateway_normalize import e2a_from_agent_fields
 from jiuwenswarm.common.schema.message import ReqMethod, Message, Mode
@@ -100,7 +100,7 @@ else:
 _env_file = get_env_file()
 load_dotenv_runtime(dotenv_path=_env_file, override=True)
 migrate_media_capability_switches(_env_file)
-reset_free_search_runtime_flags()
+apply_free_search_runtime_defaults()
 
 logger = logging.getLogger("jiuwenswarm.gateway")
 

--- a/jiuwenswarm/server/app_agentserver.py
+++ b/jiuwenswarm/server/app_agentserver.py
@@ -32,6 +32,7 @@ from jiuwenswarm.common.media_capability_config import (
     migrate_media_capability_switches,
 )
 from jiuwenswarm.common.utils import (
+    apply_free_search_runtime_defaults,
     ensure_config_migrated_from_template,
     ensure_default_builtin_skills,
     get_env_file,
@@ -39,7 +40,6 @@ from jiuwenswarm.common.utils import (
     get_user_workspace_dir,
     logger,
     prepare_workspace,
-    reset_free_search_runtime_flags,
 )
 
 # Ensure workspace initialized
@@ -163,7 +163,7 @@ else:
 _env_file = get_env_file()
 load_dotenv_runtime(dotenv_path=_env_file, override=True)
 migrate_media_capability_switches(_env_file)
-reset_free_search_runtime_flags()
+apply_free_search_runtime_defaults()
 
 from jiuwenswarm.agents.harness.common.tools.bash_tool_safety import (
     install_shell_tool_safety_hooks,

--- a/jiuwenswarm/server/runtime/agent_adapter/interface.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface.py
@@ -69,12 +69,12 @@ from jiuwenswarm.extensions.hook_event import AgentServerHookEvents
 from jiuwenswarm.extensions.hooks_context import MemoryHookContext
 from jiuwenswarm.common.schema.message import EventType, ReqMethod
 from jiuwenswarm.common.utils import (
+    apply_free_search_runtime_defaults,
     configure_skill_library,
     get_agent_home_dir,
     get_agent_workspace_dir,
     get_env_file,
     migrate_team_skill_views,
-    reset_free_search_runtime_flags,
 )
 from jiuwenswarm.server.runtime.a2ui.integration import (
     TeamA2UIBlockBuffer,
@@ -532,7 +532,7 @@ def _split_a2ui_stream_content(previous_probe: str, content: str) -> tuple[str, 
 
 
 load_dotenv_runtime(dotenv_path=get_env_file(), override=True)
-reset_free_search_runtime_flags()
+apply_free_search_runtime_defaults()
 
 
 def _trigger_auto_memory_extraction(

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -375,13 +375,13 @@ from jiuwenswarm.gateway.cron import CronTargetChannel
 from jiuwenswarm.common.schema.agent import AgentRequest, AgentResponse, AgentResponseChunk
 from jiuwenswarm.common.schema.message import ReqMethod
 from jiuwenswarm.common.utils import (
+    apply_free_search_runtime_defaults,
     get_agent_skills_dir,
     get_agent_workspace_dir,
     get_checkpoint_dir,
     get_default_project_session_workspace_dir,
     get_env_file,
     get_runtime_state_path,
-    reset_free_search_runtime_flags,
 )
 from jiuwenswarm.dotenv_early import load_dotenv_runtime
 from jiuwenswarm.common.mode_matrix import (
@@ -393,7 +393,7 @@ from jiuwenswarm.common.mode_matrix import (
 )
 
 load_dotenv_runtime(dotenv_path=get_env_file(), override=True)
-reset_free_search_runtime_flags()
+apply_free_search_runtime_defaults()
 TodoModifyTool = CompatibleTodoModifyTool
 install_todo_modify_compat_patch()
 

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -410,6 +410,96 @@ class TestMultiInstanceEnvVars:
                 os.environ["JIUWENSWARM_DATA_DIR"] = original_workspace_env
 
 
+class TestFreeSearchRuntimeDefaults:
+    """Test apply_free_search_runtime_defaults (free-search opt-in survives process start).
+
+    Every entrypoint calls this immediately after loading `.env`. Its predecessor
+    assigned both flags unconditionally, so a value read from `.env` — including one
+    the config UI had just persisted — was discarded one line later, and enabling free
+    search was silently lost on the next restart.
+    """
+
+    DDG_FLAG = "FREE_SEARCH_DDG_ENABLED"
+    BING_FLAG = "FREE_SEARCH_BING_ENABLED"
+
+    @staticmethod
+    def _unset(monkeypatch, *names):
+        """Unset flags so monkeypatch still restores them after the test.
+
+        `delenv` alone records nothing when the variable is already absent, so the
+        `setdefault` under test would leak its value into later tests.
+        """
+        for name in names:
+            monkeypatch.setenv(name, "")
+            monkeypatch.delenv(name)
+
+    def test_explicit_opt_in_survives(self, monkeypatch):
+        """An explicit opt-in from .env, the config UI, or the shell is preserved."""
+        monkeypatch.setenv(self.DDG_FLAG, "true")
+        monkeypatch.setenv(self.BING_FLAG, "true")
+
+        utils.apply_free_search_runtime_defaults()
+
+        assert os.environ[self.DDG_FLAG] == "true", "explicit DDG opt-in was discarded"
+        assert os.environ[self.BING_FLAG] == "true", "explicit Bing opt-in was discarded"
+
+    def test_explicit_opt_out_is_left_alone(self, monkeypatch):
+        """An explicit "false" stays disabled — the default never re-enables anything."""
+        monkeypatch.setenv(self.DDG_FLAG, "false")
+        monkeypatch.setenv(self.BING_FLAG, "false")
+
+        utils.apply_free_search_runtime_defaults()
+
+        assert os.environ[self.DDG_FLAG] == "false"
+        assert os.environ[self.BING_FLAG] == "false"
+
+    def test_unset_flags_get_the_disabled_default(self, monkeypatch):
+        """A fresh install that configures nothing still starts with both engines off."""
+        self._unset(monkeypatch, self.DDG_FLAG, self.BING_FLAG)
+
+        utils.apply_free_search_runtime_defaults()
+
+        assert os.environ[self.DDG_FLAG] == "false"
+        assert os.environ[self.BING_FLAG] == "false"
+
+    def test_empty_value_is_kept_and_still_reads_as_disabled(self, monkeypatch):
+        """An empty value counts as set, and both consumers still treat it as off."""
+        from jiuwenswarm.agents.harness.common.tools.mcp_toolkits import _is_free_search_enabled
+        from jiuwenswarm.agents.harness.common.tools.search_tools import _env_flag
+
+        monkeypatch.setenv(self.DDG_FLAG, "")
+        monkeypatch.setenv(self.BING_FLAG, "")
+
+        utils.apply_free_search_runtime_defaults()
+
+        assert (
+            os.environ[self.DDG_FLAG] == ""
+        ), "an empty value is set, so it is not a default to fill"
+        assert os.environ[self.BING_FLAG] == ""
+        # Blank reads as disabled on both sides, so keeping it changes no behaviour.
+        assert _env_flag(self.DDG_FLAG, default=False) is False
+        assert _env_flag(self.BING_FLAG, default=False) is False
+        assert _is_free_search_enabled() is False
+
+    def test_flags_are_handled_independently(self, monkeypatch):
+        """Opting one engine in leaves the other at the disabled default."""
+        self._unset(monkeypatch, self.BING_FLAG)
+        monkeypatch.setenv(self.DDG_FLAG, "true")
+
+        utils.apply_free_search_runtime_defaults()
+
+        assert os.environ[self.DDG_FLAG] == "true", "DDG opt-in was discarded"
+        assert os.environ[self.BING_FLAG] == "false", "unset Bing flag should take the default"
+
+        self._unset(monkeypatch, self.DDG_FLAG)
+        monkeypatch.setenv(self.BING_FLAG, "true")
+
+        utils.apply_free_search_runtime_defaults()
+
+        assert os.environ[self.BING_FLAG] == "true", "Bing opt-in was discarded"
+        assert os.environ[self.DDG_FLAG] == "false", "unset DDG flag should take the default"
+
+
 class TestHardcodedPathsPhase2:
     """Test that hardcoded paths are fixed to use getter functions (Phase 2).
 


### PR DESCRIPTION
Paired: [GitHub #2095](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2095) ↔ [GitCode !4378](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4378)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

`reset_free_search_runtime_flags()` set `FREE_SEARCH_DDG_ENABLED` and `FREE_SEARCH_BING_ENABLED` unconditionally, immediately after each entrypoint had loaded `.env`, so any explicitly configured value was discarded one line later. Since the config UI persists this toggle to `.env` through `_persist_env_updates()`, enabling free search appeared to work in the running process and was silently lost on the next restart.

This PR uses `os.environ.setdefault()` so a value set explicitly — by the config UI, by hand in `.env`, or in the shell environment — survives process start. The disabled-by-default behaviour is unchanged when nothing is set.

The function is renamed to `apply_free_search_runtime_defaults()`, since it now applies a default rather than resetting an existing value. It is internal to `jiuwenswarm.common.utils`; the five call sites are updated accordingly.

This is complementary to #2415 (merged to `dev-stable`), which builds the free- and paid-search tool descriptions at import time from these same two flags and drops the free-engine wording when they are off — so with the flags reset at every start, the *descriptions* the model sees would silently revert too, which makes an opt-in that survives restart more load-bearing rather than redundant. There is no functional overlap: #2415 touches `search_tools.py`, `.env.template` and their unit tests, this PR touches `jiuwenswarm/common/utils.py` and its call sites.


**Which issue(s) this PR fixes**:

Fixes #2094

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Replayed the real startup sequence (`load_dotenv_runtime()` followed by the defaults call) and checked `_is_free_search_enabled()`:

| flag state in .env / environment | result   |
| -------------------------------- | -------- |
| `FREE_SEARCH_DDG_ENABLED=true`   | enabled  |
| unset (fresh install)            | disabled |
| explicitly `false`               | disabled |
| empty value                      | disabled |

Five unit tests added in `tests/unit_tests/test_utils.py::TestFreeSearchRuntimeDefaults`, covering the rows above plus the interaction between the two flags:

- an explicit opt-in survives the call, for both engines;
- an explicit `false` is left alone, so the default never re-enables anything;
- unset flags receive the disabled default, which is the fresh-install path;
- an empty value counts as set and is therefore left empty, and both consumers — `_env_flag` in `search_tools.py` and in `mcp_toolkits.py` — still read blank as disabled, so keeping it changes no behaviour;
- the two flags are independent: opting one engine in leaves the other at the disabled default, in both directions.

Three of the five fail against the previous unconditional assignment, each on its own assertion: the opt-in test (`'false' == 'true'`), the empty-value test (`'false' == ''`), and the independence test. The other two encode behaviour the fix deliberately preserves and pass either way; they guard against a future change that stops applying the default at all.

Environment mutation is scoped per test through `monkeypatch`, with a helper that records the prior state before unsetting a flag so `setdefault` cannot leak a value into later tests.

Verified on a running deployment (web channel, agent mode): with the flag set in `.env`, after a restart `free_search` is offered to the agent for the first time — in the tool list of both the main agent and its subagents — and DuckDuckGo queries return results. The same deployment previously started with the engines disabled on every restart.

This branch is rebased onto the current `develop` tip, `4069b4585`. Three files collided, each in the same way and each resolved by keeping both sides: `app.py`, `app_gateway.py` and `app_agentserver.py` all call the free-search defaults immediately after `load_dotenv_runtime()`, and `develop` has since hoisted the env path into a local `_env_file` and inserted `migrate_media_capability_switches(_env_file)` directly above that call. The resolution keeps the upstream hoisting and the new migration call, and applies the rename to the line below them. No collision touched the renamed function or its body; the `from jiuwenswarm.common.utils import (...)` blocks in all three files merged without collision, as did the two call sites in `interface.py` and `interface_deep.py`.

Full unit suite: no regression against the base commit, compared test-by-test rather than by count. Re-measured after the rebase, back to back against a clean checkout of the same base `4069b4585`: the set of failing and erroring test ids is identical on both sides — three failures, all pre-existing on the base and unrelated to this change — and the delta is exactly the five tests added here, all passing. `tests/unit_tests/test_utils.py` goes from 31 to 36 passing with no test present on the base changing state, and `tests/unit_tests/agentserver` is unchanged in every respect.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**:
+ - [ ] Whether it causes forward compatibility failure
+ - [ ] Whether the dependent third-party library change is involved
-->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2094
<!-- /bot1-related-issues -->



