### PR TITLE
fix(cron): follow the store when the workspace migration relocates it

### DIFF
--- a/docs/en/InstallGuide.md
+++ b/docs/en/InstallGuide.md
@@ -407,7 +407,7 @@ rsync -av ~/.jiuwenswarm ~/.jiuwenswarm_backup
 | `agent/workspace/` | Identity, task, and workspace files |
 | `agent/workspace/memory/` | User memory data |
 | `agent/workspace/skills/` | Skills library (custom skills and config) |
-| `agent/home/` | Scheduled task data (`cron_jobs.json`) |
+| `gateway/cron_jobs.json` | Scheduled task data (`agent/home/cron_jobs.json` on deployments that have not migrated) |
 
 > `agent/jiuwenclaw_workspace/`, `agent/memory/`, and `agent/skills/` are legacy locations. Current versions migrate their contents into `agent/workspace/`.
 

--- a/docs/en/ScheduledTasks.md
+++ b/docs/en/ScheduledTasks.md
@@ -105,8 +105,10 @@ The task is automatically assigned to the project matching `project_dir` (falls 
 
 Scheduled task configurations are saved at:
 ```
-~/.jiuwenswarm/agent/home/cron_jobs.json
+~/.jiuwenswarm/gateway/cron_jobs.json
 ```
+
+> The path follows the workspace layout. A deployment that has not run the workspace migration still keeps the file at `~/.jiuwenswarm/agent/home/cron_jobs.json`; the resolver reads whichever one exists, so both layouts work.
 
 ### Create via Chat
 

--- a/docs/zh/安装指南.md
+++ b/docs/zh/安装指南.md
@@ -406,7 +406,7 @@ rsync -av ~/.jiuwenswarm ~/.jiuwenswarm_backup
 | `agent/workspace/` | 身份、任务及工作区文件 |
 | `agent/workspace/memory/` | 用户记忆数据 |
 | `agent/workspace/skills/` | 技能库（自定义技能和配置） |
-| `agent/home/` | 定时任务数据（`cron_jobs.json`） |
+| `gateway/cron_jobs.json` | 定时任务数据（未迁移的旧部署位于 `agent/home/cron_jobs.json`） |
 
 > `agent/jiuwenclaw_workspace/`、`agent/memory/` 和 `agent/skills/` 均为旧目录；当前版本会将其中的内容迁移至 `agent/workspace/`。
 

--- a/docs/zh/定时任务.md
+++ b/docs/zh/定时任务.md
@@ -105,8 +105,10 @@ Cron 表达式是定义定时任务执行时间规则的标准格式。
 
 定时任务配置保存在：
 ```
-~/.jiuwenswarm/agent/home/cron_jobs.json
+~/.jiuwenswarm/gateway/cron_jobs.json
 ```
+
+> 该路径随工作区布局变化：尚未执行工作区迁移的部署仍将文件保留在 `~/.jiuwenswarm/agent/home/cron_jobs.json`，系统按文件实际存在的位置读取，两种布局均可正常工作。
 
 ### 通过对话创建
 

--- a/jiuwenswarm/common/utils.py
+++ b/jiuwenswarm/common/utils.py
@@ -2379,14 +2379,32 @@ def get_interactions_dir() -> Path:
 
 
 def get_cron_jobs_path() -> Path:
-    """Canonical path for cron_jobs.json shared by gateway and agentserver."""
-    return get_user_workspace_dir() / "agent" / "home" / "cron_jobs.json"
+    """Path to cron_jobs.json, following wherever this workspace keeps it.
+
+    1. ``gateway/`` if present -- ``_migrate_legacy_workspace`` has run.
+    2. ``agent/home/`` if present -- it has not; repointing unconditionally
+       would empty the schedules of every deployment that never migrated.
+    3. ``gateway/`` otherwise: a fresh workspace then has no cron reason to
+       create ``agent/home``, one of the three directories whose presence
+       ``prepare_workspace`` reads as a legacy layout. Other components can
+       still create it.
+    """
+    workspace = get_user_workspace_dir()
+    gateway_path = workspace / "gateway" / "cron_jobs.json"
+    legacy_path = workspace / "agent" / "home" / "cron_jobs.json"
+    if gateway_path.exists():
+        return gateway_path
+    if legacy_path.exists():
+        return legacy_path
+    return gateway_path
 
 
 def get_heartbeat_jobs_path() -> Path:
     """Canonical path for heartbeat_jobs.json (new thread-automation heartbeat jobs).
 
-    与 ``get_cron_jobs_path`` 同目录(``agent/home``),禁止在业务代码中硬编码该路径。
+    位于 ``agent/home``,禁止在业务代码中硬编码该路径。注意它与
+    ``get_cron_jobs_path`` 不再必然同目录:后者跟随工作区迁移,迁移过的部署上
+    指向 ``gateway/``。
     """
     return get_agent_home_dir() / "heartbeat_jobs.json"
 

--- a/jiuwenswarm/common/utils.py
+++ b/jiuwenswarm/common/utils.py
@@ -2243,8 +2243,26 @@ def get_interactions_dir() -> Path:
 
 
 def get_cron_jobs_path() -> Path:
-    """Canonical path for cron_jobs.json shared by gateway and agentserver."""
-    return get_user_workspace_dir() / "agent" / "home" / "cron_jobs.json"
+    """Path to cron_jobs.json, following wherever this workspace keeps it.
+
+    ``_migrate_legacy_workspace`` relocates the file to ``gateway/`` while this
+    getter pointed at ``agent/home/``, so after a migration the scheduler read a
+    missing path and silently loaded zero jobs. Resolution order:
+
+    1. ``gateway/`` if present -- the migration ran.
+    2. ``agent/home/`` if present -- it has not; repointing unconditionally
+       would empty the schedules of every deployment that never migrated.
+    3. ``gateway/`` otherwise, so a fresh workspace never creates
+       ``agent/home``, whose existence alone marks a workspace legacy.
+    """
+    workspace = get_user_workspace_dir()
+    gateway_path = workspace / "gateway" / "cron_jobs.json"
+    legacy_path = workspace / "agent" / "home" / "cron_jobs.json"
+    if gateway_path.exists():
+        return gateway_path
+    if legacy_path.exists():
+        return legacy_path
+    return gateway_path
 
 
 def get_deepagent_todo_dir() -> Path:

--- a/jiuwenswarm/gateway/cron/scheduler.py
+++ b/jiuwenswarm/gateway/cron/scheduler.py
@@ -315,11 +315,22 @@ class CronSchedulerService:
             signature != self._last_store_signature
             and (signature != (0, 0, 0) or self._last_store_signature != (0, 0, 0))
         ):
-            logger.info(
-                "[Cron] store file changed (signature %s -> %s), reloading",
-                self._last_store_signature,
-                signature,
-            )
+            if signature == (0, 0, 0) and self._jobs:
+                # Losing a populated store is not routine housekeeping: an
+                # INFO "changed" line reads the same whether the file was edited
+                # or relocated away. Name what stops.
+                logger.warning(
+                    "[Cron] store %s disappeared while holding %d job(s); "
+                    "all schedules stop until it returns",
+                    self._store.path,
+                    len(self._jobs),
+                )
+            else:
+                logger.info(
+                    "[Cron] store file changed (signature %s -> %s), reloading",
+                    self._last_store_signature,
+                    signature,
+                )
             await self.reload()
             return True
         return False
@@ -424,6 +435,18 @@ class CronSchedulerService:
         continue executing and pushing results despite having no persistent record.
         """
         jobs = await self._store.list_jobs()
+        # A scheduler holding zero jobs is otherwise indistinguishable from a
+        # healthy one, which is how a relocated store goes unnoticed.
+        if jobs:
+            logger.info(
+                "[Cron] loaded %d job(s) from %s", len(jobs), self._store.path
+            )
+        else:
+            logger.warning(
+                "[Cron] loaded 0 jobs from %s (exists=%s) - nothing is scheduled",
+                self._store.path,
+                self._store.path.exists(),
+            )
         self._jobs = {j.id: j for j in jobs}
         new_job_ids = set(self._jobs.keys())
 

--- a/jiuwenswarm/gateway/cron/scheduler.py
+++ b/jiuwenswarm/gateway/cron/scheduler.py
@@ -311,11 +311,22 @@ class CronSchedulerService:
             signature != self._last_store_signature
             and (signature != (0, 0, 0) or self._last_store_signature != (0, 0, 0))
         ):
-            logger.info(
-                "[Cron] store file changed (signature %s -> %s), reloading",
-                self._last_store_signature,
-                signature,
-            )
+            if signature == (0, 0, 0) and self._jobs:
+                # Losing a populated store is not routine housekeeping: an
+                # INFO "changed" line reads the same whether the file was edited
+                # or relocated away. Name what stops.
+                logger.warning(
+                    "[Cron] store %s disappeared while holding %d job(s); "
+                    "all schedules stop until it returns",
+                    self._store.path,
+                    len(self._jobs),
+                )
+            else:
+                logger.info(
+                    "[Cron] store file changed (signature %s -> %s), reloading",
+                    self._last_store_signature,
+                    signature,
+                )
             await self.reload()
             return True
         return False
@@ -420,6 +431,31 @@ class CronSchedulerService:
         continue executing and pushing results despite having no persistent record.
         """
         jobs = await self._store.list_jobs()
+        # A scheduler holding zero jobs is otherwise indistinguishable from a
+        # healthy one, which is how a relocated store goes unnoticed. Only the
+        # missing store warns here, because that is the only reading this layer
+        # can classify: an existing store returning nothing is usually ordinary
+        # -- a fresh install, or every job deleted on purpose -- and the one
+        # reading that is not, a damaged file, is reported by CronJobStore,
+        # the only layer that can still tell it apart. A third reading is
+        # reported by nobody: list_jobs discards an entry CronJob.from_dict
+        # rejects on a bare ``except Exception: continue``, so a store of
+        # nine entries is served as eight with nothing logged at any level.
+        # That is a separate gap and this change does not close it.
+        if jobs:
+            logger.info(
+                "[Cron] loaded %d job(s) from %s", len(jobs), self._store.path
+            )
+        elif self._store.path.exists():
+            logger.info(
+                "[Cron] loaded 0 jobs from %s - nothing is scheduled",
+                self._store.path,
+            )
+        else:
+            logger.warning(
+                "[Cron] store file %s does not exist - nothing is scheduled",
+                self._store.path,
+            )
         self._jobs = {j.id: j for j in jobs}
         new_job_ids = set(self._jobs.keys())
 

--- a/jiuwenswarm/gateway/cron/store.py
+++ b/jiuwenswarm/gateway/cron/store.py
@@ -115,7 +115,14 @@ class _ProactiveJobProtected(RuntimeError):
 
 
 class CronJobStore:
-    """Persist cron jobs to ~/.jiuwenswarm/agent/home/cron_jobs.json.
+    """Persist cron jobs to this workspace's ``cron_jobs.json``.
+
+    The location is not fixed. ``get_cron_jobs_path`` resolves it against what
+    is on disk -- ``gateway/cron_jobs.json`` once the workspace migration has
+    relocated the file, ``agent/home/cron_jobs.json`` on a deployment that
+    never migrated -- so that neither layout is stranded. The gateway scheduler
+    and the agent-side read-only view both pass that resolved path in; the
+    ``path=None`` default falls back to the same lookup.
 
     并发安全:
       - ``asyncio.Lock``：同进程协程互斥；
@@ -514,17 +521,35 @@ class CronJobStore:
         path = self._path
         try:
             if not path.exists():
+                # Not a fault of this layer: the caller that cares reports it.
                 return {"version": 1, "jobs": []}
             raw = path.read_text(encoding="utf-8")
             data = json.loads(raw) if raw.strip() else {}
             if not isinstance(data, dict):
+                logger.warning(
+                    "Cron store %s holds a JSON %s where an object was expected; "
+                    "reading it as empty -- no schedule runs until it is repaired",
+                    path,
+                    type(data).__name__,
+                )
                 return {"version": 1, "jobs": []}
             if "version" not in data:
                 data["version"] = 1
             if "jobs" not in data:
                 data["jobs"] = []
             return data
-        except Exception:
+        except Exception as exc:
+            # Reading on returns an empty store rather than raising, so that one
+            # damaged file cannot take the gateway down with it. Say so: an
+            # unreported empty read is indistinguishable from a store that
+            # genuinely holds nothing.
+            logger.warning(
+                "Cron store %s could not be read (%s: %s); reading it as empty "
+                "-- no schedule runs until it is repaired",
+                path,
+                type(exc).__name__,
+                exc,
+            )
             return {"version": 1, "jobs": []}
 
     def _write_json_unlocked(self, data: dict[str, Any]) -> None:

--- a/tests/unit_tests/gateway/test_cron_store_path_resolution.py
+++ b/tests/unit_tests/gateway/test_cron_store_path_resolution.py
@@ -1,0 +1,248 @@
+"""``get_cron_jobs_path`` must follow wherever a workspace keeps its jobs.
+
+``_migrate_legacy_workspace`` relocates the file to ``gateway/`` while the getter
+pointed at ``agent/home/``, so after a migration the scheduler read a missing
+path and every schedule stopped firing silently. These pin the resolution order
+that repairs it without stranding anyone.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+
+import pytest
+
+from jiuwenswarm.common.utils import get_cron_jobs_path
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "jiuwenswarm.common.utils.get_user_workspace_dir", lambda: tmp_path
+    )
+    return tmp_path
+
+
+def _write(path, jobs=("job-1",)):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"version": 1, "jobs": [{"id": j} for j in jobs]}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_fresh_workspace_adopts_the_gateway_layout(workspace):
+    """Nothing on disk: use the new location, so agent/home -- the marker that
+    makes a workspace look 'legacy' -- is never created."""
+    assert get_cron_jobs_path() == workspace / "gateway" / "cron_jobs.json"
+
+
+def test_existing_deployment_keeps_its_legacy_file(workspace):
+    """The upgrade case that must not break: repointing unconditionally would
+    empty the schedule of a deployment that never migrated."""
+    legacy = _write(workspace / "agent" / "home" / "cron_jobs.json")
+    assert get_cron_jobs_path() == legacy
+
+
+def test_migrated_deployment_uses_gateway(workspace):
+    """The bug: once the migration relocated the file, the reader must follow."""
+    new = _write(workspace / "gateway" / "cron_jobs.json")
+    assert get_cron_jobs_path() == new
+
+
+def test_gateway_wins_when_both_exist(workspace):
+    """The migration can leave the old file behind; the relocated copy wins."""
+    _write(workspace / "agent" / "home" / "cron_jobs.json", jobs=("stale",))
+    new = _write(workspace / "gateway" / "cron_jobs.json", jobs=("current",))
+    assert get_cron_jobs_path() == new
+
+
+def test_an_empty_agent_home_does_not_count(workspace):
+    """A leftover lock file is not a store, or a workspace whose cron_jobs.json
+    was removed would pin itself to the legacy path forever."""
+    lock_dir = workspace / "agent" / "home"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "cron_jobs.json.lock").write_text("", encoding="utf-8")
+    assert get_cron_jobs_path() == workspace / "gateway" / "cron_jobs.json"
+
+
+_JOB = {
+    "id": "job-1",
+    "name": "Example job",
+    "enabled": True,
+    "expired": False,
+    "cron_expr": "0 0 8 * * ? *",
+    "timezone": "UTC",
+    "description": "Example scheduled job.",
+    "targets": "web",
+    "session_id": "web_session_1",
+    "mode": "agent",
+}
+
+
+def _write_job(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": 1, "jobs": [_JOB]}), encoding="utf-8")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_the_real_migration_no_longer_orphans_the_store(workspace):
+    """Run the actual migration, not an imitation of it.
+
+    A hand-rolled copy+unlink would keep passing if the migration ever changed
+    destination or stopped deleting the source -- the very drift that caused this.
+    """
+    from jiuwenswarm.common.utils import _migrate_legacy_workspace
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    legacy = workspace / "agent" / "home" / "cron_jobs.json"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text(json.dumps({"version": 1, "jobs": [_JOB]}), encoding="utf-8")
+
+    assert len(await CronJobStore(path=get_cron_jobs_path()).list_jobs()) == 1
+
+    _migrate_legacy_workspace(workspace)
+
+    # The migration did what it always did: moved the file and removed the dir.
+    assert not (workspace / "agent" / "home").exists()
+    assert (workspace / "gateway" / "cron_jobs.json").exists()
+
+    # ...and the job is still reachable, which is the part that used to fail.
+    jobs = await CronJobStore(path=get_cron_jobs_path()).list_jobs()
+    assert len(jobs) == 1, "the migration orphaned the store again"
+    assert jobs[0].id == "job-1"
+
+
+@pytest.mark.asyncio
+async def test_relocating_the_store_no_longer_loses_jobs(workspace):
+    """Reproduces the original failure: relocate, then read. Before the fix the
+    store read a missing path and reported zero jobs."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    legacy = workspace / "agent" / "home" / "cron_jobs.json"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "job-1",
+                        "name": "Example job",
+                        "enabled": True,
+                        "expired": False,
+                        "cron_expr": "0 0 8 * * ? *",
+                        "timezone": "UTC",
+                        "description": "Example scheduled job.",
+                        "targets": "web",
+                        "session_id": "web_session_1",
+                        "mode": "agent",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert len(await CronJobStore(path=get_cron_jobs_path()).list_jobs()) == 1
+
+    # What the migration does: copy to gateway/, then remove agent/home.
+    new = workspace / "gateway" / "cron_jobs.json"
+    new.parent.mkdir(parents=True, exist_ok=True)
+    new.write_text(legacy.read_text(encoding="utf-8"), encoding="utf-8")
+    legacy.unlink()
+
+    jobs = await CronJobStore(path=get_cron_jobs_path()).list_jobs()
+    assert len(jobs) == 1, "the relocated store must still be found"
+    assert jobs[0].id == "job-1"
+
+
+@contextlib.contextmanager
+def _scheduler_logs(level=logging.INFO):
+    """Collect what the scheduler logs, from the logger that emits it.
+
+    ``caplog`` attaches to the root logger, and ``setup_logger`` sets
+    ``propagate = False`` on ``jiuwenswarm`` when it is imported, so these
+    records only reach the root on pytest 9.1+, which also attaches to
+    non-propagating loggers. Attaching here holds on every version.
+    """
+    logger = logging.getLogger("jiuwenswarm.gateway.cron.scheduler")
+    records: list[logging.LogRecord] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    handler = _Collect(level)
+    original = logger.level
+    logger.setLevel(level)
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(original)
+
+
+def _scheduler(store):
+    """Minimal scheduler for the logging paths: reload() touches only the store
+    and its own bookkeeping, so the client and handler are never called."""
+    from jiuwenswarm.gateway.cron.scheduler import CronSchedulerService
+
+    return CronSchedulerService(
+        store=store, agent_client=None, message_handler=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_reload_reports_how_many_jobs_it_loaded(workspace):
+    """Say what was loaded and from where: "scheduler started" alone reads the
+    same with one job or none."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    path = _write_job(workspace / "gateway" / "cron_jobs.json")
+    with _scheduler_logs() as records:
+        await _scheduler(CronJobStore(path=path)).reload()
+
+    messages = [r.getMessage() for r in records]
+    assert any(
+        "loaded 1 job(s)" in m and str(path) in m for m in messages
+    ), messages
+
+
+@pytest.mark.asyncio
+async def test_reload_warns_when_it_loads_nothing(workspace):
+    """Zero jobs is a warning, not silence: it is the symptom of the bug."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    missing = workspace / "gateway" / "cron_jobs.json"
+    with _scheduler_logs(logging.DEBUG) as records:
+        await _scheduler(CronJobStore(path=missing)).reload()
+
+    warnings = [r.getMessage() for r in records if r.levelname == "WARNING"]
+    assert any("loaded 0 jobs" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_a_store_vanishing_under_us_warns_by_name(workspace):
+    """Losing a populated store is not routine housekeeping: the old INFO line
+    read the same whether the file was edited or had vanished with the schedules."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    path = _write_job(workspace / "gateway" / "cron_jobs.json")
+    scheduler = _scheduler(CronJobStore(path=path))
+    await scheduler.reload()
+    scheduler._sync_store_mtime()
+
+    path.unlink()
+    with _scheduler_logs() as records:
+        assert await scheduler._check_store_changed() is True
+
+    warnings = [r.getMessage() for r in records if r.levelname == "WARNING"]
+    assert any(
+        "disappeared while holding 1 job(s)" in m for m in warnings
+    ), warnings

--- a/tests/unit_tests/gateway/test_cron_store_path_resolution.py
+++ b/tests/unit_tests/gateway/test_cron_store_path_resolution.py
@@ -1,0 +1,325 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""``get_cron_jobs_path`` must follow wherever a workspace keeps its jobs.
+
+``_migrate_legacy_workspace`` relocates the file to ``gateway/`` while the getter
+pointed at ``agent/home/``, so after a migration the scheduler read a missing
+path and every schedule stopped firing silently. These pin the resolution order
+that repairs it without stranding anyone.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+
+import pytest
+
+from jiuwenswarm.common.utils import get_cron_jobs_path
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "jiuwenswarm.common.utils.get_user_workspace_dir", lambda: tmp_path
+    )
+    return tmp_path
+
+
+def _write(path, jobs=("job-1",)):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"version": 1, "jobs": [{"id": j} for j in jobs]}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_fresh_workspace_adopts_the_gateway_layout(workspace):
+    """Nothing on disk: use the new location, so the cron store does not create
+    agent/home -- one of the three directories whose presence prepare_workspace
+    reads as a legacy layout."""
+    assert get_cron_jobs_path() == workspace / "gateway" / "cron_jobs.json"
+
+
+def test_existing_deployment_keeps_its_legacy_file(workspace):
+    """The upgrade case that must not break: repointing unconditionally would
+    empty the schedule of a deployment that never migrated."""
+    legacy = _write(workspace / "agent" / "home" / "cron_jobs.json")
+    assert get_cron_jobs_path() == legacy
+
+
+def test_migrated_deployment_uses_gateway(workspace):
+    """The bug: once the migration relocated the file, the reader must follow."""
+    new = _write(workspace / "gateway" / "cron_jobs.json")
+    assert get_cron_jobs_path() == new
+
+
+def test_gateway_wins_when_both_exist(workspace):
+    """The migration can leave the old file behind; the relocated copy wins."""
+    _write(workspace / "agent" / "home" / "cron_jobs.json", jobs=("stale",))
+    new = _write(workspace / "gateway" / "cron_jobs.json", jobs=("current",))
+    assert get_cron_jobs_path() == new
+
+
+def test_an_empty_agent_home_does_not_count(workspace):
+    """A leftover lock file is not a store, or a workspace whose cron_jobs.json
+    was removed would pin itself to the legacy path forever."""
+    lock_dir = workspace / "agent" / "home"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "cron_jobs.json.lock").write_text("", encoding="utf-8")
+    assert get_cron_jobs_path() == workspace / "gateway" / "cron_jobs.json"
+
+
+_JOB = {
+    "id": "job-1",
+    "name": "Example job",
+    "enabled": True,
+    "expired": False,
+    "cron_expr": "0 0 8 * * ? *",
+    "timezone": "UTC",
+    "description": "Example scheduled job.",
+    "targets": "web",
+    "session_id": "web_session_1",
+    "mode": "agent",
+}
+
+
+def _write_job(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": 1, "jobs": [_JOB]}), encoding="utf-8")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_the_real_migration_no_longer_orphans_the_store(workspace):
+    """Run the actual migration, not an imitation of it.
+
+    A hand-rolled copy+unlink would keep passing if the migration ever changed
+    destination or stopped deleting the source -- the very drift that caused this.
+    """
+    from jiuwenswarm.common.utils import _migrate_legacy_workspace
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    legacy = workspace / "agent" / "home" / "cron_jobs.json"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text(json.dumps({"version": 1, "jobs": [_JOB]}), encoding="utf-8")
+
+    assert len(await CronJobStore(path=get_cron_jobs_path()).list_jobs()) == 1
+
+    _migrate_legacy_workspace(workspace)
+
+    # The migration did what it always did: moved the file and removed the dir.
+    assert not (workspace / "agent" / "home").exists()
+    assert (workspace / "gateway" / "cron_jobs.json").exists()
+
+    # ...and the job is still reachable, which is the part that used to fail.
+    jobs = await CronJobStore(path=get_cron_jobs_path()).list_jobs()
+    assert len(jobs) == 1, "the migration orphaned the store again"
+    assert jobs[0].id == "job-1"
+
+
+@pytest.mark.asyncio
+async def test_relocating_the_store_no_longer_loses_jobs(workspace):
+    """Reproduces the original failure: relocate, then read. Before the fix the
+    store read a missing path and reported zero jobs."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    legacy = workspace / "agent" / "home" / "cron_jobs.json"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": [
+                    {
+                        "id": "job-1",
+                        "name": "Example job",
+                        "enabled": True,
+                        "expired": False,
+                        "cron_expr": "0 0 8 * * ? *",
+                        "timezone": "UTC",
+                        "description": "Example scheduled job.",
+                        "targets": "web",
+                        "session_id": "web_session_1",
+                        "mode": "agent",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert len(await CronJobStore(path=get_cron_jobs_path()).list_jobs()) == 1
+
+    # What the migration does: copy to gateway/, then remove agent/home.
+    new = workspace / "gateway" / "cron_jobs.json"
+    new.parent.mkdir(parents=True, exist_ok=True)
+    new.write_text(legacy.read_text(encoding="utf-8"), encoding="utf-8")
+    legacy.unlink()
+
+    jobs = await CronJobStore(path=get_cron_jobs_path()).list_jobs()
+    assert len(jobs) == 1, "the relocated store must still be found"
+    assert jobs[0].id == "job-1"
+
+
+@contextlib.contextmanager
+def _logs_of(name, level):
+    """Collect what ``name`` logs, from the logger that emits it.
+
+    ``caplog`` attaches to the root logger, and ``setup_logger`` sets
+    ``propagate = False`` on ``jiuwenswarm`` when it is imported, so a record
+    emitted below it need not reach the root at all. Attaching to the logger
+    that emits it does not depend on that.
+    """
+    logger = logging.getLogger(name)
+    records: list[logging.LogRecord] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    handler = _Collect(level)
+    original = logger.level
+    logger.setLevel(level)
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(original)
+
+
+def _scheduler_logs(level=logging.INFO):
+    return _logs_of("jiuwenswarm.gateway.cron.scheduler", level)
+
+
+def _store_logs(level=logging.INFO):
+    return _logs_of("jiuwenswarm.gateway.cron.store", level)
+
+
+def _scheduler(store):
+    """Minimal scheduler for the logging paths: reload() touches only the store
+    and its own bookkeeping, so the client and handler are never called."""
+    from jiuwenswarm.gateway.cron.scheduler import CronSchedulerService
+
+    return CronSchedulerService(
+        store=store, agent_client=None, message_handler=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_reload_reports_how_many_jobs_it_loaded(workspace):
+    """Say what was loaded and from where: "scheduler started" alone reads the
+    same with one job or none."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    path = _write_job(workspace / "gateway" / "cron_jobs.json")
+    with _scheduler_logs() as records:
+        await _scheduler(CronJobStore(path=path)).reload()
+
+    messages = [r.getMessage() for r in records]
+    assert any(
+        "loaded 1 job(s)" in m and str(path) in m for m in messages
+    ), messages
+
+
+@pytest.mark.asyncio
+async def test_reload_warns_when_the_store_is_missing(workspace):
+    """A store that is not there is the symptom of the bug: warn, not silence."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    missing = workspace / "gateway" / "cron_jobs.json"
+    with _scheduler_logs(logging.DEBUG) as records:
+        await _scheduler(CronJobStore(path=missing)).reload()
+
+    warnings = [r.getMessage() for r in records if r.levelname == "WARNING"]
+    assert any(
+        "does not exist" in m and str(missing) in m for m in warnings
+    ), warnings
+
+
+@pytest.mark.asyncio
+async def test_reload_does_not_warn_for_an_existing_empty_store(workspace):
+    """An empty store that exists is an ordinary state -- a fresh install, or
+    every job deleted on purpose -- so it must not be reported as a fault.
+    Warning on it would train operators to ignore the line that matters."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    empty = workspace / "gateway" / "cron_jobs.json"
+    empty.parent.mkdir(parents=True, exist_ok=True)
+    empty.write_text(json.dumps({"version": 1, "jobs": []}), encoding="utf-8")
+
+    with _scheduler_logs(logging.DEBUG) as records:
+        await _scheduler(CronJobStore(path=empty)).reload()
+
+    assert not [r.getMessage() for r in records if r.levelname == "WARNING"]
+    infos = [r.getMessage() for r in records if r.levelname == "INFO"]
+    assert any(
+        "loaded 0 jobs" in m and str(empty) in m for m in infos
+    ), infos
+
+
+@pytest.mark.asyncio
+async def test_a_store_vanishing_under_us_warns_by_name(workspace):
+    """Losing a populated store is not routine housekeeping: the old INFO line
+    read the same whether the file was edited or had vanished with the schedules."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    path = _write_job(workspace / "gateway" / "cron_jobs.json")
+    scheduler = _scheduler(CronJobStore(path=path))
+    await scheduler.reload()
+    scheduler._sync_store_mtime()
+
+    path.unlink()
+    with _scheduler_logs() as records:
+        assert await scheduler._check_store_changed() is True
+
+    warnings = [r.getMessage() for r in records if r.levelname == "WARNING"]
+    assert any(
+        "disappeared while holding 1 job(s)" in m for m in warnings
+    ), warnings
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_store_warns_instead_of_reading_as_empty(workspace):
+    """A damaged file must not be answered with the ordinary empty store.
+
+    Every read swallows it into ``{"jobs": []}`` so that one bad file cannot
+    take the gateway down. Nothing above this layer can then tell the reading
+    apart from a store that genuinely holds nothing, so the store is where it
+    has to be said."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    corrupt = workspace / "gateway" / "cron_jobs.json"
+    corrupt.parent.mkdir(parents=True, exist_ok=True)
+    corrupt.write_text('{"version": 1, "jobs": [', encoding="utf-8")
+
+    with _store_logs(logging.DEBUG) as records:
+        jobs = await CronJobStore(path=corrupt).list_jobs()
+
+    assert jobs == []
+    warnings = [r.getMessage() for r in records if r.levelname == "WARNING"]
+    assert any(
+        "could not be read" in m and str(corrupt) in m for m in warnings
+    ), warnings
+
+
+@pytest.mark.asyncio
+async def test_a_store_holding_a_json_list_warns(workspace):
+    """The other whole-file shape that reads as empty: valid JSON, wrong type.
+    It never reaches the ``except``, so it needs its own report."""
+    from jiuwenswarm.gateway.cron.store import CronJobStore
+
+    wrong = workspace / "gateway" / "cron_jobs.json"
+    wrong.parent.mkdir(parents=True, exist_ok=True)
+    wrong.write_text(json.dumps([{"id": "job-1"}]), encoding="utf-8")
+
+    with _store_logs(logging.DEBUG) as records:
+        assert await CronJobStore(path=wrong).list_jobs() == []
+
+    warnings = [r.getMessage() for r in records if r.levelname == "WARNING"]
+    assert any(
+        "an object was expected" in m and str(wrong) in m for m in warnings
+    ), warnings


### PR DESCRIPTION
Paired: [GitHub #2377](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2377) ↔ [GitCode !4531](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4531)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #2376

May also cover [issue 805](https://github.com/openJiuwen-ai/jiuwenswarm/issues/805), where scheduled tasks vanish from the UI while `cron_jobs.json` still holds them in the gateway container — the same signature of an intact store and a reader pointed elsewhere. Unconfirmed: that deployment's workspace layout is not visible from the report. Settling it needs two things — whether `agent/home/` is absent and `gateway/cron_jobs.json` present there, and whether the gateway restarted between the task being visible and the list going empty, since a static path mismatch cannot on its own make an already-visible job vanish. What the report does say points away from a restart: on the second attempt the jobs went missing across more than five minutes in which both users' browsers were interacting continuously, and no restart is mentioned anywhere in it — which fits the mechanism in [issue 4293](https://github.com/openJiuwen-ai/jiuwenswarm/issues/4293) better than this one.

**What does this PR do / why do we need it**:

Putting cron state under `gateway/` is not this PR's idea. `1ffce071` *("fix(workspace): migrate cron_jobs.json from old_home to gateway")* chose that destination and taught `_migrate_legacy_workspace` to move the file there. What follows supplies the half that was never wired up — the reader — rather than proposing a different layout.

### How the gap opened

Two commits that are each reasonable alone:

- **`1ffce071`** added the relocation but touched only `utils.py`. The store still resolved its path through `get_agent_home_dir()`, so from that commit onward the migration wrote to a location nothing read.
- **`589d3da5`** then introduced `get_cron_jobs_path()` and unified on the reader's existing `agent/home/`, not on the destination the migration had already adopted.

Net effect: the migration reads `agent/home/cron_jobs.json`, writes it to `gateway/`, and then removes `agent/home` with the rest of the legacy layout. Afterwards the scheduler reads a path that no longer exists, `CronJobStore` returns an empty job list for a missing file, and every schedule stops firing. Nothing raises.

### The change

`get_cron_jobs_path()` now resolves rather than hardcodes:

1. `gateway/cron_jobs.json` if present — the relocation has run, honour it.
2. `agent/home/cron_jobs.json` if present — it has not; keep using it.
3. Otherwise `gateway/` — a fresh workspace adopts the destination `1ffce071` chose.

Resolution is by existence and happens once, when `CronJobStore` is constructed. Every construction site already routes through this function — the store the gateway builds for the scheduler, the store's own default, and the agent-side read-only view — and no other component reads it, so there is no second path to keep in step. It is not the only writer — `_migrate_legacy_workspace` writes the gateway copy, which is the write this change follows.

**Repointing unconditionally was the obvious fix and is the wrong one.** Every existing deployment keeps its jobs in `agent/home/`, and the relocation only runs on the legacy path, so switching the reader outright would empty their schedules on upgrade — the same silent failure, inflicted on everyone at once. Following the file breaks nobody, and case 3 stops the cron store from creating `agent/home` on a fresh workspace — one of the three directories (`agent/home`, `agent/skills`, `agent/memory`) whose presence `prepare_workspace` reads as a legacy layout. That removes one cause of the classification, not all of them: the heartbeat store still creates the directory, on any workspace.

The trigger is deliberately untouched, and it is wider than a first run: `prepare_workspace` also runs when a legacy `agent/jiuwenclaw_workspace` is present without `agent/workspace`, or when `agent/workspace/mcp/mcp_builtins` is not seated, so the migration is reachable on an ordinary upgrade. With the reader following the file, a relocation is no longer destructive, so narrowing the trigger was not needed to fix this.

One adjacent docstring is corrected because this change is what falsifies it: `get_heartbeat_jobs_path` said `heartbeat_jobs.json` sits in the same directory as `cron_jobs.json`, which stops being true once the cron path resolves to `gateway/`. It now names `agent/home` outright. That file does not move.

### Relationship to the other open fixes

[PR 3599](https://github.com/openJiuwen-ai/jiuwenswarm/pull/3599) addresses the same defect by the same mechanism, so the two overlap and only one is needed. They differ on the fresh-workspace case. That PR resolves to `gateway/` when the file is there and to `agent/home/` otherwise, so a brand-new workspace writes its first job to `agent/home/cron_jobs.json`, is flagged legacy on the next start and is migrated — `agent/home` created and then removed again, on an installation that was never legacy. The third branch here exists for that case: with no store present it returns `gateway/`. The wider coverage is additive — an end-to-end test that drives `_migrate_legacy_workspace` itself rather than imitating it, and the logging below.

The two also meet on the same lines: that PR's warning for an absent store goes into the `if not path.exists():` branch of `_read_json_unlocked` where this one puts a comment deferring to the caller. Whichever merges second reconciles that branch rather than taking both, and should rebase onto the first; if #3599 lands ahead of this, what remains here is the third resolution branch, the migration test, and the store-level and `reload()` logging.

[PR 4145](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4145) takes the opposite position: `agent/home/` canonical and the relocation deleted, rather than `gateway/` canonical and the reader supplied. Which path should be canonical is a maintainer's call, but the two cannot both merge unchanged. `_recover_gateway_cron_jobs` there takes its destination from `get_cron_jobs_path()`, which under this resolver returns the gateway file itself whenever it exists; source and destination coincide, nothing is recovered, and the only copy is then renamed `cron_jobs.json.migrated`. Where `agent/home/cron_jobs.json` is already gone — the population that recovery exists for — the next resolution finds neither file. That is a reading of the two diffs composed, not something observed.

[PR 4295](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4295) is on the same silent-loss theme and edits the same two files, but is complementary rather than competing: it addresses per-entry loss — `list_jobs` discards an entry `CronJob.from_dict` rejects on a bare `except Exception: continue` — while this PR addresses path resolution and the whole-file silences around it. Neither touches the other's lines. That per-entry drop is the one zero-job reading `reload()` cannot separate here, named as a gap in the comment this PR puts there and fixed by #4295. [Issue 4293](https://github.com/openJiuwen-ai/jiuwenswarm/issues/4293) is the defect it fixes, and it bears on the #805 attribution above: it produces the same user-visible symptom with no restart involved.

[PR 4419](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4419) also edits `scheduler.py`, for an unrelated concern — a cron job creating cron jobs — so the overlap there is textual only.

### Observability

The failure was invisible at every level, so the readings of a zero-job load that this change can tell apart are separated and named:

- `reload()` reports how many jobs were loaded and from where. A scheduler holding zero jobs previously looked identical to a healthy one — `[Cron] scheduler started` and nothing else. Zero jobs now splits by whether the file is there: a store that is not where the reader is looking warns, an existing store holding nothing logs at INFO. A fresh install and a deliberately emptied schedule both hold one legitimately, and a warning that fires routinely is one operators learn to scroll past.
- Whether the file exists is all `reload()` can go on. A present but damaged file — unparseable, or valid JSON that is not an object — used to reach it as zero jobs from a path that exists, reported as the ordinary state. `CronJobStore` now warns from both places it discards a file whole, naming the path.
- A store that disappears while jobs are held now warns by name, instead of the same `INFO "store file changed"` line used for an ordinary edit.

```
[Cron] loaded 1 job(s) from <workspace>/agent/home/cron_jobs.json
[Cron] loaded 0 jobs from <workspace>/gateway/cron_jobs.json - nothing is scheduled
[Cron] store file <workspace>/gateway/cron_jobs.json does not exist - nothing is scheduled
Cron store <path> could not be read (JSONDecodeError: Expecting value: line 1 column 25 (char 24)); reading it as empty -- no schedule runs until it is repaired
Cron store <path> holds a JSON list where an object was expected; reading it as empty -- no schedule runs until it is repaired
[Cron] store <path> disappeared while holding 2 job(s); all schedules stop until it returns
```

Two things about the store-level warning, stated rather than left to be found. It repeats on every read, since the file stays broken until it is repaired, and the web panel polls `cron.job.list` every five seconds while the scheduled-tasks screen is open — so an operator sitting there sees the line at that rate. Warning once per `(path, stat signature)` instead is a contained change if that is the worse trade. And it does not prevent the one loss here: `_upsert_job` reads a damaged file as empty and then writes unconditionally, so creating a single job over a recoverable file replaces it with a valid file holding one entry. `delete_job` and the lazy `work_mode` write-back in `list_jobs` are guarded — each writes only `if deleted:` / `if changed:` — so the loss is specific to job creation. What the warning buys is the file being named before the next write lands on it.

### Behaviour changes

- Deployments with jobs in `agent/home/` keep reading and writing there. No data moves, nothing to migrate.
- Deployments where the relocation already ran regain their schedules on the next start, with no manual step.
- A fresh workspace places the store in `gateway/` and no longer creates `agent/home/` for its cron state. Other code still can: the heartbeat store creates that directory the first time it touches its file.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

### How to test

```bash
pytest tests/unit_tests/gateway/test_cron_store_path_resolution.py
pytest tests/unit_tests/gateway/
```

13 new tests, all in `test_cron_store_path_resolution.py`. The gateway suite collects 862 on `develop` at `46bbecd2c` and 875 with this branch, 0 collection errors either side, and on a clean run everything passes on both. Compared by node id as a set rather than by total, the difference is exactly the 13 new tests: none removed, none renamed.

Two tests in `test_app_web_handlers.py` fail intermittently on both trees and should be discounted: `test_config_set_saves_claude_while_codex_dependency_is_installing` leaves a background install running past the end of the test, and that thread consumes the `time.monotonic` values `test_optional_dependency_install_times_out_after_one_hour` monkeypatches, so the second dies on `StopIteration`. Neither that module nor `app_web_handlers.py` is touched here. Coverage:

- one test per branch of the resolution order, including the upgrade case that must not break and the precedence when both files exist
- a leftover `cron_jobs.json.lock` does not count as a store, or a workspace whose jobs were removed would pin itself to the legacy path forever
- **`test_the_real_migration_no_longer_orphans_the_store`** calls `_migrate_legacy_workspace` directly rather than imitating it. A hand-rolled copy-and-unlink would keep passing if the migration ever changed destination or stopped deleting the source — the very drift that caused this bug
- six tests for the new logging, since lines that exist only to make a rare failure visible are exactly the code that rots unnoticed. Two pin distinctions rather than messages: that an existing empty store emits no warning at all, and that a present but unreadable one does

All thirteen were checked against the unfixed source first: twelve fail there, every one on an assertion rather than an import or setup error, including both end-to-end cases — so they detect the defect rather than merely accompanying the fix. The thirteenth is the upgrade case, which must keep passing either way.

### Manual verification

Start an instance whose store is in either location and confirm the job count in the log matches the file. On a workspace where the relocation has already run, schedules resume on the next start with no intervention.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [x] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

Four pages under `docs/` print `~/.jiuwenswarm/agent/home/cron_jobs.json`, which a migrated workspace does not have, and are corrected here: `docs/en/ScheduledTasks.md` and `docs/zh/定时任务.md` name it as *the* storage path, `docs/en/InstallGuide.md` and `docs/zh/安装指南.md` list it in the pre-upgrade backup table. These pages live in this repository, so nothing was sent to a separate Doc repository.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #805
- Fixes #2376
<!-- /bot1-related-issues -->

