### PR TITLE
fix(server): select native image input via modality probe

### DIFF
--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -64,6 +64,10 @@ from openjiuwen.harness.factory import (
     _inject_general_purpose_subagent,
     create_deep_agent,
 )
+from openjiuwen.harness.image_modality_probe import (
+    get_cached_image_support,
+    schedule_image_support_probe,
+)
 from openjiuwen.harness.prompts import resolve_language
 from openjiuwen.harness.rails import (
     ModelAnomalyDetectionRail,
@@ -4630,42 +4634,27 @@ class JiuWenSwarmDeepAdapter:
             notice["model_name"] = model_name
         return notice
 
-    @staticmethod
-    def _native_image_support_from_model_name(model_name: str) -> bool | None:
-        normalized = model_name.strip().lower()
-        if not normalized:
-            return None
-
-        if re.search(r"(?:^|[/_:-])glm-[0-9]+(?:\.[0-9]+)*(?:$|[/_:-])", normalized):
-            return False
-        if re.search(r"(?:^|[/_:-])glm-[^/]*v(?:$|[/_.:-])", normalized):
-            return True
-        if any(token in normalized for token in ("vision", "vl", "omni")):
-            return True
-        return None
-
     def _native_image_input_enabled(self, config: dict[str, Any], model: Any | None) -> bool:
-        model_config = getattr(model, "model_config", None)
-        model_name = str(getattr(model_config, "model_name", "") or "").strip()
-        support = self._native_image_support_from_model_name(model_name)
-        if support is False:
-            return False
         configured = config.get("enable_read_image_multimodal")
         if isinstance(configured, bool):
             return configured
-        if support is True:
-            return True
+        if model is not None:
+            support = get_cached_image_support(model)
+            if support is not None:
+                return support
+            schedule_image_support_probe(model)
+        # No verdict yet: caption via the vision model when one is configured,
+        # otherwise attempt native input.
         return self._vision_model_config is None
 
-    def _resolve_enable_read_image_multimodal(
-        self,
-        config: dict[str, Any],
-    ) -> bool | None:
+    @staticmethod
+    def _resolve_enable_read_image_multimodal(config: dict[str, Any]) -> bool | None:
         configured = config.get("enable_read_image_multimodal")
         if isinstance(configured, bool):
             return configured
-        if self._vision_model_config is not None:
-            return False
+        # None means auto: agent-core resolves it from the image modality
+        # probe on each run, keeping the rail and read_file consistent with
+        # _native_image_input_enabled.
         return None
 
     def _apply_model_to_react_agent(self, model: Model) -> None:

--- a/tests/unit_tests/agentserver/test_a2x_client_init.py
+++ b/tests/unit_tests/agentserver/test_a2x_client_init.py
@@ -529,7 +529,7 @@ def test_make_deep_agent_config_resolves_completion_timeout(
     assert deep_cfg.completion_timeout == expected_timeout
 
 
-def test_make_deep_agent_config_disables_read_image_multimodal_with_vision_model(
+def test_make_deep_agent_config_leaves_read_image_multimodal_auto_with_vision_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     adapter = JiuWenSwarmDeepAdapter()
@@ -554,7 +554,8 @@ def test_make_deep_agent_config_disables_read_image_multimodal_with_vision_model
             rails=[],
         )
 
-    assert deep_cfg.enable_read_image_multimodal is False
+    # None means auto: agent-core resolves it from the image modality probe.
+    assert deep_cfg.enable_read_image_multimodal is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agentserver/test_native_image_input_probe.py
+++ b/tests/unit_tests/agentserver/test_native_image_input_probe.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from openjiuwen.harness import image_modality_probe
+from openjiuwen.harness.image_modality_probe import (
+    probe_cache_key,
+    reset_image_support_cache,
+)
+
+from jiuwenswarm.server.runtime.agent_adapter import interface_deep as interface_module
+from jiuwenswarm.server.runtime.agent_adapter.interface_deep import JiuWenSwarmDeepAdapter
+
+
+@pytest.fixture(autouse=True)
+def _clean_probe_cache():
+    reset_image_support_cache()
+    yield
+    reset_image_support_cache()
+
+
+def _make_llm(model_name: str = "test-model", api_base: str = "https://api.example/v1"):
+    return SimpleNamespace(
+        model_client_config=SimpleNamespace(api_base=api_base),
+        model_config=SimpleNamespace(model_name=model_name),
+    )
+
+
+def _make_vision_config() -> interface_module.VisionModelConfig:
+    return interface_module.VisionModelConfig(
+        api_key="vision-key",
+        base_url="https://vision.example/v1",
+        model="vision-model",
+    )
+
+
+def _seed_verdict(llm, supported: bool) -> None:
+    image_modality_probe._probe_results[probe_cache_key(llm)] = supported
+
+
+def test_cached_true_wins_over_configured_vision_model() -> None:
+    adapter = JiuWenSwarmDeepAdapter()
+    adapter._vision_model_config = _make_vision_config()
+    llm = _make_llm("gpt-4o")
+    _seed_verdict(llm, True)
+
+    assert adapter._native_image_input_enabled({}, llm) is True
+
+
+def test_cached_false_wins_without_vision_model() -> None:
+    adapter = JiuWenSwarmDeepAdapter()
+    llm = _make_llm("routed-vllm-model")
+    _seed_verdict(llm, False)
+
+    assert adapter._native_image_input_enabled({}, llm) is False
+
+
+def test_explicit_config_wins_over_cached_verdict() -> None:
+    adapter = JiuWenSwarmDeepAdapter()
+    llm = _make_llm()
+
+    _seed_verdict(llm, False)
+    assert (
+        adapter._native_image_input_enabled({"enable_read_image_multimodal": True}, llm)
+        is True
+    )
+
+    _seed_verdict(llm, True)
+    assert (
+        adapter._native_image_input_enabled({"enable_read_image_multimodal": False}, llm)
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_verdict_falls_back_and_schedules_probe() -> None:
+    adapter = JiuWenSwarmDeepAdapter()
+    llm = _make_llm()
+
+    assert adapter._native_image_input_enabled({}, llm) is True
+    assert probe_cache_key(llm) in image_modality_probe._probe_tasks
+
+    adapter._vision_model_config = _make_vision_config()
+    assert adapter._native_image_input_enabled({}, llm) is False
+
+
+@pytest.mark.asyncio
+async def test_model_none_falls_back_without_scheduling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = JiuWenSwarmDeepAdapter()
+    scheduled: list[object] = []
+    monkeypatch.setattr(
+        interface_module, "schedule_image_support_probe", scheduled.append
+    )
+
+    assert adapter._native_image_input_enabled({}, None) is True
+    adapter._vision_model_config = _make_vision_config()
+    assert adapter._native_image_input_enabled({}, None) is False
+    assert scheduled == []


### PR DESCRIPTION
Paired: [GitHub #2479](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2479) ↔ [GitCode !4588](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4588)

**What type of PR is this?**
/kind bug


**What does this PR do / why do we need it**:
* Image attachments were routed between native model input and two-pass captioning by a model-name heuristic (`_native_image_support_from_model_name`: GLM regexes plus unanchored `"vision"`/`"vl"`/`"omni"` substrings). Names tell nothing reliable about modality: `gpt-4o`/`claude-*`/`gemini-*` matched nothing and were silently demoted to captioning whenever a dedicated `models.vision` was configured, any name containing `vl` (e.g. `vllm` routes) was declared vision-capable and received raw image blocks, and a heuristic `False` overrode an explicit `enable_read_image_multimodal: true`.
* This PR deletes the heuristic and derives the decision from agent-core's image modality probe (`openjiuwen.harness.image_modality_probe`), which sends one tiny generated image per `(api_base, model_name)` and caches the verdict. `_native_image_input_enabled` now uses the cached verdict and schedules a background probe when there is none yet; until the verdict lands it keeps the previous conservative fallback (captioning when a vision model is configured, native attempt otherwise).
* `_resolve_enable_read_image_multimodal` no longer forces `False` when a vision model is configured; it returns `None` (auto) so agent-core resolves the flag from the same probe cache. This keeps the per-request selector, the multimodal rail, and `read_file` consistent — if they disagreed, the native path could be selected while the rail strips image blocks, losing the images entirely.
* Explicit `enable_read_image_multimodal` config now always wins over detection, matching agent-core's semantics.
* The two-pass captioning path is unchanged and remains the fallback for genuinely image-blind models.


**Which issue(s) this PR fixes**:
Fixes #2476 


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* New unit test module `tests/unit_tests/agentserver/test_native_image_input_probe.py` (5 tests): cached probe verdict `True` wins over a configured vision model (the demotion bug), cached `False` wins without a vision model (the `vllm` false-positive bug), explicit config wins over a contrary cached verdict, no-verdict falls back conservatively and schedules a background probe, and `model=None` falls back without scheduling.
* Updated `tests/unit_tests/agentserver/test_a2x_client_init.py`: with a vision model configured and no explicit setting, `DeepAgentConfig.enable_read_image_multimodal` is now `None` (auto) instead of forced `False`.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2476
<!-- /bot1-related-issues -->
