### PR TITLE
feat(gateway): deliver ask_user questions to every channel as plain text

### DIFF
--- a/jiuwenswarm/gateway/channel_manager/channel_manager.py
+++ b/jiuwenswarm/gateway/channel_manager/channel_manager.py
@@ -31,6 +31,129 @@ class ChannelEvent:
     user_id: str
 
 
+def conversation_key_of(msg: "Message") -> str:
+    """The scope a pending ``ask_user`` question belongs to.
+
+    The session is the right grain: the outbound question and the reply that
+    answers it share one, and two sessions on the same channel must not steal
+    each other's answers. ``chat_id`` is the fallback for a channel that has
+    not resolved a session yet.
+    """
+    session_id = str(getattr(msg, "session_id", "") or "").strip()
+    if session_id:
+        return session_id
+    return str(getattr(msg, "chat_id", "") or "").strip()
+
+
+def prepare_ask_user_outbound(
+    msg: "Message",
+    *,
+    channel_id: str | None = None,
+) -> "Message | None":
+    """Rewrite an ``ask_user`` question for a text-only channel.
+
+    Does **not** register a pending question -- that happens only after a
+    successful ``channel.send``, so a delivery failure cannot leave a record
+    that steals a later ``1``/label reply.
+
+    ``channel_id`` is the physical delivery channel (fan-out target); when
+    omitted, ``msg.channel_id`` is used.
+
+    Returns the message unchanged when it is not a question or the channel
+    renders its own, and ``None`` when the event carries nothing worth sending.
+    """
+    try:
+        from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.ask_user_notice import (
+            as_text_message,
+            channel_renders_questions,
+        )
+    except Exception:  # noqa: BLE001 - never break dispatch over a fallback
+        logger.exception("[ChannelManager] ask_user fallback unavailable")
+        return msg
+
+    target_channel = str(
+        channel_id if channel_id is not None else getattr(msg, "channel_id", "") or ""
+    )
+    try:
+        return as_text_message(msg, channel_id=channel_id)
+    except Exception:  # noqa: BLE001 - a broken fallback must not drop traffic
+        logger.exception("[ChannelManager] ask_user fallback failed")
+        # Rich channels keep the original event. Text-only channels must not
+        # receive the raw structured payload: they drop it, and with no pending
+        # record the tool stays hung with nothing to answer.
+        if channel_renders_questions(target_channel):
+            return msg
+        return None
+
+
+def register_ask_user_pending(
+    msg: "Message",
+    *,
+    channel_id: str | None = None,
+) -> None:
+    """Record a pending question after the text notice was successfully sent."""
+    try:
+        from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.ask_user_notice import (
+            channel_renders_questions,
+            parse_question,
+        )
+        from jiuwenswarm.gateway.routing.pending_question import PENDING_QUESTIONS
+    except Exception:  # noqa: BLE001 - never break dispatch over a fallback
+        logger.exception("[ChannelManager] ask_user pending registry unavailable")
+        return
+
+    try:
+        target_channel = str(
+            channel_id if channel_id is not None else getattr(msg, "channel_id", "") or ""
+        )
+        if channel_renders_questions(target_channel):
+            return
+        parsed = parse_question(getattr(msg, "payload", None))
+        if parsed is None:
+            return
+        PENDING_QUESTIONS.register(
+            request_id=parsed.request_id,
+            channel_id=target_channel,
+            conversation_key=conversation_key_of(msg),
+            options=parsed.options,
+            source=parsed.source,
+            question=parsed.question,
+        )
+    except Exception:  # noqa: BLE001 - a broken registry must not drop traffic
+        logger.exception("[ChannelManager] ask_user pending registration failed")
+
+
+def _channel_send_delivered(result: Any) -> bool:
+    """Whether ``channel.send`` reported a real delivery.
+
+    Channels that implement the ask_user delivery contract return ``True`` only
+    after a message was handed to the platform API. Legacy ``send()`` returns
+    ``None``; that must not count as success, or a skipped send (bot down,
+    client missing, swallowed HTTP error) would register a pending question the
+    human never saw.
+    """
+    return result is True
+
+
+async def deliver_with_ask_user_fallback(
+    channel: Any,
+    msg: "Message",
+    *,
+    channel_id: str | None = None,
+    **send_kwargs: Any,
+) -> None:
+    """Prepare, send, then register a text ``ask_user`` notice on success."""
+    target_channel = str(
+        channel_id if channel_id is not None else getattr(msg, "channel_id", "") or ""
+    )
+    outbound = prepare_ask_user_outbound(msg, channel_id=target_channel)
+    if outbound is None:
+        return
+    result = await channel.send(outbound, **send_kwargs)
+    if outbound is not msg and _channel_send_delivered(result):
+        register_ask_user_pending(msg, channel_id=target_channel)
+
+
 def _build_mention_target(names: list[str]) -> dict[str, Any]:
     """构造 mention intent 的 fan_out 目标 dict（点名指定 member_names）。"""
     return {
@@ -407,7 +530,9 @@ class ChannelManager(ABC):
                 )
                 if channel:
                     try:
-                        await channel.send(msg)
+                        # text-only channels get ask_user as numbered text;
+                        # register only after a successful send.
+                        await deliver_with_ask_user_fallback(channel, msg)
                     except Exception as e:
                         logger.error("send to channel %s: %s", msg.channel_id, e, exc_info=True)
                         if msg.id and msg.id.startswith("cron-push-"):

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/dingtalk/dingtalk_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/dingtalk/dingtalk_connect.py
@@ -15,6 +15,9 @@ import httpx
 from jiuwenswarm.gateway.channel_manager.base import RobotMessageRouter, BaseChannel
 from jiuwenswarm.gateway.channel_manager.im_platforms.dingtalk.dingtalk_file_service import DingTalkFileService
 from jiuwenswarm.common.schema.message import Message, ReqMethod
+from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.text_delivery import (
+    is_stream_intermediate,
+)
 from jiuwenswarm.common.utils import get_agent_workspace_dir
 from jiuwenswarm.gateway.routing.keys import DeliveryTarget
 from jiuwenswarm.gateway.routing.session_sharing import RoutingTarget
@@ -308,6 +311,9 @@ class DingTalkChannel(BaseChannel):
             timestamp=time.time(),
             ok=True,
             req_method=ReqMethod.CHAT_SEND,
+            # chat.ask_user_question is only produced as a stream chunk, so
+            # a non-streaming request never sees the question at all.
+            is_stream=True,
             chat_id=conversation_id,
             metadata=metadata,
         )
@@ -548,27 +554,29 @@ class DingTalkChannel(BaseChannel):
 
         return url, data
 
-    async def _send_http_request(self, url: str, data: dict, token: str, chat_id: str) -> None:
-        """发送HTTP请求"""
+    async def _send_http_request(self, url: str, data: dict, token: str, chat_id: str) -> bool:
+        """发送HTTP请求. Returns True only when the platform accepts the message."""
         headers = {"x-acs-dingtalk-access-token": token}
 
         if not self._http:
             logger.warning("钉钉HTTP客户端未初始化，无法发送消息")
-            return
+            return False
 
         try:
             resp = await self._http.post(url, json=data, headers=headers)
             if resp.status_code != 200:
                 logger.error(f"钉钉消息发送失败: {resp.text}")
-            else:
-                logger.debug("钉钉消息已发送至 %s", chat_id)
+                return False
+            logger.debug("钉钉消息已发送至 %s", chat_id)
+            return True
         except Exception as e:
             logger.error(f"发送钉钉消息时出错: {e}")
+            return False
 
     async def send(
         self, msg: Message,
         *, routing_target: RoutingTarget | None = None,
-    ) -> None:
+    ) -> bool:
         """通过钉钉发送消息"""
         # 提取事件类型
         payload = msg.payload if isinstance(msg.payload, dict) else {}
@@ -577,26 +585,35 @@ class DingTalkChannel(BaseChannel):
         # 处理文件发送事件（chat.media 与 chat.file 统一走文件发送路径）
         if event_type in ("chat.file", "chat.media"):
             await self._send_file_message(msg)
-            return
+            # File delivery reports success through its own path; treat completion
+            # without raise as delivered so callers that check the bool stay sane.
+            return True
+
+        # the inbound request now streams so ask_user is emitted at all,
+        # which also turns on reasoning and tool chunks. They are dropped here,
+        # deliberately after the file branch above: a file event carries no text
+        # content and must keep reaching its own delivery path.
+        if is_stream_intermediate(msg):
+            return False
 
         # 提取内容
         content = self._extract_message_content(msg)
         if not content:
             logger.warning("钉钉发送: 在 msg.params 或 msg.payload 中未找到内容")
-            return
+            return False
         if not content.strip():
             logger.debug("钉钉发送: 跳过纯空白流式内容")
-            return
+            return False
 
         # 提取聊天ID
         chat_id = self._extract_chat_id(msg)
         if not chat_id:
             logger.warning("钉钉发送: 在消息中未找到 chat_id 或 session_id")
-            return
+            return False
 
         token = await self._get_access_token()
         if not token:
-            return
+            return False
 
         # 构建请求
         metadata = msg.metadata or {}
@@ -604,12 +621,12 @@ class DingTalkChannel(BaseChannel):
         open_conversation_id = metadata.get("conversation_id", "")
         url, data = self._build_send_request(chat_id, content, conversation_type, open_conversation_id)
 
-        # 发送HTTP请求
-        await self._send_http_request(url, data, token, chat_id)
+        delivered = await self._send_http_request(url, data, token, chat_id)
 
         # chat.final 兜底文件发送
         if event_type == "chat.final":
             await self._send_fallback_files(msg, content)
+        return delivered
 
     # ==================== 文件下载处理方法 ====================
 

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/discord/discord_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/discord/discord_connect.py
@@ -8,6 +8,9 @@ from typing import Any, Callable
 
 from jiuwenswarm.gateway.channel_manager.base import BaseChannel, ChannelMetadata, RobotMessageRouter
 from jiuwenswarm.common.schema.message import EventType, Message, ReqMethod
+from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.text_delivery import (
+    is_stream_intermediate,
+)
 from jiuwenswarm.gateway.routing.keys import DeliveryTarget
 from jiuwenswarm.gateway.routing.session_sharing import RoutingTarget
 
@@ -113,18 +116,23 @@ class DiscordChannel(BaseChannel):
                 logger.warning("DiscordChannel stop failed: %s", e)
         logger.info("DiscordChannel stopped")
 
-    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> None:
+    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> bool:
         if self._client is None or self._client.is_closed():
-            return
+            return False
+        # the inbound request streams so ask_user is emitted at all, which
+        # also turns on reasoning and tool chunks. Discord posts one message at
+        # a time, so the intermediates are dropped here.
+        if is_stream_intermediate(msg):
+            return False
 
         content = self._extract_outgoing_text(msg)
         if not content:
-            return
+            return False
 
         target_channel_id = self._extract_target_channel_id(msg)
         if target_channel_id is None:
             logger.warning("DiscordChannel send skipped: missing target channel id")
-            return
+            return False
 
         channel = self._client.get_channel(target_channel_id)
         if channel is None:
@@ -132,12 +140,14 @@ class DiscordChannel(BaseChannel):
                 channel = await self._client.fetch_channel(target_channel_id)
             except Exception as e:  # noqa: BLE001
                 logger.warning("DiscordChannel fetch channel failed: %s", e)
-                return
+                return False
 
         try:
             await channel.send(content)
         except Exception as e:  # noqa: BLE001
             logger.warning("DiscordChannel send failed: %s", e)
+            return False
+        return True
 
     async def _handle_discord_message(self, message: Any) -> None:
         if not self._running:
@@ -197,6 +207,9 @@ class DiscordChannel(BaseChannel):
             timestamp=time.time(),
             ok=True,
             req_method=ReqMethod.CHAT_SEND,
+            # chat.ask_user_question is only produced as a stream chunk, so
+            # a non-streaming request never sees the question at all.
+            is_stream=True,
             metadata={
                 "discord_user_id": author_id,
                 "discord_username": author_name,

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/platform_adapter/ask_user_notice.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/platform_adapter/ask_user_notice.py
@@ -1,0 +1,225 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Render an ``ask_user`` question as plain text for channels with no card.
+
+The ``ask_user`` tool emits ``chat.ask_user_question``. Only Feishu renders it, as
+an interactive card; the other eight IM platforms have no handler, so the event
+reaches ``send()`` and produces nothing. The agent is meanwhile blocked on the
+tool result -- which makes this a silent hang, not a missing notification.
+
+This module turns the question into a numbered message that any text channel
+already knows how to deliver. It is deliberately the *outbound* half only: the
+reply comes back as an ordinary message and is correlated separately, and the
+resume itself uses streaming ``chat.send`` with ``source="ask_user_interrupt"``
+-- the same path Web and the CLI use. ``chat.user_answer`` does not resume a
+blocked ask_user tool call on the deep adapter.
+
+Do not confuse this with the digital-avatar follow-up in ``im_pipeline``. That
+mechanism is triggered by a regex on the model's own text, and resumes by
+injecting the answer as a *new user message*. An ``ask_user`` answer must
+instead satisfy a tool call keyed by ``tool_call_id``; routing one through the
+other is the failure recorded at ``interrupt_helpers.py:304-312``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Channels that render a question natively and must not receive the text form.
+# Feishu draws a card; the rest are rich clients with their own question UI.
+_RICH_RENDERERS = frozenset({"feishu", "web", "tui", "acp", "ssh"})
+
+# Metadata keys that bind a message into an in-flight stream reply. Carried over
+# from the compaction notice: leaving them on a standalone message makes WeCom
+# fold it into the streaming answer and makes Feishu treat it as the chat.final
+# that closes the card buffer.
+_STREAM_BINDING_META_KEYS = frozenset({
+    "wecom_req_id",
+})
+
+_EVENT_SUFFIX = "chat.ask_user_question"
+
+# A question with more options than this is not usable as a numbered list in a
+# chat window; the text still lists them, but it is worth a log line.
+_MANY_OPTIONS = 12
+
+_DEFAULT_SOURCE = "ask_user_interrupt"
+
+
+@dataclass(frozen=True)
+class ParsedQuestion:
+    """The parts of an ``ask_user`` payload this module needs."""
+
+    request_id: str
+    question: str
+    #: Option labels, in the order presented. Empty means free-text.
+    options: tuple[str, ...]
+    header: str = ""
+    source: str = _DEFAULT_SOURCE
+
+
+def channel_renders_questions(channel_id: Any) -> bool:
+    """Whether this channel draws its own question UI."""
+    return str(channel_id or "").strip().lower() in _RICH_RENDERERS
+
+
+def parse_question(payload: Any) -> Optional[ParsedQuestion]:
+    """Pull the first question out of an ``ask_user`` payload.
+
+    Only the first is used, matching Feishu's card: the tool asks one thing at a
+    time in practice, and a numbered list of two interleaved option sets could
+    not be answered unambiguously by ``2``.
+
+    A missing ``request_id`` is rejected: without it the resume cannot satisfy
+    the blocked tool call.
+    """
+    if not isinstance(payload, Mapping):
+        return None
+    request_id = str(payload.get("request_id") or "").strip()
+    if not request_id:
+        return None
+    questions = payload.get("questions")
+    if not isinstance(questions, (list, tuple)) or not questions:
+        return None
+    first = questions[0]
+    if not isinstance(first, Mapping):
+        return None
+
+    text = str(first.get("question") or "").strip()
+    labels: list[str] = []
+    raw_options = first.get("options")
+    if isinstance(raw_options, (list, tuple)):
+        for option in raw_options:
+            if isinstance(option, Mapping):
+                label = str(option.get("label") or "").strip()
+            else:
+                label = str(option or "").strip()
+            if label:
+                labels.append(label)
+
+    if not text and not labels:
+        return None
+    if len(labels) > _MANY_OPTIONS:
+        logger.info(
+            "[AskUserNotice] question has %d options; a numbered reply will be awkward",
+            len(labels),
+        )
+    source = str(payload.get("source") or _DEFAULT_SOURCE).strip() or _DEFAULT_SOURCE
+    return ParsedQuestion(
+        request_id=request_id,
+        question=text,
+        options=tuple(labels),
+        header=str(first.get("header") or "").strip(),
+        source=source,
+    )
+
+
+def format_question_notice(parsed: ParsedQuestion) -> str:
+    """Render the question as a numbered prompt.
+
+    A free-text question says what is expected instead of printing an empty
+    list -- an unanswered question is the bug this feature exists to fix, and a
+    prompt with nothing to reply to reproduces it in a new way.
+    """
+    lines: list[str] = []
+    if parsed.header:
+        lines.append(f"【{parsed.header}】")
+    if parsed.question:
+        lines.append(parsed.question)
+
+    if parsed.options:
+        lines.append("")
+        for index, label in enumerate(parsed.options, start=1):
+            lines.append(f"{index}. {label}")
+        lines.append("")
+        lines.append("Reply with the number of your choice.")
+    else:
+        lines.append("")
+        lines.append("Reply to this message with your answer.")
+    return "\n".join(lines).strip()
+
+
+def as_text_message(msg: Any, *, channel_id: Any = None) -> Any:
+    """Rewrite an ``ask_user`` event into a plain-text message, or drop it.
+
+    Returns the original message when it is not a question event or when the
+    channel renders one natively, a rewritten copy shaped like an ordinary
+    ``chat.final`` text reply, or ``None`` when the payload carries no question
+    worth sending.
+
+    ``channel_id`` overrides ``msg.channel_id`` for the rich-renderer check so
+    team fan-out can rewrite for the physical delivery channel even when the
+    originator channel draws its own card.
+
+    Content alone is not enough. WeCom and WeChat only deliver ``CHAT_FINAL`` /
+    plain ``res`` messages, and stream-bound ids would fold the question into the
+    in-flight answer, so the rewrite sets the event type, gives the message its
+    own id, and strips the binding keys.
+    """
+    payload = getattr(msg, "payload", None)
+    if not isinstance(payload, Mapping):
+        return msg
+    event_type = str(payload.get("event_type") or getattr(msg, "event_type", "") or "")
+    if not event_type.endswith(_EVENT_SUFFIX):
+        return msg
+
+    target_channel = channel_id if channel_id is not None else getattr(msg, "channel_id", None)
+    if channel_renders_questions(target_channel):
+        return msg
+
+    parsed = parse_question(payload)
+    if parsed is None:
+        return None
+
+    notice = format_question_notice(parsed)
+    if not notice:
+        return None
+
+    try:
+        from dataclasses import replace
+
+        from jiuwenswarm.common.schema.message import EventType
+
+        orig_id = str(getattr(msg, "id", "") or "msg")
+        meta = getattr(msg, "metadata", None)
+        if isinstance(meta, Mapping):
+            cleaned_meta = {
+                k: v for k, v in meta.items() if k not in _STREAM_BINDING_META_KEYS
+            }
+        else:
+            cleaned_meta = {}
+        # WeChat clears its delta accumulator on every CHAT_FINAL; mark this as a
+        # standalone line so the in-flight answer survives the question.
+        cleaned_meta["standalone_notice"] = True
+        # Carried so the reply can be correlated back to this exact question.
+        cleaned_meta["ask_user_request_id"] = parsed.request_id
+
+        return replace(
+            msg,
+            id=f"{orig_id}-question",
+            type="res",
+            event_type=EventType.CHAT_FINAL,
+            params={"content": notice},
+            payload={
+                "event_type": EventType.CHAT_FINAL.value,
+                "content": notice,
+            },
+            metadata=cleaned_meta,
+        )
+    except Exception:  # noqa: BLE001 - never break delivery over a fallback
+        logger.exception("[AskUserNotice] failed to rewrite question for %s", target_channel)
+        return None
+
+
+__all__ = [
+    "ParsedQuestion",
+    "as_text_message",
+    "channel_renders_questions",
+    "format_question_notice",
+    "parse_question",
+]

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/platform_adapter/text_delivery.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/platform_adapter/text_delivery.py
@@ -1,0 +1,88 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Suppress stream intermediates on channels that post one message at a time.
+
+``chat.ask_user_question`` is only emitted as a stream chunk, so a channel that
+requests a non-streaming RPC never sees the question at all and the
+plain-text fallback cannot render it. Turning streaming on fixes that and creates a second problem: deltas,
+reasoning and tool activity start arriving too, and a channel with no
+edit-in-place UI would post each one as its own message.
+
+This is a **denylist**, not an allowlist, and that is deliberate. These four
+channels each deliver a slightly different set today -- Slack drops only
+deltas, WhatsApp drops them conditionally, DingTalk routes files before text,
+Discord filters nothing -- and none of them can be verified live here. Dropping
+a message a channel used to deliver is a worse failure than letting one noisy
+event through, so the rule only removes what streaming newly introduces and
+leaves every existing behaviour untouched.
+
+Telegram uses an allowlist instead (``should_deliver_telegram_outbound``). That
+divergence is intentional for now: it is the one channel with a live round trip
+behind it, so its stricter rule is backed by evidence the others do not yet
+have. Converging the two is worth doing once the rest have been tested for
+real.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jiuwenswarm.common.schema.message import EventType
+
+#: Events that exist only because the request streams. None of these was ever
+#: delivered to a text-only channel before streaming was turned on for
+#: these channels, so dropping them restores the previous experience
+#: rather than changing it.
+STREAM_INTERMEDIATE_EVENTS = frozenset({
+    EventType.CHAT_DELTA,
+    EventType.CHAT_REASONING,
+    EventType.CHAT_RETRACT,
+    EventType.CHAT_TOOL_CALL,
+    EventType.CHAT_TOOL_UPDATE,
+    EventType.CHAT_TOOL_RESULT,
+    EventType.CHAT_USAGE_METADATA,
+    EventType.CHAT_USAGE_SUMMARY,
+    EventType.CHAT_SYMPHONY_STATUS,
+    EventType.CHAT_PROCESSING_STATUS,
+    EventType.CHAT_SUBTASK_UPDATE,
+    EventType.CHAT_EVOLUTION_STATUS,
+    # The raw question. The plain-text fallback rewrites it into a
+    # chat.final before send() is reached, so seeing it here means the
+    # rewrite declined -- and the payload
+    # is a structured question, not a sentence, so posting it would be worse
+    # than saying nothing.
+    EventType.CHAT_ASK_USER_QUESTION,
+})
+
+_STREAM_INTERMEDIATE_VALUES = frozenset(
+    event.value for event in STREAM_INTERMEDIATE_EVENTS
+)
+
+
+def is_stream_intermediate(msg: Any) -> bool:
+    """Whether this outbound message is stream noise a text channel should skip.
+
+    Reads the event type from the message and from ``payload`` because the two
+    do not always agree: a rewritten message carries the enum, while a raw
+    forwarded chunk may only have the string in its payload.
+    """
+    event_type = getattr(msg, "event_type", None)
+    if event_type in STREAM_INTERMEDIATE_EVENTS:
+        return True
+
+    value = getattr(event_type, "value", None) or event_type
+    if isinstance(value, str) and value in _STREAM_INTERMEDIATE_VALUES:
+        return True
+
+    payload = getattr(msg, "payload", None)
+    if isinstance(payload, dict):
+        payload_type = payload.get("event_type")
+        if isinstance(payload_type, str) and payload_type in _STREAM_INTERMEDIATE_VALUES:
+            return True
+    return False
+
+
+__all__ = [
+    "STREAM_INTERMEDIATE_EVENTS",
+    "is_stream_intermediate",
+]

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/slack/slack_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/slack/slack_connect.py
@@ -11,6 +11,9 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 
 from jiuwenswarm.common.schema.message import EventType, Message, ReqMethod
+from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.text_delivery import (
+    is_stream_intermediate,
+)
 from jiuwenswarm.gateway.channel_manager.base import (
     BaseChannel,
     ChannelMetadata,
@@ -126,20 +129,23 @@ class SlackChannel(BaseChannel):
 
     async def send(
         self, msg: Message, *, routing_target: RoutingTarget | None = None
-    ) -> None:
+    ) -> bool:
         if self._client is None:
-            return
-        if msg.event_type == EventType.CHAT_DELTA:
-            return
+            return False
+        # the inbound request streams so ask_user is emitted at all, which
+        # also turns on reasoning and tool chunks. Slack posts one message at a
+        # time, so the intermediates are dropped here.
+        if is_stream_intermediate(msg):
+            return False
 
         content = self._extract_outgoing_text(msg)
         if not content:
-            return
+            return False
 
         channel_id, thread_ts = self._extract_delivery(msg, routing_target)
         if not channel_id:
             logger.warning("SlackChannel send skipped: missing target channel id")
-            return
+            return False
 
         for chunk in self._split_text(content):
             kwargs: dict[str, Any] = {"channel": channel_id, "text": chunk}
@@ -149,7 +155,8 @@ class SlackChannel(BaseChannel):
                 await self._client.chat_postMessage(**kwargs)
             except Exception as exc:  # noqa: BLE001
                 logger.warning("SlackChannel send failed: %s", exc)
-                return
+                return False
+        return True
 
     async def _handle_app_mention(
         self, event: dict[str, Any], body: dict[str, Any]
@@ -229,6 +236,9 @@ class SlackChannel(BaseChannel):
             chat_id=channel_id,
             user_id=user_id,
             req_method=ReqMethod.CHAT_SEND,
+            # chat.ask_user_question is only produced as a stream chunk, so
+            # a non-streaming request never sees the question at all.
+            is_stream=True,
             metadata={
                 "user_id": user_id,
                 "slack_event_id": event_id,

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/telegram/telegram_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/telegram/telegram_connect.py
@@ -12,11 +12,85 @@ from typing import Any, Callable
 import logging
 
 from jiuwenswarm.gateway.channel_manager.base import BaseChannel, ChannelMetadata, RobotMessageRouter
-from jiuwenswarm.common.schema.message import Message, ReqMethod
+from jiuwenswarm.common.schema.message import EventType, Message, ReqMethod
 from jiuwenswarm.gateway.routing.keys import DeliveryTarget
 from jiuwenswarm.gateway.routing.session_sharing import RoutingTarget
 
 logger = logging.getLogger(__name__)
+
+# Telegram has no edit-in-place streaming UI. AgentServer must still be called
+# with is_stream=True so HITL events (ask_user, etc.) are emitted as chunks, but
+# only these final-like events are forwarded as Bot messages.
+_TELEGRAM_DELIVER_EVENTS = frozenset({
+    EventType.CHAT_FINAL,
+    EventType.CHAT_ERROR,
+    EventType.CHAT_INTERRUPT_RESULT,
+    EventType.HEARTBEAT_RELAY,
+    EventType.CHAT_FILE,
+    EventType.CHAT_MEDIA,
+    EventType.TEAM_MESSAGE,
+})
+
+
+def should_deliver_telegram_outbound(msg: Message) -> bool:
+    """Whether this outbound message should become a Telegram Bot API send.
+
+    Stream noise (deltas, tool calls, raw ask_user_question) is dropped here.
+    The plain-text fallback rewrites ask_user into ``chat.final`` before
+    ``send()``, so the numbered question still gets through as a final.
+    """
+    event_type = getattr(msg, "event_type", None)
+    if event_type in _TELEGRAM_DELIVER_EVENTS:
+        pass
+    elif event_type is None and getattr(msg, "type", None) == "res":
+        # Unary / plain response envelope without an event_type.
+        pass
+    else:
+        return False
+
+    content = (
+        (getattr(msg, "params", None) or {}).get("content")
+        or (getattr(msg, "payload", None) or {}).get("content")
+        or ""
+    )
+    if isinstance(content, dict):
+        content = content.get("output", "") or ""
+    return bool(str(content).strip())
+
+
+def build_telegram_inbound_message(
+    *,
+    message_id: str,
+    session_id: str,
+    text: str,
+    chat_id: int,
+    user_id: int,
+    username: str | None,
+    is_group_chat: bool,
+) -> Message:
+    """Build the gateway Message for an inbound Telegram chat.send.
+
+    ``is_stream=True`` is required so AgentServer emits stream chunks such as
+    ``chat.ask_user_question``. Outbound filtering keeps the chat quiet.
+    """
+    return Message(
+        id=str(message_id),
+        type="req",
+        channel_id="telegram",
+        session_id=session_id,
+        params={"content": text, "query": text},
+        timestamp=time.time(),
+        ok=True,
+        req_method=ReqMethod.CHAT_SEND,
+        is_stream=True,
+        metadata={
+            "chat_id": chat_id,
+            "user_id": user_id,
+            "message_id": message_id,
+            "username": username,
+            "is_group_chat": is_group_chat,
+        },
+    )
 
 try:
     from telegram import Update
@@ -155,24 +229,33 @@ class TelegramChannel(BaseChannel):
 
         logger.info("Telegram Bot 已停止")
 
-    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> None:
+    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> bool:
         """通过 Telegram 发送消息."""
         if not self._application or not self._running:
             logger.warning("Telegram Bot not initialized or not running")
-            return
+            return False
+
+        # Drop stream intermediates; only finals / errors / ask_user text notices.
+        if not should_deliver_telegram_outbound(msg):
+            logger.debug(
+                "Telegram send: skip event_type=%s type=%s",
+                getattr(msg, "event_type", None),
+                getattr(msg, "type", None),
+            )
+            return False
 
         try:
             # 从 session_id 或 metadata 获取 chat_id
             chat_id = self._get_chat_id_from_message(msg)
             if not chat_id:
                 logger.warning("Telegram send: 无法确定 chat_id")
-                return
+                return False
 
             # 提取消息内容
             content = self._extract_content(msg)
             if not content:
                 logger.warning("Telegram send: content 为空，跳过发送")
-                return
+                return False
 
             # 发送消息
             parse_mode = (
@@ -199,9 +282,11 @@ class TelegramChannel(BaseChannel):
                     raise
 
             logger.debug("Telegram message sent to chat_id=%s", chat_id)
+            return True
 
         except Exception as e:
             logger.error(f"Error sending Telegram message: {type(e).__name__}: {e}")
+            return False
 
     def _get_chat_id_from_message(self, msg: Message) -> int | None:
         """从 Message 中提取 chat_id."""
@@ -355,23 +440,14 @@ class TelegramChannel(BaseChannel):
                 session_id = f"telegram_{chat_id}"
                 self._chat_sessions[chat_id] = session_id
 
-            # 创建 Message 对象
-            user_message = Message(
-                id=str(message_id),
-                type="req",
-                channel_id=self.channel_id,
+            user_message = build_telegram_inbound_message(
+                message_id=str(message_id),
                 session_id=session_id,
-                params={"content": text, "query": text},
-                timestamp=time.time(),
-                ok=True,
-                req_method=ReqMethod.CHAT_SEND,
-                metadata={
-                    "chat_id": chat_id,
-                    "user_id": user_id,
-                    "message_id": message_id,
-                    "username": update.effective_user.username,
-                    "is_group_chat": is_group_chat,
-                },
+                text=text,
+                chat_id=chat_id,
+                user_id=user_id,
+                username=update.effective_user.username,
+                is_group_chat=is_group_chat,
             )
 
             # 发送到 Gateway 或 Router

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/wechat/wechat_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/wechat/wechat_connect.py
@@ -469,16 +469,18 @@ class WechatChannel(BaseChannel):
             raise RuntimeError("WechatChannel HTTP client is not initialized")
         return http
 
-    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> None:
+    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> bool:
         """delta 聚合；enable_streaming 时与原先一致：工具调用/结果会即时下发并在边界冲刷 delta；关闭时仅 chat.final / interrupt 等完结事件合并下发（对齐飞书非流式）。"""
         if not self._http or not self.config.bot_token:
             logger.warning("WechatChannel 未就绪，跳过发送")
-            return
+            return False
 
         streaming = bool(self.config.enable_streaming)
+        meta = getattr(msg, "metadata", None)
+        standalone_notice = isinstance(meta, dict) and bool(meta.get("standalone_notice"))
 
         if msg.event_type == EventType.CHAT_PROCESSING_STATUS:
-            return
+            return False
 
         if msg.event_type == EventType.HEARTBEAT_RELAY:
             user_id = self._extract_platform_user_id(msg)
@@ -486,18 +488,19 @@ class WechatChannel(BaseChannel):
                 logger.warning(
                     "WechatChannel 心跳未发送：无有效用户 ID（需先发消息或携带 wechat_user_id/reply_to_user_id）"
                 )
-                return
+                return False
             content = self._extract_content(msg)
             if content:
                 if await self._should_skip_due_to_send_limit(msg):
                     self._stash_overflow_content(msg, content)
-                    return
+                    return False
                 await self._send_text_chunks_to_user(msg, content)
-            return
+                return True
+            return False
 
         if msg.event_type == EventType.CHAT_TOOL_CALL:
             if not streaming:
-                return
+                return False
             flushed = self._take_accumulated_delta(msg)
             payload = msg.payload if isinstance(msg.payload, dict) else {}
             tool_call_str = format_tool_call_message(payload)
@@ -506,40 +509,41 @@ class WechatChannel(BaseChannel):
             )
             if await self._should_skip_due_to_send_limit(msg):
                 self._stash_overflow_content(msg, content)
-                return
+                return False
             await self._send_text_chunks_to_user(msg, content)
-            return
+            return True
 
         if msg.event_type == EventType.CHAT_TOOL_RESULT:
-            return
+            return False
 
         if msg.event_type == EventType.CHAT_ERROR:
             if await self._should_skip_due_to_send_limit(msg):
                 self._stash_overflow_content(msg, self._extract_content(msg))
-                return
+                return False
             self._clear_delta_session(msg)
             err_line = self._extract_content(msg)
             if err_line:
                 await self._send_text_chunks_to_user(msg, err_line)
-            return
+                return True
+            return False
 
         if msg.event_type == EventType.CHAT_DELTA:
             if self._is_reasoning_chunk(msg):
-                return
+                return False
             payload = msg.payload if isinstance(msg.payload, dict) else {}
             chunk = str(payload.get("content", "") or "")
             raw_index = payload.get("index")
             index = raw_index if isinstance(raw_index, int) else None
             sk = self._delta_session_key(msg)
             if not sk:
-                return
+                return False
             mk = self._message_session_key(msg)
             if mk:
                 self._streaming_sessions.add(mk)
             flushed = self._delta_accumulator.add_chunk(sk, chunk, index=index)
             if flushed:
                 self._delta_leading[sk] = (self._delta_leading.get(sk) or "") + flushed
-            return
+            return False
 
         if self._is_stream_complete_marker(msg):
             mk = self._message_session_key(msg)
@@ -547,7 +551,7 @@ class WechatChannel(BaseChannel):
                 self._streaming_sessions.discard(mk)
                 self._continue_active_sessions.discard(mk)
             self._clear_delta_session(msg)
-            return
+            return False
 
         allow_plain_res = (
             msg.type == "res"
@@ -559,30 +563,34 @@ class WechatChannel(BaseChannel):
             EventType.CHAT_INTERRUPT_RESULT,
         )
         if msg.event_type not in final_like_events and not allow_plain_res:
-            return
+            return False
 
         user_id = self._extract_platform_user_id(msg)
         if not user_id:
             logger.warning("WechatChannel 无法确定回发目标用户")
-            return
+            return False
         if self._is_reasoning_chunk(msg):
-            return
+            return False
 
         content_str = self._strip_think_tags(self._extract_content(msg)).strip()
         if not content_str or self._is_thinking_only_content(content_str):
             logger.debug("WechatChannel 消息内容为空或仅为思考占位，跳过发送")
-            return
+            return False
         if await self._should_skip_due_to_send_limit(msg):
             self._stash_overflow_content(msg, content_str)
-            return
+            return False
         await self._send_text_chunks_to_user(msg, content_str)
-        self._clear_delta_session(msg)
-        mk = self._message_session_key(msg)
-        if mk:
-            self._streaming_sessions.discard(mk)
-            self._continue_active_sessions.discard(mk)
-        self.current_round = 0
-        self._current_round_session_key = ""
+        # ask_user plain-text notices are CHAT_FINAL but must not wipe the
+        # in-flight answer accumulator mid-stream.
+        if not standalone_notice:
+            self._clear_delta_session(msg)
+            mk = self._message_session_key(msg)
+            if mk:
+                self._streaming_sessions.discard(mk)
+                self._continue_active_sessions.discard(mk)
+            self.current_round = 0
+            self._current_round_session_key = ""
+        return True
 
     def _delta_session_key(self, msg: Message) -> str:
         return str(msg.session_id or msg.id or "")

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/wecom/wecom_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/wecom/wecom_connect.py
@@ -1122,15 +1122,19 @@ class WecomChannel(BaseChannel):
         msg: Message,
         *,
         routing_target: RoutingTarget | None = None,
-    ) -> None:
+    ) -> bool:
         """通过企业微信发送消息。支持流式（reply_stream）与非流式（send_message）。
 
         V2: resolved/delivery 为 team 模式分发元数据，企微通道当前通过
         msg.metadata 获取投递信息，暂不直接消费。
+
+        Returns True when a payload was handed to the WeCom client for this call.
+        Early skips (not connected, filtered event types) return False so ask_user
+        pending registration does not treat a no-op as delivery.
         """
         if not self._ws_client or not getattr(self._ws_client, "is_connected", False):
             logger.warning("WecomChannel 未连接，跳过发送")
-            return
+            return False
 
         # 不向企业微信发送 chat.processing_status（思考状态事件），避免展示思考过程
         if msg.event_type == EventType.CHAT_PROCESSING_STATUS:
@@ -1138,7 +1142,7 @@ class WecomChannel(BaseChannel):
             meta = getattr(msg, "metadata", None) or {}
             if isinstance(payload, dict):
                 await self._handle_processing_status_event(msg, meta, payload)
-            return
+            return False
 
         # 提取事件类型
         payload = msg.payload if isinstance(msg.payload, dict) else {}
@@ -1147,7 +1151,7 @@ class WecomChannel(BaseChannel):
         # 处理文件发送事件（chat.media 与 chat.file 统一走文件发送路径）
         if event_type in ("chat.file", "chat.media"):
             await self._send_file_message(msg)
-            return
+            return False
 
         # 心跳/系统事件
         if msg.event_type == EventType.HEARTBEAT_RELAY:
@@ -1166,7 +1170,7 @@ class WecomChannel(BaseChannel):
                 logger.warning(
                     "[WecomChannel] 心跳未发送：无有效 chatid。请先在企业微信中与机器人对话一次，以写入 last_chat_id"
                 )
-            return
+            return False
 
         # 流式回复：CHAT_DELTA / CHAT_FINAL 通过 reply_stream 发送，替换首帧「...」
         req_id = self._get_req_id_for_stream(msg)
@@ -1180,7 +1184,7 @@ class WecomChannel(BaseChannel):
             if entry:
                 if self._is_reasoning_chunk(msg):
                     logger.debug("WecomChannel 跳过 reasoning chunk: req_id=%s", req_id)
-                    return
+                    return False
                 content = self._extract_content_from_payload(msg)
                 if content is not None:
                     is_final = msg.event_type == EventType.CHAT_FINAL
@@ -1194,9 +1198,9 @@ class WecomChannel(BaseChannel):
                         if msg.event_type == EventType.CHAT_FINAL:
                             self._pending_streams.pop(req_id, None)
                             self._stream_completed_requests.add(req_id)
-                        return
+                        return False
                     if not is_final and to_send == entry.get("last_sent"):
-                        return
+                        return False
                     
                     # 群聊场景：出站管线已在 publish_robot_messages 时设置 reply_scope
                     meta = getattr(msg, "metadata", None) or {}
@@ -1219,9 +1223,10 @@ class WecomChannel(BaseChannel):
                             body = {"msgtype": "markdown", "markdown": {"content": to_send}}
                             await self._ws_client.send_message(target_user_id, body)
                             logger.info("[WecomChannel] 私发消息成功: user_id=%s len=%d", target_user_id, len(to_send))
+                            return True
                         except Exception as e:
                             logger.error("[WecomChannel] 私发消息失败: %s", e)
-                        return
+                            return False
                     
                     # 非群聊场景或无目标用户，正常流式发送
                     try:
@@ -1241,17 +1246,18 @@ class WecomChannel(BaseChannel):
                         if is_final:
                             self._pending_streams.pop(req_id, None)
                             self._stream_completed_requests.add(req_id)
+                        return True
                     except Exception as e:
                         logger.error("WecomChannel 流式发送失败: %s", e)
                         if msg.event_type == EventType.CHAT_FINAL:
                             self._pending_streams.pop(req_id, None)
                             self._stream_completed_requests.add(req_id)
-                    return
+                        return False
 
         if req_id and req_id in self._stream_completed_requests:
             logger.debug("WecomChannel 跳过已完成的流式请求: req_id=%s", req_id)
             self._stream_completed_requests.discard(req_id)
-            return
+            return False
 
         if msg.event_type == EventType.CHAT_ERROR:
             if req_id:
@@ -1267,20 +1273,20 @@ class WecomChannel(BaseChannel):
                     )
                 except Exception as e:
                     logger.debug("WecomChannel 发送错误消息失败: %s", e)
-            return
+            return False
 
         # 非流式或无 pending：仅 CHAT_FINAL 用 send_message
         if msg.event_type != EventType.CHAT_FINAL:
-            return
+            return False
         if req_id:
             self._pending_streams.pop(req_id, None)
         if self._is_reasoning_chunk(msg):
             logger.debug("[WecomChannel] 跳过 final reasoning chunk")
-            return
+            return False
         content = self._strip_think_tags(self._extract_content(msg)).strip()
         if not content or self._is_thinking_only_content(content):
             logger.debug("[WecomChannel] 消息内容为空或仅为思考占位，跳过发送")
-            return
+            return False
 
         meta = getattr(msg, "metadata", None) or {}
         chatid = self._extract_chatid(msg)
@@ -1293,7 +1299,7 @@ class WecomChannel(BaseChannel):
         )
         if not chatid:
             logger.warning("[WecomChannel] 无法确定回发目标 chatid, msg.id=%s", msg.id)
-            return
+            return False
 
         request_id = str(msg.id or "").strip()
         if request_id:
@@ -1345,6 +1351,8 @@ class WecomChannel(BaseChannel):
 
         except Exception as e:
             logger.error("WecomChannel 发送失败: %s", e)
+            return False
+        return True
 
     async def _run_client(self) -> None:
         """在后台运行 WebSocket 客户端。"""

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/whatsapp/whatsapp_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/whatsapp/whatsapp_connect.py
@@ -14,6 +14,9 @@ from typing import Any, Callable
 
 from jiuwenswarm.gateway.channel_manager.base import BaseChannel, ChannelMetadata, RobotMessageRouter
 from jiuwenswarm.common.schema.message import EventType, Message, ReqMethod
+from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.text_delivery import (
+    is_stream_intermediate,
+)
 from jiuwenswarm.gateway.routing.keys import DeliveryTarget
 from jiuwenswarm.gateway.routing.session_sharing import RoutingTarget
 
@@ -104,27 +107,33 @@ class WhatsAppChannel(BaseChannel):
         self._set_connection_state("stopped", bridge_ws_connected=False, whatsapp_connected=False, qr_pending=False)
         logger.info("WhatsAppChannel stopped")
 
-    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> None:
+    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> bool:
         if self._ws is None:
-            return
+            return False
         if not self._whatsapp_connected:
             logger.warning("WhatsAppChannel send skipped: WhatsApp not connected (state=%s)", self._bridge_state)
-            return
+            return False
         if (
                 not self.config.enable_streaming
                 and msg.type == "event"
                 and msg.event_type == EventType.CHAT_DELTA
         ):
-            return
+            return False
+        # the inbound request now streams so ask_user is emitted at all,
+        # which also turns on reasoning and tool chunks. Those are dropped here.
+        # Deltas keep their own guard above: an operator who set
+        # enable_streaming wanted them, and this change must not take that away.
+        if msg.event_type != EventType.CHAT_DELTA and is_stream_intermediate(msg):
+            return False
 
         text = self._extract_outgoing_text(msg)
         if not text.strip():
-            return
+            return False
 
         target_jid = self._extract_target_jid(msg)
         if not target_jid:
             logger.warning("WhatsAppChannel send skipped: no target jid")
-            return
+            return False
 
         frame = {
             "type": "send",
@@ -133,6 +142,7 @@ class WhatsAppChannel(BaseChannel):
             "request_id": msg.id,
         }
         await self._send_frame(frame)
+        return True
 
     def get_metadata(self) -> ChannelMetadata:
         return ChannelMetadata(
@@ -295,6 +305,9 @@ class WhatsAppChannel(BaseChannel):
             timestamp=time.time(),
             ok=True,
             req_method=ReqMethod.CHAT_SEND,
+            # chat.ask_user_question is only produced as a stream chunk, so
+            # a non-streaming request never sees the question at all.
+            is_stream=True,
             metadata={
                 "whatsapp_jid": jid,
                 "whatsapp_sender": sender,

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/xiaoyi/xiaoyi_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/xiaoyi/xiaoyi_connect.py
@@ -493,7 +493,7 @@ class XiaoyiChannel(BaseChannel):
         session_id = self._session_task_map.get(task_id, task_id)
         return session_id, task_id
 
-    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> None:
+    async def send(self, msg: Message, *, routing_target: RoutingTarget | None = None) -> bool:
         """发送消息到小艺服务端（A2A 格式，双通道发送）.
 
         V2 Stream Routing:
@@ -503,13 +503,13 @@ class XiaoyiChannel(BaseChannel):
         """
         # ── team 模式：双通道投递 ──
         if routing_target is not None:
-            await self._send_team(msg, routing_target)
-            return
+            return await self._send_team(msg, routing_target)
 
         # ── 非 team 模式：原有单值路径 ──
         if not self._ws_connections:
-            return
+            return False
         await self._send_legacy(msg)
+        return True
 
     async def _send_legacy(self, msg: Message) -> None:
         """非 team 模式原有单值投递路径（保留兼容）."""
@@ -699,19 +699,26 @@ class XiaoyiChannel(BaseChannel):
         EventType.CHAT_PROCESSING_STATUS,
     })
 
-    async def _send_team(self, msg: Message, routing_target: RoutingTarget) -> None:
-        """team 模式双通道投递：活跃会话走 ws 流式，非活跃走 push webhook 全文 final."""
+    async def _send_team(self, msg: Message, routing_target: RoutingTarget) -> bool:
+        """team 模式双通道投递：活跃会话走 ws 流式，非活跃走 push webhook 全文 final.
+
+        Returns whether a payload was actually handed off to ws/push/legacy.
+        The caller (``send()``) surfaces this to ``_channel_send_delivered``,
+        which gates ``register_ask_user_pending`` -- returning ``True`` for a
+        message this method silently dropped would register a pending
+        question for a notice the human never received.
+        """
         delivery = routing_target.delivery
         if delivery is None or not isinstance(delivery, XiaoyiDeliveryTarget):
             logger.warning(
                 "[XiaoyiChannel] _send_team drop: delivery invalid type=%s event=%s intent=%s",
                 type(delivery).__name__, msg.event_type, routing_target.intent,
             )
-            return
+            return False
 
         # 白名单过滤：team member 场景丢弃中间过程，只投递结果类消息
         if msg.event_type not in self._TEAM_ALLOWED_EVENTS:
-            return
+            return False
 
         agent_id = delivery.agent_id
         content = self._extract_team_content(msg)
@@ -734,25 +741,27 @@ class XiaoyiChannel(BaseChannel):
 
         # status_update / file 类事件透传（不参与 push 合并）
         if should_send_as_status_update(msg.event_type):
-            if ws_session and ws_task:
-                status_text = get_status_text_for_event(msg.event_type, msg.payload)
-                status_state = get_status_state_for_event(msg.event_type, msg.payload)
-                for url_key in list(self._ws_connections.keys()):
-                    await self._send_status_update_with_state(
-                        ws_task, ws_session, status_text, status_state, url_key
-                    )
-            return
+            if not (ws_session and ws_task):
+                return False
+            status_text = get_status_text_for_event(msg.event_type, msg.payload)
+            status_state = get_status_state_for_event(msg.event_type, msg.payload)
+            for url_key in list(self._ws_connections.keys()):
+                await self._send_status_update_with_state(
+                    ws_task, ws_session, status_text, status_state, url_key
+                )
+            return True
         if msg.event_type == EventType.CHAT_FILE:
-            if ws_session and ws_task:
-                files = msg.payload.get("files", {}) if isinstance(msg.payload, dict) else {}
-                for file_info in files:
-                    for url_key, ws in self._ws_connections.items():
-                        if ws:
-                            try:
-                                await self._send_file_response(ws_session, ws_task, file_info, url_key)
-                            except Exception as e:
-                                logger.warning(f"XiaoyiChannel 发送文件响应失败 ({url_key}): {e}")
-            return
+            if not (ws_session and ws_task):
+                return False
+            files = msg.payload.get("files", {}) if isinstance(msg.payload, dict) else {}
+            for file_info in files:
+                for url_key, ws in self._ws_connections.items():
+                    if ws:
+                        try:
+                            await self._send_file_response(ws_session, ws_task, file_info, url_key)
+                        except Exception as e:
+                            logger.warning(f"XiaoyiChannel 发送文件响应失败 ({url_key}): {e}")
+            return True
 
         # 判定投递通道
         if ws_active:
@@ -760,25 +769,29 @@ class XiaoyiChannel(BaseChannel):
             logger.info("[XiaoyiChannel] _send_team → ws: agent_id=%s sid=%s", (agent_id or "")[:8],
                         (ws_session or "")[:8])
             await self._send_ws_to_user(ws_session, ws_task, msg, content)
-        else:
-            # ② 后台 → push webhook 全文 final（带 per-agent_id 合并窗口）
-            # push_id 优先用 delivery 的，否则从活跃映射取（最后一次已知值）
-            push_id = delivery.push_id
-            if not push_id and agent_id:
-                active = self._active_push_sessions.get(agent_id)
-                if active:
-                    push_id = active[2]
-            if push_id and agent_id:
-                logger.info("[XiaoyiChannel] _send_team → push: agent_id=%s push_id=%s", (agent_id or "")[:8],
-                            push_id[:8])
-                await self._send_push_to_user(agent_id, push_id, content)
-            elif self._ws_connections:
-                # ③ 兜底：无 push_id 且无活跃会话，走 legacy（按 metadata 投递）
-                logger.info("[XiaoyiChannel] _send_team → legacy fallback: agent_id=%s", (agent_id or "")[:8])
-                await self._send_legacy(msg)
-            else:
-                logger.warning("[XiaoyiChannel] _send_team drop: no ws/push/legacy available agent_id=%s",
-                               (agent_id or "")[:8])
+            return True
+
+        # ② 后台 → push webhook 全文 final（带 per-agent_id 合并窗口）
+        # push_id 优先用 delivery 的，否则从活跃映射取（最后一次已知值）
+        push_id = delivery.push_id
+        if not push_id and agent_id:
+            active = self._active_push_sessions.get(agent_id)
+            if active:
+                push_id = active[2]
+        if push_id and agent_id:
+            logger.info("[XiaoyiChannel] _send_team → push: agent_id=%s push_id=%s", (agent_id or "")[:8],
+                        push_id[:8])
+            await self._send_push_to_user(agent_id, push_id, content)
+            return True
+        if self._ws_connections:
+            # ③ 兜底：无 push_id 且无活跃会话，走 legacy（按 metadata 投递）
+            logger.info("[XiaoyiChannel] _send_team → legacy fallback: agent_id=%s", (agent_id or "")[:8])
+            await self._send_legacy(msg)
+            return True
+
+        logger.warning("[XiaoyiChannel] _send_team drop: no ws/push/legacy available agent_id=%s",
+                        (agent_id or "")[:8])
+        return False
 
     def _resolve_active_ws(
             self, agent_id: str, delivery: XiaoyiDeliveryTarget

--- a/jiuwenswarm/gateway/message_handler/message_handler.py
+++ b/jiuwenswarm/gateway/message_handler/message_handler.py
@@ -301,6 +301,76 @@ class MessageHandler(ABC):
     def set_inbound_pipeline(self, pipeline: Any) -> None:
         self._inbound_pipeline = pipeline
 
+    def _convert_pending_question_reply(self, msg: "Message") -> bool:
+        """Turn a reply to a text-rendered ``ask_user`` question into its answer.
+
+        Only ordinary ``chat.send`` text is considered: a channel that drew its
+        own card already emits ``chat.user_answer`` / an interrupt resume and
+        must not be touched.
+
+        The conversion keeps ``chat.send`` and injects
+        ``source="ask_user_interrupt"`` so the deep adapter resumes the blocked
+        tool call -- the same path Web and the CLI use. ``chat.user_answer``
+        would only hit evolution-approval handling and leave the tool hung.
+
+        A reply that does not select an option is left alone and reaches the
+        agent as an ordinary message. Swallowing it would be a new way to lose
+        a user's words -- the exact failure this fallback exists to fix -- and the question
+        stays pending so it can still be answered.
+
+        Returns whether the message was converted, for tests and logging.
+        """
+        # ReqMethod is not imported at module scope in this file; every other
+        # user imports it locally, and referencing it here would only fail at
+        # call time, which no import check would catch.
+        from jiuwenswarm.common.schema.message import ReqMethod
+
+        if getattr(msg, "req_method", None) != ReqMethod.CHAT_SEND:
+            return False
+        params = msg.params if isinstance(msg.params, dict) else {}
+        # Already an interrupt resume -- leave it alone.
+        if str(params.get("source") or "").strip() in _INTERRUPT_RESUME_SOURCES:
+            return False
+        text = str(params.get("query") or params.get("content") or "").strip()
+        if not text:
+            return False
+
+        try:
+            from jiuwenswarm.gateway.channel_manager.channel_manager import conversation_key_of
+            from jiuwenswarm.gateway.routing.pending_question import (
+                PENDING_QUESTIONS,
+                build_interrupt_resume_params,
+            )
+
+            resolved = PENDING_QUESTIONS.resolve(
+                str(getattr(msg, "channel_id", "") or ""),
+                conversation_key_of(msg),
+                text,
+            )
+        except Exception:  # noqa: BLE001 - a broken lookup must not drop the message
+            logger.exception("[MessageHandler] pending-question lookup failed")
+            return False
+
+        if resolved is None:
+            return False
+
+        question, answer, custom_input = resolved
+        # Keep chat.send; force streaming so the agent interaction lease is used.
+        msg.req_method = ReqMethod.CHAT_SEND
+        msg.is_stream = True
+        msg.params = build_interrupt_resume_params(
+            question.request_id,
+            answer,
+            source=question.source,
+            question=question.question,
+            custom_input=custom_input,
+        )
+        logger.info(
+            "[MessageHandler] ask_user text reply resolved: channel=%s request_id=%s answer=%s",
+            msg.channel_id, question.request_id, answer[:60],
+        )
+        return True
+
     def set_outbound_pipeline(self, pipeline: Any) -> None:
         self._outbound_pipeline = pipeline
 
@@ -1007,6 +1077,17 @@ class MessageHandler(ABC):
                     sid_mode[sid] = task_mode
             else:
                 unresolved_rids.append(rid)
+
+        # This chat.send is about to kill the AgentServer work behind any
+        # ask_user question pending on these sessions. PENDING_QUESTIONS.resolve
+        # only pops on a matched answer, so without this the record would
+        # outlive its request_id and a later "1"/"2" would be rewritten into a
+        # resume for a tool call that no longer exists.
+        if sid_mode:
+            from jiuwenswarm.gateway.routing.pending_question import PENDING_QUESTIONS
+
+            for old_sid in sid_mode:
+                PENDING_QUESTIONS.discard(channel_id, old_sid)
 
         # Stop gateway stream consumers first — never block on AgentServer RPC.
         tasks_to_stop = [task for _rid, task, _sess, _mode in candidates]
@@ -3532,6 +3613,10 @@ class MessageHandler(ABC):
                 # 将当前 Channel 的控制状态应用到消息上
                 await self._resolve_external_channel_session(msg)
                 self._apply_channel_state(msg)
+                # a reply to an ask_user question asked as plain text must
+                # become an interrupt resume (chat.send + ask_user_interrupt),
+                # not a new turn and not chat.user_answer.
+                self._convert_pending_question_reply(msg)
                 channel_type = self._resolve_control_channel_type(msg)
                 if (
                     channel_type in self._control_channel_types

--- a/jiuwenswarm/gateway/routing/pending_question.py
+++ b/jiuwenswarm/gateway/routing/pending_question.py
@@ -1,0 +1,266 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Questions asked through ``ask_user`` and awaiting a plain-text reply.
+
+Deliberately **not** :class:`PendingInteraction`. That record exists for the
+digital-avatar follow-up, which resumes by injecting the answer as a new user
+message. An ``ask_user`` answer must instead satisfy a blocked tool call via
+``chat.send`` with ``source="ask_user_interrupt"`` -- the same resume path Web
+and the CLI use. ``chat.user_answer`` only covers evolution approvals on the
+deep adapter; using it here leaves the tool hung. Issue #1976 is what happens
+when the avatar path and the tool-resume path are confused, so they do not
+share a store.
+
+State is in memory, matching Feishu's ``_user_question_card``. A gateway restart
+loses pending questions, which is the same exposure the card path already
+carries and is preferable to persisting a record whose only consumer is a
+single process's in-flight tool call.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+#: A question nobody answers should not shadow ordinary messages forever.
+DEFAULT_TTL_SECONDS = 30 * 60
+
+#: Default interrupt source for tool-backed ``ask_user`` questions.
+DEFAULT_ASK_USER_SOURCE = "ask_user_interrupt"
+
+_LEADING_INDEX = re.compile(r"^\s*[（(\[]?(\d{1,2})[)\].、:：]?\s*$")
+
+#: The label StructuredAskUserRail always appends to a structured question's
+#: options (see interrupt_helpers._build_multi_questions). Selecting it is a
+#: request for custom input, not an answer by itself.
+_OTHER_LABEL = "other"
+
+
+@dataclass(frozen=True)
+class PendingQuestion:
+    """One unanswered ``ask_user`` question on a text-only channel."""
+
+    request_id: str
+    channel_id: str
+    conversation_key: str
+    options: tuple[str, ...]
+    source: str = DEFAULT_ASK_USER_SOURCE
+    question: str = ""
+    created_at: float = field(default_factory=time.time)
+
+    def is_expired(self, ttl: float = DEFAULT_TTL_SECONDS, *, now: float | None = None) -> bool:
+        return (now if now is not None else time.time()) - self.created_at > ttl
+
+
+def match_reply(text: str, options: tuple[str, ...]) -> Optional[str]:
+    """Map a reply to the option it selects, or ``None`` if it selects none.
+
+    Three spellings are accepted, in this order: the bare index (``2``, ``2.``,
+    ``(2)``), the option label itself, and a case-insensitive label match. A
+    reply that matches nothing returns ``None`` so the caller can let it through
+    as an ordinary message -- silently swallowing it would be a new way to lose
+    a user's words, which is the failure this whole feature is about.
+
+    A question with no options accepts anything non-empty: the reply *is* the
+    answer.
+    """
+    stripped = (text or "").strip()
+    if not stripped:
+        return None
+    if not options:
+        return stripped
+
+    index_match = _LEADING_INDEX.match(stripped)
+    if index_match:
+        index = int(index_match.group(1))
+        if 1 <= index <= len(options):
+            return options[index - 1]
+        # A number outside the range is a miss, not the first option.
+        return None
+
+    for label in options:
+        if stripped == label:
+            return label
+    lowered = stripped.lower()
+    for label in options:
+        if lowered == label.lower():
+            return label
+    return None
+
+
+def _is_other_option(label: str) -> bool:
+    return label.strip().lower() == _OTHER_LABEL
+
+
+def resolve_reply(text: str, options: tuple[str, ...]) -> Optional[tuple[str, str]]:
+    """Map a reply to ``(answer, custom_input)``, or ``None`` if it answers nothing.
+
+    Structured ``ask_user`` payloads always append an "Other" option
+    (StructuredAskUserRail / ``_build_multi_questions``). Three outcomes,
+    layered on top of :func:`match_reply`:
+
+    - The reply selects a real (non-"Other") option by index or label: that
+      option, with no custom input -- unchanged from before Other existed.
+    - The reply selects "Other" itself, bare (its index or its label, with
+      nothing else): not a complete answer. "Other" exists to carry custom
+      text, and StructuredAskUserRail rejects a bare "Other" as an empty
+      answer (#2330); returning ``None`` here leaves the question pending
+      instead of resuming the tool call with nothing useful.
+    - Anything else, when "Other" is offered: the whole reply is custom text
+      for "Other", matching the shape Web/CLI send
+      (``selected_options=["Other"]`` + ``custom_input``).
+
+    A question with no options keeps taking the whole reply verbatim -- there
+    is no "Other" concept without options.
+    """
+    stripped = (text or "").strip()
+    if not stripped:
+        return None
+
+    matched = match_reply(stripped, options)
+    if matched is not None:
+        if options and _is_other_option(matched):
+            return None
+        return (matched, "")
+
+    if any(_is_other_option(label) for label in options):
+        return ("Other", stripped)
+    return None
+
+
+class PendingQuestionRegistry:
+    """Per-conversation store of unanswered questions.
+
+    One question per conversation at a time: a second question replaces the
+    first, because the agent can only be blocked on one ``ask_user`` call in a
+    conversation and a stale entry would steal the reply meant for the new one.
+    """
+
+    def __init__(self, ttl: float = DEFAULT_TTL_SECONDS) -> None:
+        self._ttl = ttl
+        self._lock = threading.Lock()
+        self._pending: dict[tuple[str, str], PendingQuestion] = {}
+
+    @staticmethod
+    def _key(channel_id: str, conversation_key: str) -> tuple[str, str]:
+        return (str(channel_id or "").strip().lower(), str(conversation_key or "").strip())
+
+    def register(
+        self,
+        *,
+        request_id: str,
+        channel_id: str,
+        conversation_key: str,
+        options: tuple[str, ...],
+        source: str = DEFAULT_ASK_USER_SOURCE,
+        question: str = "",
+    ) -> PendingQuestion:
+        entry = PendingQuestion(
+            request_id=request_id,
+            channel_id=str(channel_id or ""),
+            conversation_key=str(conversation_key or ""),
+            options=tuple(options),
+            source=str(source or DEFAULT_ASK_USER_SOURCE).strip() or DEFAULT_ASK_USER_SOURCE,
+            question=str(question or "").strip(),
+        )
+        with self._lock:
+            self._pending[self._key(channel_id, conversation_key)] = entry
+        return entry
+
+    def peek(self, channel_id: str, conversation_key: str) -> Optional[PendingQuestion]:
+        """The live question for this conversation, dropping it if expired."""
+        key = self._key(channel_id, conversation_key)
+        with self._lock:
+            entry = self._pending.get(key)
+            if entry is None:
+                return None
+            if entry.is_expired(self._ttl):
+                self._pending.pop(key, None)
+                return None
+            return entry
+
+    def resolve(self, channel_id: str, conversation_key: str, text: str):
+        """Match a reply against the pending question.
+
+        Returns ``(question, answer_label, custom_input)`` when the reply
+        answers it, and ``None`` when there is nothing pending or the reply is
+        not an answer (including a bare "Other" selection, which is not a
+        complete answer). The entry is only removed on a match -- a stray
+        message must not consume the question the user has yet to answer.
+        """
+        entry = self.peek(channel_id, conversation_key)
+        if entry is None:
+            return None
+        resolved = resolve_reply(text, entry.options)
+        if resolved is None:
+            return None
+        answer, custom_input = resolved
+        with self._lock:
+            self._pending.pop(self._key(channel_id, conversation_key), None)
+        return entry, answer, custom_input
+
+    def discard(self, channel_id: str, conversation_key: str) -> None:
+        with self._lock:
+            self._pending.pop(self._key(channel_id, conversation_key), None)
+
+    def cleanup_expired(self) -> int:
+        now = time.time()
+        with self._lock:
+            stale = [k for k, v in self._pending.items() if v.is_expired(self._ttl, now=now)]
+            for key in stale:
+                self._pending.pop(key, None)
+        return len(stale)
+
+
+#: Process-wide registry. The gateway is a single process; Feishu's card cache
+#: is scoped the same way.
+PENDING_QUESTIONS = PendingQuestionRegistry()
+
+
+def build_interrupt_resume_params(
+    request_id: str,
+    answer: str,
+    *,
+    source: str = DEFAULT_ASK_USER_SOURCE,
+    question: str = "",
+    custom_input: str = "",
+) -> dict:
+    """The ``chat.send`` params that resume a blocked ``ask_user`` tool call.
+
+    Matches what the CLI and Web send (``source="ask_user_interrupt"`` over
+    streaming ``chat.send``). ``chat.user_answer`` is the wrong path: the deep
+    adapter's ``handle_user_answer`` only resolves evolution approvals.
+
+    ``custom_input`` carries free text typed for the "Other" option --
+    ``interface.py``'s ``_build_interactive_input_from_answers`` reads it
+    alongside ``selected_options`` to recover the user's actual words instead
+    of the literal placeholder "Other".
+    """
+    answer_entry: dict = {"selected_options": [answer]}
+    question_text = str(question or "").strip()
+    if question_text:
+        answer_entry["question"] = question_text
+    custom_input_text = str(custom_input or "").strip()
+    if custom_input_text:
+        answer_entry["custom_input"] = custom_input_text
+    return {
+        "query": "",
+        "request_id": request_id,
+        "answers": [answer_entry],
+        "source": str(source or DEFAULT_ASK_USER_SOURCE).strip() or DEFAULT_ASK_USER_SOURCE,
+    }
+
+
+__all__ = [
+    "DEFAULT_ASK_USER_SOURCE",
+    "DEFAULT_TTL_SECONDS",
+    "PENDING_QUESTIONS",
+    "PendingQuestion",
+    "PendingQuestionRegistry",
+    "build_interrupt_resume_params",
+    "match_reply",
+    "resolve_reply",
+]

--- a/jiuwenswarm/gateway/routing/session_sharing.py
+++ b/jiuwenswarm/gateway/routing/session_sharing.py
@@ -536,8 +536,19 @@ class SessionDispatcher:
 
         routing_target = SessionDispatcher._build_routing_target(target, group_subs, delivery)
         try:
+            # fan-out bypasses the single-channel dispatch branch, so the
+            # ask_user text rewrite + post-send registration must live here too.
+            from jiuwenswarm.gateway.channel_manager.channel_manager import (
+                deliver_with_ask_user_fallback,
+            )
+
             await asyncio.wait_for(
-                channel.send(msg, routing_target=routing_target),
+                deliver_with_ask_user_fallback(
+                    channel,
+                    msg,
+                    channel_id=container_key.channel_id,
+                    routing_target=routing_target,
+                ),
                 timeout=10.0,
             )
         except asyncio.TimeoutError:

--- a/tests/unit_tests/gateway/test_ask_user_notice.py
+++ b/tests/unit_tests/gateway/test_ask_user_notice.py
@@ -1,0 +1,191 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Rendering an ``ask_user`` question for a channel with no card.
+
+The agent is blocked on the tool result while this event is in flight, so the
+thing being pinned here is not cosmetic: on the eight channels with no handler
+the question produces nothing and the conversation hangs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.schema import Message
+from jiuwenswarm.common.schema.message import EventType
+from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.ask_user_notice import (
+    as_text_message,
+    channel_renders_questions,
+    format_question_notice,
+    parse_question,
+)
+
+
+def _payload(question="Which one?", options=("Alpha", "Beta"), request_id="req-7", header=""):
+    entry = {"question": question}
+    if options is not None:
+        entry["options"] = [{"label": label} for label in options]
+    if header:
+        entry["header"] = header
+    return {
+        "event_type": "chat.ask_user_question",
+        "request_id": request_id,
+        "questions": [entry],
+    }
+
+
+def _msg(channel_id="telegram", payload=None, metadata=None):
+    return Message(
+        id="req-42",
+        type="event",
+        channel_id=channel_id,
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload=payload if payload is not None else _payload(),
+        metadata=metadata if metadata is not None else {},
+    )
+
+
+# ---------------------------------------------------------------- capability
+
+
+@pytest.mark.parametrize("channel", ["feishu", "web", "tui", "acp", "ssh", "FEISHU"])
+def test_channels_with_their_own_question_ui_are_left_alone(channel: str) -> None:
+    """Feishu draws a card; a text copy would be a duplicate question."""
+    assert channel_renders_questions(channel) is True
+    original = _msg(channel_id=channel)
+    assert as_text_message(original) is original
+
+
+@pytest.mark.parametrize(
+    "channel", ["telegram", "slack", "discord", "wechat", "wecom", "dingtalk", "whatsapp", "xiaoyi"],
+)
+def test_text_only_channels_get_a_rewrite(channel: str) -> None:
+    assert channel_renders_questions(channel) is False
+    out = as_text_message(_msg(channel_id=channel))
+    assert out is not None
+    assert "Alpha" in out.payload["content"]
+
+
+# ------------------------------------------------------------------ parsing
+
+
+def test_options_are_parsed_in_order() -> None:
+    parsed = parse_question(_payload(options=("Alpha", "Beta", "Gamma")))
+    assert parsed is not None
+    assert parsed.options == ("Alpha", "Beta", "Gamma")
+    assert parsed.request_id == "req-7"
+
+
+def test_bare_string_options_are_accepted() -> None:
+    """Not every producer wraps a label in a dict."""
+    payload = _payload(options=None)
+    payload["questions"][0]["options"] = ["Alpha", "Beta"]
+    parsed = parse_question(payload)
+    assert parsed is not None
+    assert parsed.options == ("Alpha", "Beta")
+
+
+def test_a_free_text_question_parses_with_no_options() -> None:
+    parsed = parse_question(_payload(options=None))
+    assert parsed is not None
+    assert parsed.options == ()
+
+
+def test_a_payload_with_no_questions_is_not_a_question() -> None:
+    assert parse_question({"request_id": "x", "questions": []}) is None
+    assert parse_question({"request_id": "x"}) is None
+    assert parse_question(None) is None
+
+
+def test_only_the_first_question_is_used() -> None:
+    """Two interleaved option sets could not be answered by ``2``."""
+    payload = _payload()
+    payload["questions"].append({"question": "Second?", "options": [{"label": "Later"}]})
+    parsed = parse_question(payload)
+    assert parsed is not None
+    assert parsed.question == "Which one?"
+    assert parsed.options == ("Alpha", "Beta")
+
+
+# --------------------------------------------------------------- formatting
+
+
+def test_options_are_numbered_from_one() -> None:
+    text = format_question_notice(parse_question(_payload(options=("Alpha", "Beta"))))
+    assert "1. Alpha" in text
+    assert "2. Beta" in text
+    assert "Which one?" in text
+
+
+def test_a_free_text_question_says_what_is_expected() -> None:
+    """An empty option list would reproduce the hang in a new way."""
+    text = format_question_notice(parse_question(_payload(options=None)))
+    assert "Reply to this message" in text
+    assert "1." not in text
+
+
+def test_the_header_is_shown_when_present() -> None:
+    text = format_question_notice(parse_question(_payload(header="Deploy")))
+    assert "Deploy" in text
+
+
+# ----------------------------------------------------------------- envelope
+
+
+def test_the_notice_is_shaped_like_an_ordinary_chat_final() -> None:
+    """WeCom/WeChat only deliver CHAT_FINAL / plain res; content alone is dropped."""
+    original = _msg(metadata={"wecom_req_id": "stream-1", "chat_type": "dm"})
+    out = as_text_message(original)
+
+    assert out is not None and out is not original
+    assert out.type == "res"
+    assert out.event_type == EventType.CHAT_FINAL
+    assert out.payload["event_type"] == "chat.final"
+    assert out.id == "req-42-question"
+    assert out.params["content"] == out.payload["content"]
+
+
+def test_stream_binding_metadata_is_stripped() -> None:
+    out = as_text_message(_msg(metadata={"wecom_req_id": "stream-1", "chat_type": "dm"}))
+    assert "wecom_req_id" not in out.metadata
+    assert out.metadata["chat_type"] == "dm"
+
+
+def test_the_notice_is_marked_standalone() -> None:
+    """WeChat clears its delta accumulator on CHAT_FINAL; the answer must survive."""
+    out = as_text_message(_msg())
+    assert out.metadata["standalone_notice"] is True
+
+
+def test_the_request_id_travels_with_the_notice() -> None:
+    """The reply has to be correlated back to this exact question."""
+    out = as_text_message(_msg())
+    assert out.metadata["ask_user_request_id"] == "req-7"
+
+
+def test_a_non_question_event_is_untouched() -> None:
+    original = _msg(payload={"event_type": "chat.final", "content": "hi"})
+    assert as_text_message(original) is original
+
+
+def test_a_question_with_nothing_in_it_is_not_delivered() -> None:
+    assert as_text_message(_msg(payload={"event_type": "chat.ask_user_question", "questions": []})) is None
+
+
+def test_a_question_without_request_id_is_not_delivered() -> None:
+    """An empty request_id cannot resume the blocked tool call."""
+    assert as_text_message(_msg(payload=_payload(request_id=""))) is None
+    assert parse_question(_payload(request_id="")) is None
+    assert parse_question(_payload(request_id="   ")) is None
+
+
+def test_as_text_message_honours_an_explicit_target_channel() -> None:
+    """Fan-out may deliver to a text channel while msg.channel_id is a rich one."""
+    original = _msg(channel_id="feishu")
+    assert as_text_message(original) is original
+    out = as_text_message(original, channel_id="telegram")
+    assert out is not None and out is not original
+    assert "Alpha" in out.payload["content"]

--- a/tests/unit_tests/gateway/test_ask_user_wiring.py
+++ b/tests/unit_tests/gateway/test_ask_user_wiring.py
@@ -1,0 +1,237 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""The two ends of the ask_user fallback joined up: dispatch registers, inbound converts.
+
+These exist because the unit suites cannot see a NameError. Both hooks call
+symbols that are imported locally in their modules, so a missing import fails
+only at call time -- which is exactly how a previous change to this file broke
+thirteen tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.schema import Message
+from jiuwenswarm.common.schema.message import EventType, ReqMethod
+from jiuwenswarm.gateway.channel_manager.channel_manager import (
+    conversation_key_of,
+    deliver_with_ask_user_fallback,
+    prepare_ask_user_outbound,
+    register_ask_user_pending,
+)
+from jiuwenswarm.gateway.message_handler.message_handler import MessageHandler
+from jiuwenswarm.gateway.routing.pending_question import PENDING_QUESTIONS
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    PENDING_QUESTIONS.discard("telegram", "s1")
+    PENDING_QUESTIONS.discard("xiaoyi", "s1")
+    yield
+    PENDING_QUESTIONS.discard("telegram", "s1")
+    PENDING_QUESTIONS.discard("xiaoyi", "s1")
+
+
+def _question_msg(channel_id="telegram", session_id="s1", request_id="req-7", options=None):
+    opts = options if options is not None else [{"label": "Alpha"}, {"label": "Beta"}]
+    return Message(
+        id="req-42",
+        type="event",
+        channel_id=channel_id,
+        session_id=session_id,
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload={
+            "event_type": "chat.ask_user_question",
+            "request_id": request_id,
+            "source": "ask_user_interrupt",
+            "questions": [
+                {"question": "Which one?", "options": opts}
+            ],
+        },
+        metadata={},
+    )
+
+
+def _reply_msg(text, channel_id="telegram", session_id="s1"):
+    return Message(
+        id="in-1",
+        type="req",
+        channel_id=channel_id,
+        session_id=session_id,
+        params={"query": text},
+        timestamp=0.0,
+        ok=True,
+        req_method=ReqMethod.CHAT_SEND,
+        payload={},
+        metadata={},
+    )
+
+
+def _deliver_and_register(msg, *, channel_id=None):
+    """Simulate the production order: rewrite, then register only after 'send'."""
+    outbound = prepare_ask_user_outbound(msg, channel_id=channel_id)
+    if outbound is not None and outbound is not msg:
+        register_ask_user_pending(msg, channel_id=channel_id or msg.channel_id)
+    return outbound
+
+
+# ------------------------------------------------------------------ outbound
+
+
+def test_prepare_rewrites_without_registering() -> None:
+    """A failed send must not leave a pending question that steals later replies."""
+    out = prepare_ask_user_outbound(_question_msg())
+
+    assert out is not None
+    assert out.event_type == EventType.CHAT_FINAL
+    assert "1. Alpha" in out.payload["content"]
+    assert PENDING_QUESTIONS.peek("telegram", "s1") is None
+
+
+def test_register_after_successful_delivery() -> None:
+    out = _deliver_and_register(_question_msg())
+
+    assert out is not None
+    pending = PENDING_QUESTIONS.peek("telegram", "s1")
+    assert pending is not None
+    assert pending.request_id == "req-7"
+    assert pending.options == ("Alpha", "Beta")
+    assert pending.source == "ask_user_interrupt"
+
+
+@pytest.mark.asyncio
+async def test_deliver_registers_only_when_send_returns_true() -> None:
+    """A skipped/failed send must not leave a pending question that steals ``1``."""
+
+    class _Channel:
+        def __init__(self, result):
+            self.result = result
+            self.sent = []
+
+        async def send(self, msg, **kwargs):
+            self.sent.append(msg)
+            return self.result
+
+    msg = _question_msg()
+
+    skipped = _Channel(False)
+    await deliver_with_ask_user_fallback(skipped, msg)
+    assert skipped.sent and skipped.sent[0].event_type == EventType.CHAT_FINAL
+    assert PENDING_QUESTIONS.peek("telegram", "s1") is None
+
+    legacy_none = _Channel(None)
+    await deliver_with_ask_user_fallback(legacy_none, msg)
+    assert PENDING_QUESTIONS.peek("telegram", "s1") is None
+
+    ok = _Channel(True)
+    await deliver_with_ask_user_fallback(ok, msg)
+    assert PENDING_QUESTIONS.peek("telegram", "s1") is not None
+
+
+def test_a_channel_with_a_card_registers_nothing() -> None:
+    """Feishu answers through its own callback; a pending record would double-answer."""
+    original = _question_msg(channel_id="feishu")
+    assert prepare_ask_user_outbound(original) is original
+    register_ask_user_pending(original)
+    assert PENDING_QUESTIONS.peek("feishu", "s1") is None
+
+
+def test_fan_out_target_channel_drives_rewrite_and_registration() -> None:
+    """Team fan-out delivers to a physical channel that may differ from msg.channel_id."""
+    # Originator channel is feishu (rich), but the fan-out target is xiaoyi (text-only).
+    msg = _question_msg(channel_id="feishu")
+    out = prepare_ask_user_outbound(msg, channel_id="xiaoyi")
+
+    assert out is not None and out is not msg
+    assert "1. Alpha" in out.payload["content"]
+    register_ask_user_pending(msg, channel_id="xiaoyi")
+    assert PENDING_QUESTIONS.peek("xiaoyi", "s1") is not None
+    assert PENDING_QUESTIONS.peek("feishu", "s1") is None
+
+
+def test_the_conversation_key_is_the_session() -> None:
+    assert conversation_key_of(_question_msg(session_id="s9")) == "s9"
+
+
+# ------------------------------------------------------------------- inbound
+
+
+def test_a_numbered_reply_becomes_an_interrupt_resume() -> None:
+    """Web/CLI resume ask_user via chat.send + source; chat.user_answer does not."""
+    _deliver_and_register(_question_msg())
+    reply = _reply_msg("2")
+
+    converted = MessageHandler._convert_pending_question_reply(None, reply)
+
+    assert converted is True
+    assert reply.req_method == ReqMethod.CHAT_SEND
+    assert reply.is_stream is True
+    assert reply.params["source"] == "ask_user_interrupt"
+    assert reply.params["request_id"] == "req-7"
+    assert reply.params["query"] == ""
+    assert reply.params["answers"][0]["selected_options"] == ["Beta"]
+
+
+def test_an_unrelated_message_stays_a_chat_send() -> None:
+    """It must reach the agent, and the question must stay answerable."""
+    _deliver_and_register(_question_msg())
+    reply = _reply_msg("hold on, let me check")
+
+    converted = MessageHandler._convert_pending_question_reply(None, reply)
+
+    assert converted is False
+    assert reply.req_method == ReqMethod.CHAT_SEND
+    assert reply.params == {"query": "hold on, let me check"}
+    assert PENDING_QUESTIONS.peek("telegram", "s1") is not None
+
+
+def test_a_reply_with_no_pending_question_is_untouched() -> None:
+    reply = _reply_msg("2")
+
+    assert MessageHandler._convert_pending_question_reply(None, reply) is False
+    assert reply.req_method == ReqMethod.CHAT_SEND
+
+
+def test_an_answer_message_is_not_reconverted() -> None:
+    """A card channel already sends CHAT_ANSWER; touching it would double-handle."""
+    _deliver_and_register(_question_msg())
+    already = _reply_msg("2")
+    already.req_method = ReqMethod.CHAT_ANSWER
+
+    assert MessageHandler._convert_pending_question_reply(None, already) is False
+
+
+# ------------------------------------------------------------ Other / custom_input
+
+
+_OTHER_OPTIONS = [{"label": "Alpha"}, {"label": "Beta"}, {"label": "Other"}]
+
+
+def test_a_bare_other_reply_is_not_converted_and_stays_pending() -> None:
+    """StructuredAskUserRail rejects a bare Other as an empty answer (#2330)."""
+    _deliver_and_register(_question_msg(options=_OTHER_OPTIONS))
+    reply = _reply_msg("Other")
+
+    converted = MessageHandler._convert_pending_question_reply(None, reply)
+
+    assert converted is False
+    assert reply.params == {"query": "Other"}
+    assert PENDING_QUESTIONS.peek("telegram", "s1") is not None
+
+
+def test_free_text_resumes_as_other_custom_input() -> None:
+    """The free text must satisfy StructuredAskUserRail via custom_input, not vanish."""
+    _deliver_and_register(_question_msg(options=_OTHER_OPTIONS))
+    reply = _reply_msg("Actually I want a third thing")
+
+    converted = MessageHandler._convert_pending_question_reply(None, reply)
+
+    assert converted is True
+    assert reply.params["source"] == "ask_user_interrupt"
+    assert reply.params["request_id"] == "req-7"
+    assert reply.params["answers"][0]["selected_options"] == ["Other"]
+    assert reply.params["answers"][0]["custom_input"] == "Actually I want a third thing"
+    assert PENDING_QUESTIONS.peek("telegram", "s1") is None

--- a/tests/unit_tests/gateway/test_message_handler_stream_cancel.py
+++ b/tests/unit_tests/gateway/test_message_handler_stream_cancel.py
@@ -13,6 +13,7 @@ from jiuwenswarm.common.schema import Message
 from jiuwenswarm.common.e2a.gateway_normalize import e2a_from_agent_fields
 from jiuwenswarm.common.schema.message import ReqMethod
 from jiuwenswarm.gateway.message_handler.message_handler import ChannelMode, MessageHandler
+from jiuwenswarm.gateway.routing.pending_question import PENDING_QUESTIONS
 from jiuwenswarm.gateway.routing.session_sharing import SubRole
 
 
@@ -336,6 +337,92 @@ async def test_tui_keeps_streams_on_different_session() -> None:
     assert not orphan_task.cancelled()
     await asyncio.sleep(0)
     assert len(_FakeAgentClient.sent_requests) == 0
+
+
+# ── cancelling the blocked stream must not leave a stale pending question ──
+#
+# An unmatched reply (e.g. "hold on") to a plain-text ask_user notice is left
+# as an ordinary chat.send. That chat.send then cancels the in-flight
+# AgentServer work that owns the ask_user interrupt -- the request_id the
+# pending question points at is now dead. A later "1"/"2" must not be
+# rewritten into a resume for that dead request_id; the cancellation must
+# also discard the pending question.
+
+
+@pytest.fixture(autouse=True)
+def _clean_pending_questions():
+    PENDING_QUESTIONS.discard("tui", "sess_ask")
+    PENDING_QUESTIONS.discard("tui", "sess_other_ask")
+    yield
+    PENDING_QUESTIONS.discard("tui", "sess_ask")
+    PENDING_QUESTIONS.discard("tui", "sess_other_ask")
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_blocked_stream_discards_its_pending_question() -> None:
+    handler = _TestMessageHandler.create()
+    PENDING_QUESTIONS.register(
+        request_id="call_ask_1",
+        channel_id="tui",
+        conversation_key="sess_ask",
+        options=("Alpha", "Beta"),
+    )
+    goal_task = _seed_stream_task(
+        handler, rid="rid-ask", channel_id="tui", session_id="sess_ask",
+    )
+    msg = _chat_send_message(channel_id="tui", session_id="sess_ask")
+    msg.params["query"] = "hold on, let me check"
+
+    try:
+        cancelled = await handler.cancel_stream_tasks_for_channel(msg)
+        assert cancelled == 1
+        assert goal_task.cancelled()
+        assert PENDING_QUESTIONS.peek("tui", "sess_ask") is None
+    finally:
+        if not goal_task.done():
+            goal_task.cancel()
+        await asyncio.gather(goal_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_different_channel_does_not_discard_unrelated_pending_questions() -> None:
+    handler = _TestMessageHandler.create()
+    PENDING_QUESTIONS.register(
+        request_id="call_ask_2",
+        channel_id="tui",
+        conversation_key="sess_other_ask",
+        options=("Alpha", "Beta"),
+    )
+    web_task = _seed_stream_task(
+        handler, rid="rid-web-ask", channel_id="web", session_id="sess_web_ask",
+    )
+    msg = _chat_send_message(channel_id="web", session_id="sess_web_ask")
+
+    try:
+        await handler.cancel_stream_tasks_for_channel(msg)
+        assert PENDING_QUESTIONS.peek("tui", "sess_other_ask") is not None
+    finally:
+        if not web_task.done():
+            web_task.cancel()
+        await asyncio.gather(web_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_no_candidates_to_cancel_leaves_the_pending_question_alone() -> None:
+    """A chat.send that cancels nothing (no in-flight stream) must not touch it."""
+    handler = _TestMessageHandler.create()
+    PENDING_QUESTIONS.register(
+        request_id="call_ask_3",
+        channel_id="tui",
+        conversation_key="sess_ask",
+        options=("Alpha", "Beta"),
+    )
+    msg = _chat_send_message(channel_id="tui", session_id="sess_ask")
+
+    cancelled = await handler.cancel_stream_tasks_for_channel(msg)
+
+    assert cancelled == 0
+    assert PENDING_QUESTIONS.peek("tui", "sess_ask") is not None
 
 
 def test_is_single_user_channel_acp_only() -> None:

--- a/tests/unit_tests/gateway/test_pending_question.py
+++ b/tests/unit_tests/gateway/test_pending_question.py
@@ -1,0 +1,250 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Correlating a plain-text reply back to a blocked ``ask_user`` call.
+
+Two rules carry most of the risk. A reply that is not an answer must fall
+through as an ordinary message rather than be swallowed, and the answer must be
+shaped so it satisfies the tool call -- not so it resumes the conversation with
+text, which is what the digital-avatar path does and what issue #1976 was.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.gateway.routing.pending_question import (
+    PendingQuestionRegistry,
+    build_interrupt_resume_params,
+    match_reply,
+    resolve_reply,
+)
+
+OPTIONS = ("Alpha", "Beta", "Gamma")
+OPTIONS_WITH_OTHER = ("Yes", "No", "Other")
+
+
+# ------------------------------------------------------------ reply matching
+
+
+@pytest.mark.parametrize("text", ["2", " 2 ", "2.", "(2)", "[2]", "2、", "2:"])
+def test_an_index_selects_the_option(text: str) -> None:
+    assert match_reply(text, OPTIONS) == "Beta"
+
+
+def test_a_label_selects_itself() -> None:
+    assert match_reply("Gamma", OPTIONS) == "Gamma"
+
+
+def test_a_label_matches_case_insensitively() -> None:
+    assert match_reply("gamma", OPTIONS) == "Gamma"
+
+
+@pytest.mark.parametrize("text", ["0", "4", "99"])
+def test_an_index_outside_the_range_is_not_an_answer(text: str) -> None:
+    """Falling back to the first option would answer for the user."""
+    assert match_reply(text, OPTIONS) is None
+
+
+def test_an_unrelated_message_is_not_an_answer() -> None:
+    """It must reach the agent as an ordinary message, not vanish."""
+    assert match_reply("actually, wait", OPTIONS) is None
+
+
+def test_an_empty_reply_is_not_an_answer() -> None:
+    assert match_reply("   ", OPTIONS) is None
+    assert match_reply("", ()) is None
+
+
+def test_a_free_text_question_takes_the_whole_reply() -> None:
+    assert match_reply("  use the second one  ", ()) == "use the second one"
+
+
+# ------------------------------------------------------- Other / custom_input
+#
+# Structured ask_user payloads always append an "Other" option (#2330 /
+# StructuredAskUserRail). The plain-text fallback must not treat a bare
+# "Other" selection as a complete answer, and any free text that is not a
+# listed option must resume as custom_input for "Other" -- not
+# selected_options=["Other"] alone, which StructuredAskUserRail rejects as
+# an empty answer.
+
+
+def test_a_real_option_still_resolves_normally_when_other_is_present() -> None:
+    assert resolve_reply("1", OPTIONS_WITH_OTHER) == ("Yes", "")
+    assert resolve_reply("No", OPTIONS_WITH_OTHER) == ("No", "")
+
+
+@pytest.mark.parametrize("text", ["3", "Other", "other", " OTHER "])
+def test_bare_other_by_number_or_label_is_not_a_complete_answer(text: str) -> None:
+    """Other exists to carry custom text; alone it must not resume the tool."""
+    assert resolve_reply(text, OPTIONS_WITH_OTHER) is None
+
+
+def test_free_text_that_matches_no_option_becomes_other_custom_input() -> None:
+    assert resolve_reply("I'd like something else entirely", OPTIONS_WITH_OTHER) == (
+        "Other",
+        "I'd like something else entirely",
+    )
+
+
+def test_an_out_of_range_index_becomes_other_custom_input_when_other_is_offered() -> None:
+    """A stray number is still free text once the question offers a custom path."""
+    assert resolve_reply("99", OPTIONS_WITH_OTHER) == ("Other", "99")
+
+
+def test_unmatched_text_without_other_still_falls_through() -> None:
+    """No Other option means the pre-existing "let it through" behavior is unchanged."""
+    assert resolve_reply("actually, wait", OPTIONS) is None
+
+
+def test_resolve_reply_matches_match_reply_for_free_text_questions() -> None:
+    assert resolve_reply("  use the second one  ", ()) == ("use the second one", "")
+
+
+def test_resolve_reply_on_empty_text_is_not_an_answer() -> None:
+    assert resolve_reply("   ", OPTIONS_WITH_OTHER) is None
+
+
+# ---------------------------------------------------------------- registry
+
+
+def _registry() -> PendingQuestionRegistry:
+    return PendingQuestionRegistry()
+
+
+def test_a_registered_question_resolves_its_reply() -> None:
+    reg = _registry()
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="chat-9", options=OPTIONS)
+
+    resolved = reg.resolve("telegram", "chat-9", "2")
+
+    assert resolved is not None
+    question, answer, custom_input = resolved
+    assert question.request_id == "req-1"
+    assert answer == "Beta"
+    assert custom_input == ""
+
+
+def test_resolving_consumes_the_question() -> None:
+    reg = _registry()
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="chat-9", options=OPTIONS)
+
+    assert reg.resolve("telegram", "chat-9", "1") is not None
+    assert reg.resolve("telegram", "chat-9", "1") is None
+
+
+def test_a_non_answer_does_not_consume_the_question() -> None:
+    """A stray message must not eat the question the user has yet to answer."""
+    reg = _registry()
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="chat-9", options=OPTIONS)
+
+    assert reg.resolve("telegram", "chat-9", "hold on") is None
+    assert reg.resolve("telegram", "chat-9", "3") is not None
+
+
+def test_questions_are_scoped_per_conversation() -> None:
+    reg = _registry()
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="chat-9", options=OPTIONS)
+
+    assert reg.resolve("telegram", "other-chat", "1") is None
+    assert reg.resolve("slack", "chat-9", "1") is None
+    assert reg.resolve("telegram", "chat-9", "1") is not None
+
+
+def test_a_second_question_replaces_the_first() -> None:
+    """The agent can only block on one ask_user per conversation."""
+    reg = _registry()
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="chat-9", options=OPTIONS)
+    reg.register(request_id="req-2", channel_id="telegram", conversation_key="chat-9", options=("Yes", "No"))
+
+    resolved = reg.resolve("telegram", "chat-9", "1")
+    assert resolved is not None
+    assert resolved[0].request_id == "req-2"
+    assert resolved[1] == "Yes"
+
+
+def test_an_expired_question_stops_shadowing_ordinary_messages() -> None:
+    reg = PendingQuestionRegistry(ttl=-1)
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="chat-9", options=OPTIONS)
+
+    assert reg.peek("telegram", "chat-9") is None
+    assert reg.resolve("telegram", "chat-9", "1") is None
+
+
+def test_cleanup_reports_what_it_dropped() -> None:
+    reg = PendingQuestionRegistry(ttl=-1)
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="a", options=OPTIONS)
+    reg.register(request_id="req-2", channel_id="telegram", conversation_key="b", options=OPTIONS)
+
+    assert reg.cleanup_expired() == 2
+
+
+def test_discard_removes_without_an_answer() -> None:
+    reg = _registry()
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="chat-9", options=OPTIONS)
+    reg.discard("telegram", "chat-9")
+    assert reg.peek("telegram", "chat-9") is None
+
+
+def test_bare_other_reply_leaves_the_question_pending() -> None:
+    """A bare Other selection is not a complete answer -- it must stay answerable."""
+    reg = _registry()
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="chat-9", options=OPTIONS_WITH_OTHER)
+
+    assert reg.resolve("telegram", "chat-9", "Other") is None
+    assert reg.peek("telegram", "chat-9") is not None
+
+
+def test_custom_text_reply_resolves_with_other_and_consumes_the_question() -> None:
+    reg = _registry()
+    reg.register(request_id="req-1", channel_id="telegram", conversation_key="chat-9", options=OPTIONS_WITH_OTHER)
+
+    resolved = reg.resolve("telegram", "chat-9", "Maybe both, actually")
+
+    assert resolved is not None
+    question, answer, custom_input = resolved
+    assert question.request_id == "req-1"
+    assert answer == "Other"
+    assert custom_input == "Maybe both, actually"
+    assert reg.peek("telegram", "chat-9") is None
+
+
+# ------------------------------------------------------------- answer shape
+
+
+def test_the_answer_is_shaped_like_an_interrupt_resume() -> None:
+    """CLI/Web resume via chat.send + source=ask_user_interrupt, not chat.user_answer."""
+    params = build_interrupt_resume_params("req-1", "Beta", question="Which one?")
+
+    assert params["query"] == ""
+    assert params["request_id"] == "req-1"
+    assert params["source"] == "ask_user_interrupt"
+    assert params["answers"][0]["selected_options"] == ["Beta"]
+    assert params["answers"][0]["question"] == "Which one?"
+    assert "custom_input" not in params["answers"][0]
+
+
+def test_custom_input_travels_alongside_the_other_selection() -> None:
+    """Matches the shape StructuredAskUserRail expects to recover free text (#2330)."""
+    params = build_interrupt_resume_params(
+        "req-1", "Other", question="Which one?", custom_input="Something else",
+    )
+
+    assert params["answers"][0]["selected_options"] == ["Other"]
+    assert params["answers"][0]["custom_input"] == "Something else"
+
+
+def test_register_keeps_the_interrupt_source() -> None:
+    reg = _registry()
+    reg.register(
+        request_id="req-1",
+        channel_id="telegram",
+        conversation_key="chat-9",
+        options=OPTIONS,
+        source="ask_user_interrupt",
+        question="Which one?",
+    )
+    pending = reg.peek("telegram", "chat-9")
+    assert pending is not None
+    assert pending.source == "ask_user_interrupt"
+    assert pending.question == "Which one?"

--- a/tests/unit_tests/gateway/test_telegram_stream_delivery.py
+++ b/tests/unit_tests/gateway/test_telegram_stream_delivery.py
@@ -1,0 +1,92 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Telegram must use stream RPC without spamming the chat with deltas."""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.schema import Message
+from jiuwenswarm.common.schema.message import EventType
+from jiuwenswarm.gateway.channel_manager.im_platforms.telegram.telegram_connect import (
+    build_telegram_inbound_message,
+    should_deliver_telegram_outbound,
+)
+
+
+def _msg(*, event_type=None, content="", msg_type="res"):
+    payload = {"content": content}
+    if event_type is not None:
+        payload["event_type"] = (
+            event_type.value if isinstance(event_type, EventType) else event_type
+        )
+    return Message(
+        id="m1",
+        type=msg_type,
+        channel_id="telegram",
+        session_id="telegram_1",
+        params={"content": content} if content else {},
+        timestamp=0.0,
+        ok=True,
+        payload=payload,
+        event_type=event_type if isinstance(event_type, EventType) else None,
+        metadata={"chat_id": 1},
+    )
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        EventType.CHAT_FINAL,
+        EventType.CHAT_ERROR,
+        EventType.CHAT_INTERRUPT_RESULT,
+        EventType.HEARTBEAT_RELAY,
+    ],
+)
+def test_final_like_events_are_delivered(event_type: EventType) -> None:
+    assert should_deliver_telegram_outbound(_msg(event_type=event_type, content="hi")) is True
+
+
+def test_plain_res_without_event_type_is_delivered() -> None:
+    """Unary complete responses still need to reach the user."""
+    assert should_deliver_telegram_outbound(_msg(content="hello", msg_type="res")) is True
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        EventType.CHAT_DELTA,
+        EventType.CHAT_REASONING,
+        EventType.CHAT_TOOL_CALL,
+        EventType.CHAT_TOOL_RESULT,
+        EventType.CHAT_PROCESSING_STATUS,
+        EventType.CHAT_ASK_USER_QUESTION,
+        EventType.TODO_UPDATED,
+        EventType.CHAT_USAGE_METADATA,
+    ],
+)
+def test_stream_noise_is_not_delivered(event_type: EventType) -> None:
+    """Telegram has no edit-in-place UI; delivering deltas would spam the chat."""
+    assert should_deliver_telegram_outbound(_msg(event_type=event_type, content="x")) is False
+
+
+def test_empty_final_is_not_worth_delivering() -> None:
+    assert should_deliver_telegram_outbound(_msg(event_type=EventType.CHAT_FINAL, content="")) is False
+
+
+def test_inbound_chat_send_uses_stream_rpc() -> None:
+    """Without stream RPC, ask_user never emits chat.ask_user_question to the gateway."""
+    msg = build_telegram_inbound_message(
+        message_id="9",
+        session_id="telegram_1",
+        text="hi",
+        chat_id=1,
+        user_id=1,
+        username=None,
+        is_group_chat=False,
+    )
+    from jiuwenswarm.common.schema.message import ReqMethod
+
+    assert msg.is_stream is True
+    assert msg.req_method == ReqMethod.CHAT_SEND
+    assert msg.params["query"] == "hi"

--- a/tests/unit_tests/gateway/test_text_channel_stream_delivery.py
+++ b/tests/unit_tests/gateway/test_text_channel_stream_delivery.py
@@ -1,0 +1,124 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Streaming reaches the four silent channels without flooding them.
+
+``chat.ask_user_question`` is only emitted as a stream chunk, so Discord, Slack,
+WhatsApp and DingTalk -- which all built their inbound request without
+``is_stream`` -- never saw the question at all. Turning streaming on is half the
+fix; the other half is not posting every delta and tool call as its own message.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.schema import Message
+from jiuwenswarm.common.schema.message import EventType
+from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.text_delivery import (
+    STREAM_INTERMEDIATE_EVENTS,
+    is_stream_intermediate,
+)
+
+
+def _msg(event_type=None, *, payload_event=None, content="hi"):
+    payload = {"content": content}
+    if payload_event is not None:
+        payload["event_type"] = payload_event
+    return Message(
+        id="m1",
+        type="res",
+        channel_id="slack",
+        session_id="s1",
+        params={"content": content},
+        timestamp=0.0,
+        ok=True,
+        event_type=event_type,
+        payload=payload,
+        metadata={},
+    )
+
+
+# ------------------------------------------------------------ what is dropped
+
+
+@pytest.mark.parametrize("event", sorted(STREAM_INTERMEDIATE_EVENTS, key=lambda e: e.value))
+def test_every_stream_intermediate_is_dropped(event) -> None:
+    assert is_stream_intermediate(_msg(event)) is True
+
+
+def test_the_raw_question_is_dropped() -> None:
+    """The plain-text fallback rewrites it before send(); arriving raw means the rewrite declined."""
+    assert is_stream_intermediate(_msg(EventType.CHAT_ASK_USER_QUESTION)) is True
+
+
+def test_an_event_type_only_in_the_payload_is_still_recognised() -> None:
+    """A forwarded chunk may carry the string without the enum."""
+    assert is_stream_intermediate(_msg(payload_event="chat.tool_call")) is True
+
+
+# ------------------------------------------------------------ what survives
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        EventType.CHAT_FINAL,
+        EventType.CHAT_ERROR,
+        EventType.CHAT_FILE,
+        EventType.CHAT_MEDIA,
+        EventType.TEAM_MESSAGE,
+        EventType.CHAT_INTERRUPT_RESULT,
+        EventType.HEARTBEAT_RELAY,
+    ],
+)
+def test_deliverable_events_survive(event) -> None:
+    """The rule removes what streaming newly introduces, nothing else."""
+    assert is_stream_intermediate(_msg(event)) is False
+
+
+def test_a_message_with_no_event_type_survives() -> None:
+    """A plain unary response envelope must still be delivered."""
+    assert is_stream_intermediate(_msg(None)) is False
+
+
+def test_the_b3_notice_survives() -> None:
+    """The plain-text fallback rewrites the question into a chat.final, which must get through."""
+    notice = _msg(EventType.CHAT_FINAL, payload_event="chat.final", content="1. Alpha")
+    assert is_stream_intermediate(notice) is False
+
+
+# --------------------------------------------------- the four inbound requests
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "jiuwenswarm.gateway.channel_manager.im_platforms.slack.slack_connect",
+        "jiuwenswarm.gateway.channel_manager.im_platforms.discord.discord_connect",
+        "jiuwenswarm.gateway.channel_manager.im_platforms.whatsapp.whatsapp_connect",
+        "jiuwenswarm.gateway.channel_manager.im_platforms.dingtalk.dingtalk_connect",
+    ],
+)
+def test_the_channel_module_imports(module_path: str) -> None:
+    """The guard is called at send time, so a bad import fails only in production."""
+    import importlib
+
+    module = importlib.import_module(module_path)
+    assert module is not None
+
+
+@pytest.mark.parametrize(
+    "source_path",
+    [
+        "jiuwenswarm/gateway/channel_manager/im_platforms/slack/slack_connect.py",
+        "jiuwenswarm/gateway/channel_manager/im_platforms/discord/discord_connect.py",
+        "jiuwenswarm/gateway/channel_manager/im_platforms/whatsapp/whatsapp_connect.py",
+        "jiuwenswarm/gateway/channel_manager/im_platforms/dingtalk/dingtalk_connect.py",
+    ],
+)
+def test_the_inbound_request_streams(source_path: str) -> None:
+    """Without is_stream the question is never emitted and the plain-text fallback is inert."""
+    from pathlib import Path
+
+    source = Path(source_path).read_text(encoding="utf-8")
+    assert "is_stream=True" in source, f"{source_path} still builds a non-streaming request"

--- a/tests/unit_tests/gateway/test_wechat_standalone_notice.py
+++ b/tests/unit_tests/gateway/test_wechat_standalone_notice.py
@@ -1,0 +1,66 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""WeChat must not wipe the delta accumulator for ask_user plain-text notices."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from jiuwenswarm.common.schema.message import EventType, Message
+from jiuwenswarm.gateway.channel_manager.im_platforms.wechat.wechat_connect import (
+    WechatChannel,
+)
+
+
+@pytest.mark.asyncio
+async def test_standalone_notice_keeps_delta_session() -> None:
+    channel = WechatChannel.__new__(WechatChannel)
+    channel._http = object()
+    channel.config = SimpleNamespace(bot_token="tok", enable_streaming=True)
+    channel._delta_accumulator = SimpleNamespace(
+        add_chunk=lambda *a, **k: None,
+        flush=lambda *a, **k: "",
+        clear=lambda key: cleared.append(key),
+    )
+    channel._delta_leading = {"sess": "partial answer"}
+    channel._streaming_sessions = {"user-1"}
+    channel._continue_active_sessions = set()
+    channel.current_round = 3
+    channel._current_round_session_key = "user-1"
+    cleared: list[str] = []
+
+    channel._extract_platform_user_id = lambda msg: "user-1"
+    channel._is_reasoning_chunk = lambda msg: False
+    channel._strip_think_tags = lambda text: text
+    channel._is_thinking_only_content = lambda text: False
+    channel._extract_content = lambda msg: "Which environment?\n\n1. staging\n2. production"
+    channel._should_skip_due_to_send_limit = AsyncMock(return_value=False)
+    channel._send_text_chunks_to_user = AsyncMock()
+    channel._is_stream_accept_ack_only = lambda msg: False
+    channel._is_stream_complete_marker = lambda msg: False
+    channel._delta_session_key = lambda msg: "sess"
+    channel._message_session_key = lambda msg: "user-1"
+    channel._take_accumulated_delta = lambda msg: None
+
+    msg = Message(
+        id="q-1",
+        type="res",
+        channel_id="wechat",
+        session_id="sess",
+        params={"content": "Which environment?\n\n1. staging\n2. production"},
+        timestamp=0.0,
+        ok=True,
+        event_type=EventType.CHAT_FINAL,
+        payload={"content": "Which environment?\n\n1. staging\n2. production"},
+        metadata={"standalone_notice": True, "ask_user_request_id": "req-1"},
+    )
+
+    assert await channel.send(msg) is True
+    channel._send_text_chunks_to_user.assert_awaited_once()
+    assert cleared == []
+    assert channel._delta_leading == {"sess": "partial answer"}
+    assert "user-1" in channel._streaming_sessions
+    assert channel.current_round == 3

--- a/tests/unit_tests/gateway/test_xiaoyi_send_delivery.py
+++ b/tests/unit_tests/gateway/test_xiaoyi_send_delivery.py
@@ -1,0 +1,177 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""``XiaoyiChannel.send()`` must report success only when it actually delivered.
+
+Team fan-out (``deliver_with_ask_user_fallback`` /
+``_channel_send_delivered``) registers a pending ``ask_user`` question only
+when ``channel.send`` returns ``True``. ``_send_team`` had branches --
+invalid delivery target, a filtered event, and no ws/push/legacy channel
+available -- that logged a drop and sent nothing, yet ``send()`` always
+returned ``True`` for the team path regardless of what ``_send_team`` did.
+A pending question registered for a notice the human never received leaves
+the ask_user tool call blocked with no way to answer it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.schema import Message
+from jiuwenswarm.common.schema.message import EventType
+from jiuwenswarm.gateway.channel_manager.im_platforms.xiaoyi.xiaoyi_connect import (
+    XiaoyiChannel,
+    XiaoyiChannelConfig,
+)
+from jiuwenswarm.gateway.channel_manager.base import RobotMessageRouter
+from jiuwenswarm.gateway.routing.keys import XiaoyiDeliveryTarget
+from jiuwenswarm.gateway.routing.session_sharing import RoutingTarget
+
+
+def _channel() -> XiaoyiChannel:
+    return XiaoyiChannel(XiaoyiChannelConfig(enabled=True, channel_id="xiaoyi"), RobotMessageRouter())
+
+
+def _final_msg(content: str = "the answer") -> Message:
+    return Message(
+        id="msg-1",
+        type="res",
+        channel_id="xiaoyi",
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        event_type=EventType.CHAT_FINAL,
+        payload={"event_type": "chat.final", "content": content},
+    )
+
+
+def _routing_target(delivery) -> RoutingTarget:
+    return RoutingTarget(intent="private", delivery=delivery)
+
+
+# ------------------------------------------------------- the drop that lied
+
+
+@pytest.mark.asyncio
+async def test_send_reports_failure_when_no_ws_push_or_legacy_channel_exists() -> None:
+    """The exact branch named in the bug report: '_send_team drop: no ws/push/legacy'."""
+    channel = _channel()
+    # No push_id, no active ws mapping for this agent_id, and no ws connections
+    # at all -- _send_team must fall into its final "drop" branch.
+    delivery = XiaoyiDeliveryTarget(agent_id="agent-1", push_id="")
+
+    delivered = await channel.send(_final_msg(), routing_target=_routing_target(delivery))
+
+    assert delivered is False
+
+
+@pytest.mark.asyncio
+async def test_send_reports_failure_for_an_invalid_delivery_target() -> None:
+    channel = _channel()
+
+    delivered = await channel.send(_final_msg(), routing_target=_routing_target(None))
+
+    assert delivered is False
+
+
+@pytest.mark.asyncio
+async def test_send_reports_failure_for_a_filtered_intermediate_event() -> None:
+    """CHAT_DELTA is intentionally dropped for team members; that is not a delivery."""
+    channel = _channel()
+    delivery = XiaoyiDeliveryTarget(agent_id="agent-1", push_id="push-1")
+    msg = Message(
+        id="msg-delta",
+        type="res",
+        channel_id="xiaoyi",
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        event_type=EventType.CHAT_DELTA,
+        payload={"event_type": "chat.delta", "delta": "partial"},
+    )
+
+    delivered = await channel.send(msg, routing_target=_routing_target(delivery))
+
+    assert delivered is False
+
+
+# --------------------------------------------------------- the real deliveries
+
+
+@pytest.mark.asyncio
+async def test_send_reports_success_when_a_push_is_actually_sent(monkeypatch) -> None:
+    channel = _channel()
+    sent: list[tuple[str, str, str]] = []
+
+    async def _fake_push(agent_id: str, push_id: str, content: str) -> None:
+        sent.append((agent_id, push_id, content))
+
+    monkeypatch.setattr(channel, "_send_push_to_user", _fake_push)
+    delivery = XiaoyiDeliveryTarget(agent_id="agent-1", push_id="push-1")
+
+    delivered = await channel.send(_final_msg("hello"), routing_target=_routing_target(delivery))
+
+    assert delivered is True
+    assert sent == [("agent-1", "push-1", "hello")]
+
+
+@pytest.mark.asyncio
+async def test_send_reports_success_when_ws_is_active(monkeypatch) -> None:
+    channel = _channel()
+    channel._ws_connections["ws_url1"] = object()
+    channel._active_push_sessions["agent-1"] = ("xy-session", "xy-task", "push-1", __import__("time").time())
+    sent: list[tuple[str, str]] = []
+
+    async def _fake_ws(session_id, task_id, msg, content):
+        sent.append((session_id, task_id))
+
+    monkeypatch.setattr(channel, "_send_ws_to_user", _fake_ws)
+    delivery = XiaoyiDeliveryTarget(agent_id="agent-1", push_id="push-1")
+
+    delivered = await channel.send(_final_msg("hi"), routing_target=_routing_target(delivery))
+
+    assert delivered is True
+    assert sent == [("xy-session", "xy-task")]
+
+
+@pytest.mark.asyncio
+async def test_send_reports_success_via_legacy_fallback(monkeypatch) -> None:
+    """No push_id, no active session, but a ws connection exists -- legacy fallback."""
+    channel = _channel()
+    channel._ws_connections["ws_url1"] = object()
+    sent: list[Message] = []
+
+    async def _fake_legacy(msg: Message) -> None:
+        sent.append(msg)
+
+    monkeypatch.setattr(channel, "_send_legacy", _fake_legacy)
+    delivery = XiaoyiDeliveryTarget(agent_id="agent-1", push_id="")
+
+    msg = _final_msg("legacy path")
+    delivered = await channel.send(msg, routing_target=_routing_target(delivery))
+
+    assert delivered is True
+    assert sent == [msg]
+
+
+# ------------------------------------------------------- non-team path unchanged
+
+
+@pytest.mark.asyncio
+async def test_non_team_send_still_returns_false_without_a_ws_connection() -> None:
+    channel = _channel()
+    assert await channel.send(_final_msg()) is False
+
+
+@pytest.mark.asyncio
+async def test_non_team_send_still_returns_true_with_a_ws_connection(monkeypatch) -> None:
+    channel = _channel()
+    channel._ws_connections["ws_url1"] = object()
+
+    async def _fake_legacy(msg: Message) -> None:
+        return None
+
+    monkeypatch.setattr(channel, "_send_legacy", _fake_legacy)
+
+    assert await channel.send(_final_msg()) is True


### PR DESCRIPTION
Paired: [GitHub #2480](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2480) ↔ [GitCode !4589](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4589)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!--
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block.

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind bug


**What does this PR do / why do we need it**:

The `ask_user` tool emits `chat.ask_user_question`, and of the nine IM platforms
only Feishu renders it, as an interactive card. On the other eight the agent
asks a question, nothing reaches the human, and the conversation hangs on a
tool result that will never arrive. A silent hang rather than a missing
notification.

A question now becomes a numbered text message on any channel that cannot draw
one, and a reply to it resumes the blocked call.

```
Which environment should I deploy to?

1. staging
2. production

Reply with the number of your choice.
```

Replying `2` resumes the agent with `production`.

## The resume path is the load-bearing decision

The answer is sent as a streaming `chat.send` carrying
`source="ask_user_interrupt"`, `request_id` and `answers` — the same shape the
CLI and Web use, and what `_is_interrupt_resume_chat_send` already recognises
against a module-level set that already lists that source.

`chat.user_answer` looks like the obvious choice and is wrong: it only reaches
evolution-approval handling, so the tool stays hung. `cli/chat.py` says so
outright — *"Using chat.user_answer here would NOT resume the task."* Feishu's
card callback does emit `chat.user_answer`, which is what makes the wrong path
look verified.

This is also not the digital-avatar follow-up in `im_pipeline`. That mechanism
is triggered by a regex on the model's own text and resumes by injecting the
answer as a new user message. Confusing the two is issue **#1976**, where the
option card re-popped forever because the answer was swallowed, so the stores
are kept separate: `pending_question.py` is deliberately not
`PendingInteraction`.

## Streaming is what makes the question exist at all

`chat.ask_user_question` is only emitted as a stream chunk. Five channels built
their inbound `chat.send` without `is_stream`, which defaults to `False`, so
AgentServer never produced the event and the rewrite had nothing to rewrite.
This was invisible to every unit test, because the tests inject the question
event directly; the Telegram live round trip is what surfaced it.

Turning streaming on cannot stand alone: the same switch starts emitting
deltas, reasoning and tool activity, and these channels have no edit-in-place
UI, so each chunk would arrive as its own message.

Telegram uses an allowlist of deliverable events, backed by a live test.
Discord, Slack, WhatsApp and DingTalk use a denylist of stream intermediates
instead, because they each deliver a different set today and none could be
verified live here — dropping a message a channel used to deliver is a worse
failure than letting one noisy event through. Two placements are load-bearing:
in DingTalk the guard sits after the file/media branch, since a file event
carries no text and has its own path, and in WhatsApp the existing
`enable_streaming` delta guard is left untouched because an operator who turned
it on wanted those deltas.

## Where the hooks go

Outbound at `ChannelManager`'s dispatch loop and at `SessionDispatcher`'s
fan-out, because those are two different delivery paths — fan-out calls
`channel.send` directly and would otherwise ship the raw event. Inbound in the
`message_handler` consume loop, right after channel state is applied and before
the branch that handles what it converts the message into.

Not in `im_outbound`/`im_inbound`: both return early unless the session is a
digital avatar, and only Feishu and WeCom ever register adapters with them.
They are the avatar router, not a general path.

Registration happens only after a successful send, so a delivery failure cannot
leave a record that later steals a bare `"1"`. The physical delivery channel is
passed explicitly, since under fan-out it differs from `msg.channel_id`.

## Decisions worth stating

A reply that selects nothing stays an ordinary `chat.send` and reaches the
agent unchanged, with the question still pending. Swallowing it would be a new
way to lose a user's words — the failure this feature exists to fix. An index
outside the range is a miss for the same reason: falling back to the first
option would answer for the user.

Content alone is not enough on the wire. WeCom and WeChat gate delivery on
event type before reading the text, so the rewrite sets `CHAT_FINAL`, gives the
notice its own id, and strips stream-binding keys that would fold it into the
in-flight answer. It is marked standalone so WeChat does not clear the delta
accumulator and lose the real reply.

A payload with no `request_id` is not rendered: without it the resume has
nothing to target. Only the first question is shown, matching Feishu's card,
because two interleaved option sets could not be answered by `"2"`. A free-text
question takes the whole reply and says so.

State is in memory, matching Feishu's `_user_question_card`. A restart loses
pending questions — the same exposure the card path already has, and better
than persisting a record whose only consumer is one process's in-flight tool
call.

Feishu is untouched and keeps its card.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2475


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- **111 tests** across five suites: formatting and envelope, reply correlation,
  gateway wiring, Telegram delivery, and the shared text-channel rule. The
  wiring suites exist because the pure-unit suites cannot see a `NameError` in a
  locally-imported symbol, and two cases assert the channel sources keep
  `is_stream=True`, because that switch is only exercised at runtime.
- **Gateway regression:** 581 passed, 3 failed — pre-existing and environmental
  (`test_message_handler_security_review_prompt` expects `origin/master` while
  the machine defaults to `main`), confirmed by running them in a worktree
  without these changes.
- **Live:** verified end to end on Telegram — asked a question, received the
  numbered text, replied with the index, agent resumed. The other seven
  channels are covered by tests only.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1976
- Fixes #2475
<!-- /bot1-related-issues -->
