### PR TITLE
fix(logging): repair nine logger calls that silently drop their record

### DIFF
--- a/jiuwenswarm/agents/harness/common/memory/dreaming/sweeper.py
+++ b/jiuwenswarm/agents/harness/common/memory/dreaming/sweeper.py
@@ -470,7 +470,7 @@ class Sweeper:
                 m = re.search(r'^name:\s*(.+)$', text, re.MULTILINE)
                 lines.append(f"- {m.group(1).strip()}" if m else f"- {f.stem}")
             except Exception:
-                logger.warning("[dreaming] failed to read consolidated file %s: %s", f, exc_info=True)
+                logger.warning("[dreaming] failed to read consolidated file %s", f, exc_info=True)
                 continue
         return "\n".join(lines) if lines else empty_label
 
@@ -575,7 +575,7 @@ class Sweeper:
                 data = json.loads(raw) if raw.strip() else {}
                 return data if isinstance(data, dict) else {}
         except Exception:
-            logger.warning("[dreaming] failed to load checkpoint %s: %s", path, exc_info=True)
+            logger.warning("[dreaming] failed to load checkpoint %s", path, exc_info=True)
             pass
         return {}
 

--- a/jiuwenswarm/gateway/app_gateway.py
+++ b/jiuwenswarm/gateway/app_gateway.py
@@ -1177,7 +1177,12 @@ class GatewayServer(BaseWebChannel):
                         await result
                 except Exception as e:  # pragma: no cover
                     logger.warning(
-                        "%s on_disconnect hook error: %s",
+                        "WebChannel on_disconnect hook error: %s",
+                        format_ws_diagnostics(
+                            {"remote": remote, "path": request_path},
+                            describe_ws_peer(ws),
+                            describe_ws_exception(e),
+                        ),
                     )
 
     async def _handle_raw_message(self, ws: Any, raw: str, request_path: str, route: RouteConfig) -> None:

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
@@ -574,7 +574,7 @@ class FeishuChannel(BaseChannel):
             try:
                 await self._shutdown_ws_client()
             except Exception as e:
-                logger.warning("停止WebSocket客户端时发生异常: {}", e)
+                logger.warning("停止WebSocket客户端时发生异常: %s", e)
 
         if self._ws_thread_loop and self._ws_thread_loop.is_running():
             self._ws_thread_loop.call_soon_threadsafe(self._ws_thread_loop.stop)
@@ -603,7 +603,7 @@ class FeishuChannel(BaseChannel):
                 try:
                     await conn.close(code=1000, reason="bye")
                 except Exception as e:
-                    logger.debug("飞书连接关闭时出现异常: {}", e)
+                    logger.debug("飞书连接关闭时出现异常: %s", e)
 
             await asyncio.sleep(0.05)
 
@@ -615,7 +615,7 @@ class FeishuChannel(BaseChannel):
         except asyncio.TimeoutError:
             logger.debug("飞书客户端清理超时，继续停止事件循环")
         except Exception as e:
-            logger.debug("飞书客户端清理任务异常: {}", e)
+            logger.debug("飞书客户端清理任务异常: %s", e)
 
     @staticmethod
     def _patch_ws_client_shutdown(ws_client: Any) -> None:
@@ -631,7 +631,7 @@ class FeishuChannel(BaseChannel):
                 return await original_disconnect()
             except RuntimeError as e:
                 if "Lock is not acquired" in str(e):
-                    logger.debug("忽略 lark_oapi 断连并发异常: {}", e)
+                    logger.debug("忽略 lark_oapi 断连并发异常: %s", e)
                     return None
                 raise
 

--- a/jiuwenswarm/gateway/channel_manager/web/web_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/web/web_connect.py
@@ -447,7 +447,7 @@ class WebChannel(BaseWsChannel):
                 )
             except Exception as send_err:
                 logger.warning(
-                    "WebChannel failed to send handler error response ({}): {}",
+                    "WebChannel failed to send handler error response (%s): %s",
                     invocation.method, send_err,
                 )
             return False

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -7242,8 +7242,8 @@ class JiuWenSwarmDeepAdapter:
         _session_is_active = self._is_session_active(_normalized_sid)
         if not _session_is_active and intent in ("pause", "resume"):
             logger.info(
-                "[JiuWenSwarmDeepAdapter] interrupt(%s):",
-                "session=%s not active on this adapter, ",
+                "[JiuWenSwarmDeepAdapter] interrupt(%s): "
+                "session=%s not active on this adapter, "
                 "skipping pause/resume (active_sessions=%s)",
                 intent,
                 request.session_id,

--- a/tests/unit_tests/common/test_logging_format_args.py
+++ b/tests/unit_tests/common/test_logging_format_args.py
@@ -1,0 +1,108 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Guard against ``logging`` calls whose arguments cannot be formatted.
+
+``logging`` interpolates lazily with printf-style ``%`` formatting. When the
+format string and the positional arguments disagree -- ``{}`` placeholders
+copied from ``str.format``, a missing argument, or a stray comma that turns an
+intended implicit string concatenation into extra arguments -- ``Logger.emit``
+raises ``TypeError`` internally. ``Handler.handleError`` swallows it, prints
+``--- Logging error ---`` plus a traceback to stderr, and the intended record
+never reaches any handler. Because these calls live in ``except`` blocks, the
+diagnostic is lost exactly when it is needed.
+
+The mismatch is invisible until the branch executes, so it is pinned here by
+scanning the package source rather than by exercising each call site.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import jiuwenswarm
+
+PACKAGE_ROOT = Path(jiuwenswarm.__file__).parent
+
+LEVEL_METHODS = frozenset({"debug", "info", "warning", "error", "critical", "exception"})
+
+# printf-style conversion specifiers; the ``%%`` escape is not a placeholder.
+_CONVERSION = re.compile(r"%[-#0 +]*[0-9*]*(?:\.[0-9*]+)?[hlL]?[diouxXeEfFgGcrsa%]")
+
+
+def _count_placeholders(fmt: str) -> int:
+    return sum(1 for m in _CONVERSION.finditer(fmt) if not m.group(0).endswith("%"))
+
+
+def _iter_logger_calls(tree: ast.AST):
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr not in LEVEL_METHODS:
+            continue
+        owner = func.value
+        name = owner.id if isinstance(owner, ast.Name) else getattr(owner, "attr", "")
+        if "log" in name.lower():
+            yield node
+
+
+def _mismatches(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found = []
+    for node in _iter_logger_calls(tree):
+        if not node.args:
+            continue
+        fmt_node = node.args[0]
+        if not (isinstance(fmt_node, ast.Constant) and isinstance(fmt_node.value, str)):
+            continue
+        fmt = fmt_node.value
+        # ``%(name)s`` consumes a single mapping argument, so counting does not apply.
+        if "%(" in fmt:
+            continue
+        args = node.args[1:]
+        if any(isinstance(a, ast.Starred) for a in args):
+            continue
+        expected = _count_placeholders(fmt)
+        if expected != len(args):
+            rel = path.relative_to(PACKAGE_ROOT.parent)
+            found.append(
+                f"{rel}:{node.lineno}: {expected} placeholder(s) but {len(args)} "
+                f"argument(s) -- {fmt!r}"
+            )
+    return found
+
+
+def test_logging_calls_have_matching_format_arguments():
+    mismatches = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        try:
+            mismatches.extend(_mismatches(path))
+        except SyntaxError:
+            # Templates and vendored snippets are not always importable Python.
+            continue
+
+    assert mismatches == [], "logging format/argument mismatch:\n" + "\n".join(mismatches)
+
+
+def test_detector_flags_a_known_bad_call(tmp_path):
+    """The scan must actually catch the shapes this module is guarding against."""
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "import logging\n"
+        "logger = logging.getLogger(__name__)\n"
+        "logger.warning('braces instead of percent: {}', exc)\n"
+        "logger.warning('two %s slots %s', only_one)\n"
+        "logger.info('prefix(%s):', 'stray', 'commas')\n"
+        "logger.info('fine %s and %%s literal', value)\n",
+        encoding="utf-8",
+    )
+    # ``_mismatches`` reports paths relative to the package parent, so point it there.
+    tree = ast.parse(sample.read_text(encoding="utf-8"))
+    bad = [
+        node.lineno
+        for node in _iter_logger_calls(tree)
+        if node.args
+        and isinstance(node.args[0], ast.Constant)
+        and _count_placeholders(node.args[0].value) != len(node.args[1:])
+    ]
+    assert bad == [3, 4, 5]


### PR DESCRIPTION
Paired: [GitHub #2516](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2516) ↔ [GitCode !4611](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4611)

## 问题

`logging` 使用 printf 风格的 `%` 插值，并把格式化推迟到 emit 时刻。因此格式串与参数不匹配时，异常发生在 handler 内部而非调用点：`Handler.handleError` 捕获 `TypeError`，向 stderr 打印 `--- Logging error ---` 加一段回溯，而原本要记录的内容不会到达任何 handler。

九处中有八处位于 `except` 块内，也就是说日志恰好在最需要它的时候消失。

复现（Python 3.12）：

```python
>>> logging.getLogger("x").warning("停止WebSocket客户端时发生异常: {}", ValueError("boom"))
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
...
TypeError: not all arguments converted during string formatting
```

handler 收到的内容为空字符串。

## 三种形态

**一、从 `str.format` 抄来的 `{}` 占位符。** `logging` 找不到 `%` 转换符，参数全部多余。

**二、参数不足**，`exc_info=True` 占了第二个 `%s` 期待的位置。`exc_info` 是关键字参数，不是位置值：

```python
logger.warning("[dreaming] failed to load checkpoint %s: %s", path, exc_info=True)
# TypeError: not enough arguments for format string
```

**三、参数个数笔误。** `interface_deep.py` 多写了逗号，把本应是隐式字符串拼接的三段变成三个额外参数——紧邻的 `elif` 分支就是正确写法。`app_gateway.py` 的 disconnect 钩子告警声明了两个转换符却一个参数都没传，捕获到的异常 `e` 从未被记录；现改为与一百行之上的 `on_connect` 钩子处理器一致。

## 修改清单

| 文件 | 行号 | 形态 |
|---|---|---|
| `feishu_connect.py` | 577, 606, 618, 634 | `{}` 占位符 |
| `web_connect.py` | 449 | `{}` 占位符 |
| `sweeper.py` | 473, 578 | 参数不足 |
| `interface_deep.py` | 7244 | 多余逗号 |
| `app_gateway.py` | 1179 | 无参数 |

无逻辑变更，只动格式串与参数列表。

## 回归测试

`tests/unit_tests/common/test_logging_format_args.py` 用 `ast` 遍历整个包，比较每个字面量 `logging` 格式串中 `%` 转换符的数量与其后的位置参数个数。映射风格 `%(name)s`、星号展开参数、非字面量格式串一律跳过（静态无法计数）。另有一个测试把三种已知错误形态喂给检测器，防止守卫退化成空转。

794 个模块，本地耗时约 1.7 秒。在修复前的代码上运行会精确报出上表九处。

## 说明

- 检出方式：`ruff --select PLE1205,PLE1206` 报出其中 6 处；另外 3 处「参数不足」是本 PR 新增的 AST 扫描发现的，ruff 未覆盖。
- 本地环境缺少 `openjiuwen` 依赖，无法运行完整单元测试套件；已验证的部分为：新增测试通过、五个改动文件 `py_compile` 通过、`ruff` 相关规则清零、AST 扫描由 9 处降为 0 处。完整套件以 CI 结果为准。

---

## Summary (EN)

`logging` uses printf-style `%` interpolation deferred to emit time, so a format string that disagrees with its arguments raises `TypeError` inside `Handler.handleError`, which prints `--- Logging error ---` to stderr and drops the record. Eight of the nine sites are in `except` blocks, so the diagnostic is lost exactly when it is needed.

Three shapes: `{}` placeholders copied from `str.format` (5 sites); too few arguments where `exc_info=True` took a `%s` slot (2 sites); argument-count typos — stray commas breaking an intended implicit string concatenation in `interface_deep.py`, and a disconnect-hook warning in `app_gateway.py` with two conversions and no arguments at all.

No logic changes. Adds an AST-based regression test that scans the package and fails on the pre-fix tree with exactly these nine findings.