### PR TITLE
fix(tui): handle tool updates and cancel streams before rewind

### DIFF
--- a/jiuwenswarm/channels/tui/frontend/src/app-state.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/app-state.ts
@@ -233,6 +233,7 @@ const DEFERRED_TRANSCRIPT_EVENTS = new Set([
   "chat.error",
   "chat.tool_call",
   "chat.tool_result",
+  "chat.tool_update",
   "chat.symphony_status",
   "chat.interrupt_result",
   "chat.ask_user_question",
@@ -569,6 +570,9 @@ export class CliPiAppState {
     },
     addToolResultPayload: (payload, sessionId, requestId, updatedAt) => {
       this.addToolResultPayload(payload, sessionId, requestId, updatedAt);
+    },
+    applyToolUpdatePayload: (payload, sessionId) => {
+      this.applyToolUpdatePayload(payload, sessionId);
     },
     addSyntheticToolExecution: (tool, sessionId, requestId, at) => {
       this.addSyntheticToolExecution(tool, sessionId, requestId, at);
@@ -3143,6 +3147,56 @@ export class CliPiAppState {
     );
     this.applyTodoToolResult(nextTool);
     this.scheduleToolTimeoutCheck();
+  }
+
+  private applyToolUpdatePayload(payload: Record<string, unknown>, sessionId: string): void {
+    const update =
+      payload.tool_update && typeof payload.tool_update === "object"
+        ? (payload.tool_update as Record<string, unknown>)
+        : payload;
+    const toolCallId =
+      typeof update.tool_call_id === "string"
+        ? update.tool_call_id
+        : typeof payload.tool_call_id === "string"
+          ? payload.tool_call_id
+          : "";
+    if (!toolCallId) {
+      return;
+    }
+
+    const execution = this.toolExecutions.get(toolCallId);
+    if (!execution || execution.tool.status !== "running") {
+      return;
+    }
+
+    const beam = update.beam_search_event;
+    let summary = execution.tool.summary;
+    if (beam && typeof beam === "object") {
+      const event = (beam as Record<string, unknown>).event;
+      if (typeof event === "string" && event.trim()) {
+        summary = `Beam search: ${event.trim()}`;
+      }
+    }
+    if (summary === execution.tool.summary) {
+      return;
+    }
+
+    const nextTool: ToolCallDisplay = {
+      ...execution.tool,
+      summary,
+    };
+    const nowIso = new Date().toISOString();
+    this.toolExecutions.set(toolCallId, {
+      ...execution,
+      tool: nextTool,
+      updatedAt: nowIso,
+    });
+    this.entries = upsertToolGroupDisplay(
+      this.entries,
+      sessionId,
+      execution.requestId,
+      nextTool,
+    );
   }
 
   private applyTodoToolResult(tool: ToolCallDisplay): void {

--- a/jiuwenswarm/channels/tui/frontend/src/core/event-handlers.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/event-handlers.ts
@@ -156,6 +156,7 @@ export interface AppEventDelegate {
     requestId?: string,
     updatedAt?: string,
   ): void;
+  applyToolUpdatePayload(payload: Record<string, unknown>, sessionId: string): void;
   addSyntheticToolExecution(
     tool: ToolCallDisplay,
     sessionId: string,
@@ -1162,6 +1163,10 @@ export function handleIncomingFrame(delegate: AppEventDelegate, frame: EventFram
         typeof payload.request_id === "string" ? payload.request_id : undefined,
       );
       _handleWorktreeToolResult(delegate, payload);
+      return true;
+
+    case "chat.tool_update":
+      delegate.applyToolUpdatePayload(payload, activeSessionId);
       return true;
 
     case "chat.symphony_status": {

--- a/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
@@ -882,9 +882,37 @@ def resolve_3rdagent_switch_session_id(params: dict | None) -> str:
     return str(params.get("session_id") or "").strip()
 
 
+async def _cancel_session_work_before_rewind(
+    message_handler: Any,
+    target_sid: str,
+    *,
+    user_id: str | None = None,
+) -> None:
+    """Stop in-flight gateway streams and AgentServer work before /rewind."""
+    if message_handler is None:
+        return
+    sid = (target_sid or "").strip()
+    if not sid:
+        return
+    try:
+        await message_handler.cancel_agent_session_work(
+            "tui",
+            sid,
+            user_id=user_id,
+            publish_interrupt_result=False,
+        )
+    except Exception:
+        logger.warning(
+            "[cli rewind] cancel in-flight work failed: session_id=%s",
+            sid,
+            exc_info=True,
+        )
+
+
 def register_cli_handlers(bind: CliHandlersBindParams) -> None:
     channel = bind.channel
     agent_client = bind.agent_client
+    message_handler = bind.message_handler
     on_config_saved = bind.on_config_saved
     path = bind.path
     cron_controller_ref = bind.cron_controller
@@ -1983,6 +2011,9 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             )
             return
 
+        await _cancel_session_work_before_rewind(
+            message_handler, target_sid, user_id=user_id,
+        )
         if await _forward_rewind_e2a(
             ForwardRewindE2AParams(
                 ws=ws,
@@ -2062,6 +2093,9 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             )
             return
 
+        await _cancel_session_work_before_rewind(
+            message_handler, target_sid, user_id=user_id,
+        )
         if await _forward_rewind_e2a(
             ForwardRewindE2AParams(
                 ws=ws,

--- a/jiuwenswarm/gateway/message_handler/message_handler.py
+++ b/jiuwenswarm/gateway/message_handler/message_handler.py
@@ -1564,6 +1564,43 @@ class MessageHandler(ABC):
             )
             return False
 
+    async def cancel_agent_session_work(
+        self,
+        channel_id: str,
+        session_id: str,
+        *,
+        user_id: str | None = None,
+        publish_interrupt_result: bool = False,
+    ) -> bool:
+        """Cancel gateway streams and AgentServer work for one session.
+
+        Control commands such as TUI rewind reuse the disconnect cancel stub.
+        ``publish_interrupt_result`` defaults to ``False`` so rewind does not
+        surface an intermediate interrupt notice to the user.
+        """
+        cid = (channel_id or "").strip()
+        sid = (session_id or "").strip()
+        if not cid or not sid:
+            return True
+        stub = self._build_disconnect_cancel_message(cid, sid, user_id=user_id)
+        try:
+            return bool(
+                await self._cancel_agent_work_for_session(
+                    stub,
+                    sid,
+                    publish_interrupt_result=publish_interrupt_result,
+                    channel_id=cid,
+                )
+            )
+        except Exception:
+            logger.warning(
+                "[MessageHandler] session work cancel failed: channel_id=%s session_id=%s",
+                cid,
+                sid,
+                exc_info=True,
+            )
+            return False
+
     async def _delayed_disconnect_cancel(
         self,
         channel_id: str,

--- a/tests/unit_tests/agents/test_pdf_tools.py
+++ b/tests/unit_tests/agents/test_pdf_tools.py
@@ -188,7 +188,7 @@ async def test_read_pdf_subset_discloses_the_pages_it_skipped(tmp_path: Path):
     pdf_path = tmp_path / "sample.pdf"
     pdf_path.write_bytes(_build_minimal_pdf([f"Page {i} body" for i in range(1, 6)]))
 
-    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path), "pages": "1-2"}})
+    result = await read_pdf.invoke({"pdf_path": str(pdf_path), "pages": "1-2"})
 
     # The page text a caller passing `pages` already got is unchanged.
     assert "Page 1 body" in result
@@ -213,7 +213,7 @@ async def test_read_pdf_discloses_pages_lost_to_the_page_cap(tmp_path: Path):
     pdf_path = tmp_path / "big.pdf"
     pdf_path.write_bytes(_build_minimal_pdf([f"Page {i} body" for i in range(1, 102)]))
 
-    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path)}})
+    result = await read_pdf.invoke({"pdf_path": str(pdf_path)})
 
     assert "Partial read: 1 of 101 pages were NOT read" in result
     assert "pages 101" in result
@@ -231,7 +231,7 @@ async def test_read_pdf_page_cap_remedy_points_past_a_subset(tmp_path: Path):
     pdf_path = tmp_path / "big.pdf"
     pdf_path.write_bytes(_build_minimal_pdf([f"Page {i} body" for i in range(1, 102)]))
 
-    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path), "pages": "1-2"}})
+    result = await read_pdf.invoke({"pdf_path": str(pdf_path), "pages": "1-2"})
 
     assert "Partial read: 99 of 101 pages were NOT read" in result
     assert "Omit `pages` to read the whole document" not in result
@@ -245,11 +245,11 @@ async def test_read_pdf_full_read_adds_no_partial_note(tmp_path: Path):
     pdf_path.write_bytes(_build_minimal_pdf(["Alpha", "Bravo", "Charlie"]))
 
     # Default (no `pages`) reads everything, so there is nothing to disclose.
-    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path)}})
+    result = await read_pdf.invoke({"pdf_path": str(pdf_path)})
     assert "Partial read" not in result
 
     # An explicit range that happens to cover the document is a full read too.
-    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path), "pages": "1-3"}})
+    result = await read_pdf.invoke({"pdf_path": str(pdf_path), "pages": "1-3"})
     assert "Partial read" not in result
 
 
@@ -281,7 +281,7 @@ async def test_read_pdf_discloses_truncation_of_a_single_page(tmp_path: Path):
 
     # No page is left unread here, so only the max_chars cut-off is disclosed.
     result = await read_pdf.invoke(
-        {"inputs": {"pdf_path": str(pdf_path), "max_chars": 1000}}
+        {"pdf_path": str(pdf_path), "max_chars": 1000}
     )
     assert "the rest of the document was NOT read" in result
     assert "unread pages" not in result

--- a/tests/unit_tests/gateway/test_cli_channel_handlers.py
+++ b/tests/unit_tests/gateway/test_cli_channel_handlers.py
@@ -152,6 +152,113 @@ class FailedOnceScheduledDisconnectMessageHandler(FakeMessageHandler):
         )
 
 
+class RewindCancelMessageHandler(FakeMessageHandler):
+    def __init__(self):
+        super().__init__()
+        self.rewind_cancels: list[tuple[str, str, dict]] = []
+
+    async def cancel_agent_session_work(
+        self,
+        channel_id,
+        session_id,
+        *,
+        user_id=None,
+        publish_interrupt_result=False,
+    ):
+        self.rewind_cancels.append(
+            (
+                channel_id,
+                session_id,
+                {
+                    "user_id": user_id,
+                    "publish_interrupt_result": publish_interrupt_result,
+                },
+            )
+        )
+        return True
+
+
+@pytest.mark.asyncio
+async def test_cancel_session_work_before_rewind_invokes_message_handler():
+    handler = RewindCancelMessageHandler()
+    await tui_connect_module._cancel_session_work_before_rewind(
+        handler, "sess-1", user_id="alice",
+    )
+    assert handler.rewind_cancels == [
+        ("tui", "sess-1", {"user_id": "alice", "publish_interrupt_result": False}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_rewind_cancels_in_flight_work_before_rewind(monkeypatch):
+    server = FakeGatewayServer()
+    handler = RewindCancelMessageHandler()
+
+    monkeypatch.setattr(
+        "jiuwenswarm.agents.harness.common.session_ops_service.rewind_session",
+        lambda **kwargs: {"remaining_records": 1},
+    )
+
+    register_cli_handlers(
+        CliHandlersBindParams(
+            channel=server,
+            agent_client=_offline_local_client(),
+            message_handler=handler,
+            on_config_saved=None,
+            path="/tui",
+        )
+    )
+
+    await server.local_handlers["/tui"]["session.rewind"](
+        object(),
+        "req-rewind",
+        {"session_id": "sess-rewind", "turn_index": 1},
+        "sess-rewind",
+    )
+
+    assert handler.rewind_cancels == [
+        ("tui", "sess-rewind", {"user_id": None, "publish_interrupt_result": False}),
+    ]
+    assert server.responses[-1]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_session_rewind_and_restore_cancels_before_local_fallback(monkeypatch):
+    server = FakeGatewayServer()
+    handler = RewindCancelMessageHandler()
+
+    monkeypatch.setattr(
+        "jiuwenswarm.agents.harness.common.session_ops_service.rewind_session",
+        lambda **kwargs: {"remaining_records": 0},
+    )
+    monkeypatch.setattr(
+        "jiuwenswarm.agents.harness.common.session_ops_service.restore_session_files",
+        lambda **kwargs: {"restored_files": [], "deleted_files": [], "errors": []},
+    )
+
+    register_cli_handlers(
+        CliHandlersBindParams(
+            channel=server,
+            agent_client=_offline_local_client(),
+            message_handler=handler,
+            on_config_saved=None,
+            path="/tui",
+        )
+    )
+
+    await server.local_handlers["/tui"]["session.rewind_and_restore"](
+        object(),
+        "req-rewind-restore",
+        {"session_id": "sess-restore", "turn_index": 2},
+        "sess-restore",
+    )
+
+    assert handler.rewind_cancels == [
+        ("tui", "sess-restore", {"user_id": None, "publish_interrupt_result": False}),
+    ]
+    assert server.responses[-1]["ok"] is True
+
+
 @pytest.mark.asyncio
 async def test_register_cli_handlers_registers_local_methods():
     server = FakeGatewayServer()


### PR DESCRIPTION
Paired: [GitHub #2632](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2632) ↔ [GitCode !4672](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4672)

The TUI ignored chat.tool_update events and logged them as unhandled WebSocket frames. Handle the event and refresh in-flight tool summaries for beam-search progress. Cancel gateway streams and AgentServer work before session.rewind and session.rewind_and_restore so orphaned keepalive frames no longer hit dead queues.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
/kind bug


**What does this PR do / why do we need it**:
* **TUI `chat.tool_update`:** add a handler in `event-handlers.ts` and `applyToolUpdatePayload()` in `app-state.ts` so progress events (e.g. Symphony beam search) no longer fall through to the default branch and log `[ws] unhandled event: chat.tool_update`. Running tools get an updated summary when `beam_search_event` is present.
* **Rewind stream cleanup:** before TUI `session.rewind` and `session.rewind_and_restore`, call `_cancel_session_work_before_rewind()` to stop gateway stream tasks and notify AgentServer, matching the IM `/rewind` path. This prevents orphaned keepalive frames from hitting removed message queues (`收到无目标队列的消息`).
* **Why:** manual TUI testing showed console noise and gateway warnings that Web UI / IM channels do not exhibit. No AgentServer changes required.


**Which issue(s) this PR fixes**:
Fixes https://github.com/openJiuwen-ai/jiuwenswarm/issues/2631


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* **Unit tests:** added 3 cases in `tests/unit_tests/gateway/test_cli_channel_handlers.py` — direct `_cancel_session_work_before_rewind` call, `session.rewind`, and `session.rewind_and_restore` local-fallback paths. All assert cancel runs with `publish_interrupt_result=False` and `channel_id="tui"`.
* **Frontend build:** `npm run build` in `jiuwenswarm/channels/tui/frontend` passes (TypeScript compiles with new delegate method and handler).
* **Manual (recommended before merge):**
  1. TUI + tool emitting `chat.tool_update` → no unhandled-event log; tool summary updates on progress.
  2. `/rewind` or `session.rewind_and_restore` during or after an active stream → rewind succeeds; fewer/no repeated orphan-queue warnings in `gateway.log`.
  3. Idle-session `/rewind` → history truncation and file restore unchanged (regression).
* **Performance / reliability:** cancel before rewind is best-effort (logged warning on failure, rewind continues). No new external API surface.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [x] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [x] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2631
<!-- /bot1-related-issues -->
