### PR TITLE
feat(context): enable auto-compact by default with IM notices

### DIFF
--- a/jiuwenswarm/common/e2a/acp/session_updates.py
+++ b/jiuwenswarm/common/e2a/acp/session_updates.py
@@ -98,6 +98,37 @@ def _build_incremental_text_update(
     }
 
 
+def build_acp_compression_update(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Non-final ``session/update`` for ``context.compression_state``.
+
+    ACP cannot reuse the ``CHAT_FINAL`` rewrite the IM channels use to splice
+    a standalone notice into a turn: that rewrite keeps the original
+    ``msg.id``, and an ACP prompt result keyed on that id would end the turn
+    early (a fresh id, in turn, misses ``_request_ctx`` and gets dropped).
+    ``agent_message_chunk`` is the one ``sessionUpdate`` kind every ACP
+    client already renders as visible chat text, so compaction is surfaced
+    that way instead -- with its own message id, so it never touches the
+    turn's own ``assistant_message_id`` / incremental text accumulator.
+
+    Reuses the IM notice formatter (and its per-processor occupancy
+    threshold) so ACP does not spam a "compacting..." line the moment a low
+    occupancy ``started`` event fires, and so wording stays one source of
+    truth across every channel that has to synthesize this notice.
+    """
+    from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.compression_notice import (
+        format_compression_notice,
+    )
+
+    notice = format_compression_notice(payload)
+    if not notice:
+        return None
+    return {
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": str(uuid.uuid4()),
+        "content": {"type": "text", "text": notice},
+    }
+
+
 def build_acp_session_update(
     msg: Message,
     payload: dict[str, Any],
@@ -106,6 +137,9 @@ def build_acp_session_update(
     event_type = msg.event_type
     if event_type == EventType.CHAT_SYMPHONY_STATUS:
         return None
+
+    if event_type == EventType.CONTEXT_COMPRESSION_STATE:
+        return build_acp_compression_update(payload)
 
     if event_type in (
         EventType.CHAT_DELTA,

--- a/jiuwenswarm/common/schema/message.py
+++ b/jiuwenswarm/common/schema/message.py
@@ -233,6 +233,7 @@ class EventType(Enum):
     CHAT_TOOL_RESULT = "chat.tool_result"
     CHAT_SYMPHONY_STATUS = "chat.symphony_status"
     CONTEXT_USAGE = "context.usage"
+    CONTEXT_COMPRESSION_STATE = "context.compression_state"
     TODO_UPDATED = "todo.updated"
     CHAT_PROCESSING_STATUS = "chat.processing_status"
     CHAT_ERROR = "chat.error"

--- a/jiuwenswarm/gateway/channel_manager/channel_manager.py
+++ b/jiuwenswarm/gateway/channel_manager/channel_manager.py
@@ -200,6 +200,13 @@ class ChannelManager(ABC):
         """按 ChannelKey 精确查找 Channel。"""
         return self._channels.get(channel_key)
 
+    def _prepare_outbound(self, msg: "Message", *, delivery_channel_id: str | None = None) -> "Message | None":
+        from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.compression_notice import (
+            prepare_outbound_message,
+        )
+        channel = delivery_channel_id or getattr(msg, "channel_id", None)
+        return prepare_outbound_message(msg, delivery_channel_id=channel)
+
     def pop_channels_by_id(self, channel_id: str) -> list["BaseChannel"]:
         """弹出并返回所有匹配 channel_id 的 Channel 实例（多应用场景下同一 channel_id 对应多个 app）。
 
@@ -375,7 +382,11 @@ class ChannelManager(ABC):
                     )
                     for ch in targets:
                         try:
-                            await ch.send(fanout_msg)
+                            delivery_id = getattr(ch, "channel_id", msg.channel_id)
+                            outbound = self._prepare_outbound(fanout_msg, delivery_channel_id=delivery_id)
+                            if outbound is None:
+                                continue
+                            await ch.send(outbound)
                         except Exception as e:
                             logger.error(
                                 "[ChannelManager] 飞书 fan-out 投递失败: channel_id=%s app=%s id=%s: %s",
@@ -407,7 +418,16 @@ class ChannelManager(ABC):
                 )
                 if channel:
                     try:
-                        await channel.send(msg)
+                        # Context compaction reaches Web and the TUI as a rich
+                        # inline event; every IM channel drops it, so the agent
+                        # rewrites the conversation's history and the human is
+                        # never told. Substitute a plain-text line here, at the
+                        # single dispatch point, rather than teaching ten
+                        # delivery paths a new message type.
+                        outbound = self._prepare_outbound(msg)
+                        if outbound is None:
+                            continue
+                        await channel.send(outbound)
                     except Exception as e:
                         logger.error("send to channel %s: %s", msg.channel_id, e, exc_info=True)
                         if msg.id and msg.id.startswith("cron-push-"):

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
@@ -1603,8 +1603,15 @@ class FeishuChannel(BaseChannel):
                 await self._send_ask_user_question_card(msg)
                 return
 
-            if streaming_enabled and await self._handle_cardkit_streaming_event(
-                msg, event_name, payload, meta, route_delivery
+            # Compaction / system lines share the session but must not open a
+            # second CardKit card keyed by msg.id (…-compaction).
+            standalone_notice = bool(meta.get("standalone_notice"))
+            if (
+                streaming_enabled
+                and not standalone_notice
+                and await self._handle_cardkit_streaming_event(
+                    msg, event_name, payload, meta, route_delivery
+                )
             ):
                 return
 

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/platform_adapter/compression_notice.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/platform_adapter/compression_notice.py
@@ -1,0 +1,320 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Plain-text notice for ``context.compression_state``, shared by every IM channel.
+
+Web and the TUI render compression inline with a rich, multi-part line. The nine
+IM platforms would otherwise render nothing: the agent drops history out from
+under the conversation and the human has no way to know. This module turns the
+event into a sentence a chat client can send.
+
+**What IM announces**
+
+- ``started`` once occupancy reaches the processor's own
+  ``trigger_context_ratio``: a short "Context N% — compacting…" line so the user
+  sees occupancy before history rewrites.
+- ``completed`` / ``compressed`` / ``failed``: outcome lines (tokens freed, or
+  failure warning).
+
+**What stays silent**
+
+- ``noop`` always.
+- ``started`` without a usable percent, or below the configured ratio — avoids
+  unquantified "compacting…" noise and most started→noop orphan lines.
+
+The threshold is read from the same config section the compressor reads, per
+processor, rather than being a constant. It used to be a hard-coded 80, which
+matched only the default ratio: an operator who lowered ``trigger_context_ratio``
+kept the compaction and the outcome line and silently lost the warning.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Mapping, Optional
+
+from jiuwenswarm.common.utils import logger
+
+# Channels that render ``context.compression_state`` themselves, richly and
+# inline. They must keep receiving the raw event; only the channels that would
+# otherwise drop it on the floor get the plain-text substitute.
+_RICH_RENDERERS = frozenset({"web", "tui", "acp", "ssh"})
+
+# Statuses that mean the conversation history actually changed.
+_DONE = {"completed", "compressed"}
+# Statuses that mean it tried and did not finish; the user should know, because
+# the next turn may hit a context limit that compaction was meant to avoid.
+_FAILED = {"failed", "error"}
+
+# The occupancy at which a compressor fires, per processor, read from the same
+# config the compressor reads. A hard-coded 80 here would silently stop
+# announcing the moment an operator lowered ``trigger_context_ratio``: the
+# compaction would still happen, the outcome line would still arrive, and only
+# the warning the user actually needs would go missing.
+_PROCESSOR_CONFIG_SECTIONS = {
+    "DialogueCompressor": "dialogue_compressor_config",
+    "CurrentRoundCompressor": "current_round_compressor_config",
+    "RoundLevelCompressor": "round_level_compressor_config",
+    "SessionMemoryCompressor": "session_memory_config",
+}
+
+# Class default in the compressor tree; used when a section omits the key.
+_DEFAULT_TRIGGER_CONTEXT_RATIO = 0.8
+
+# The config is a YAML read behind a lock and this runs per event, so the parsed
+# ratios are cached. The TTL is short because ``enable_reload`` lets an operator
+# change the ratio without a restart -- a stale threshold for one minute is a
+# fair trade for not re-reading a file on every compression event.
+_RATIO_CACHE_TTL_SECONDS = 60.0
+_ratio_cache: dict[str, float] | None = None
+_ratio_cache_at = 0.0
+
+
+def reset_trigger_ratio_cache() -> None:
+    """Drop the cached ratios. For tests and for an explicit config reload."""
+    global _ratio_cache, _ratio_cache_at
+    _ratio_cache = None
+    _ratio_cache_at = 0.0
+
+
+def _load_trigger_ratios() -> dict[str, float]:
+    """Read ``trigger_context_ratio`` per processor from the effective config.
+
+    The section lives under ``react``, not at the top level: the deep adapter
+    builds its context rail from ``config_base["react"]``, so that is the only
+    place a value here can agree with the compressor that fires. Reading the top
+    level instead returns nothing and falls back to the default for every
+    processor -- which looks like it works and silently restores the constant
+    this function exists to remove.
+    """
+    ratios: dict[str, float] = {}
+    try:
+        from jiuwenswarm.common.config import get_config
+
+        react_cfg = (get_config() or {}).get("react") or {}
+        if not isinstance(react_cfg, Mapping):
+            return ratios
+        engine_cfg = react_cfg.get("context_engine_config") or {}
+        if not isinstance(engine_cfg, Mapping):
+            return ratios
+        for processor, section in _PROCESSOR_CONFIG_SECTIONS.items():
+            cfg = engine_cfg.get(section)
+            if not isinstance(cfg, Mapping):
+                continue
+            value = _as_number(cfg.get("trigger_context_ratio"))
+            # A ratio outside (0, 1] is not a ratio; ignore it rather than
+            # computing a threshold no percentage can ever cross.
+            if value is not None and 0 < value <= 1:
+                ratios[processor] = value
+    except Exception:  # noqa: BLE001 - a notice must never break delivery
+        logger.debug("[compression] could not read trigger ratios", exc_info=True)
+    return ratios
+
+
+def started_notice_min_percent(processor: str) -> float:
+    """Occupancy, in percent, at or above which ``started`` is worth announcing.
+
+    Equals the processor's own trigger ratio, so the notice fires exactly when
+    the compaction does instead of on a constant that only matched the default.
+    """
+    global _ratio_cache, _ratio_cache_at
+
+    now = time.monotonic()
+    if _ratio_cache is None or now - _ratio_cache_at >= _RATIO_CACHE_TTL_SECONDS:
+        _ratio_cache = _load_trigger_ratios()
+        _ratio_cache_at = now
+
+    ratio = _ratio_cache.get(processor, _DEFAULT_TRIGGER_CONTEXT_RATIO)
+    return ratio * 100
+
+_PROCESSOR_LABELS = {
+    "DialogueCompressor": "earlier messages",
+    "CurrentRoundCompressor": "the current round",
+    "RoundLevelCompressor": "the whole conversation",
+    "SessionMemoryCompressor": "session memory",
+}
+
+
+def _as_int(value: Any) -> Optional[int]:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_number(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_tokens(value: int) -> str:
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}M"
+    if value >= 1_000:
+        return f"{value / 1_000:.1f}k"
+    return str(value)
+
+
+def format_compression_notice(payload: Mapping[str, Any]) -> Optional[str]:
+    """One line for a chat channel, or None when nothing should be posted.
+
+    Announces high-occupancy ``started`` and compaction outcomes; returns None
+    for ``noop`` and low/unknown-occupancy ``started``. Never raises: a
+    malformed payload yields None rather than breaking delivery of the turn.
+    """
+    if not isinstance(payload, Mapping):
+        return None
+
+    status = str(payload.get("status") or "").strip().lower()
+    processor = str(payload.get("processor") or "").strip()
+    what = _PROCESSOR_LABELS.get(processor, "conversation history")
+
+    if status in _FAILED:
+        return f"⚠️ Could not compact {what} — this turn may run short of context."
+
+    before = payload.get("before") if isinstance(payload.get("before"), Mapping) else {}
+
+    if status == "started":
+        pct = _as_number(before.get("context_percent"))
+        if pct is None or pct < started_notice_min_percent(processor):
+            return None
+        return f"🗜️ Context {round(pct)}% — compacting…"
+
+    if status not in _DONE:
+        return None
+
+    after = payload.get("after") if isinstance(payload.get("after"), Mapping) else {}
+    before_tokens = _as_int(before.get("tokens"))
+    after_tokens = _as_int(after.get("tokens"))
+
+    # Without both sides there is no saving to quote, so say the plain fact.
+    if before_tokens is None or after_tokens is None or before_tokens <= 0:
+        return f"🗜️ Compacted {what} to free up context."
+
+    saved = before_tokens - after_tokens
+    if saved <= 0:
+        # Reported done but nothing shrank. Do not claim a saving that did not
+        # happen; the honest line is that history changed shape.
+        return f"🗜️ Compacted {what}."
+
+    pct = round(saved * 100 / before_tokens)
+    return (
+        f"🗜️ Compacted {what}: {_format_tokens(before_tokens)} → "
+        f"{_format_tokens(after_tokens)} tokens ({pct}% freed)."
+    )
+
+
+def channel_renders_compression(channel_id: Any) -> bool:
+    """Whether this channel already displays compression events on its own."""
+    return str(channel_id or "").strip().lower() in _RICH_RENDERERS
+
+
+# Metadata keys that bind a message into an in-flight stream reply. Keeping them
+# on the notice would make WeCom mash the line into reply_stream, or make Feishu
+# treat it as the chat.final that closes the card buffer. Xiaoyi uses
+# xiaoyi_task_id as the A2A artifact stream key — a CHAT_FINAL with that id
+# flushes the in-flight answer buffer into the notice.
+_STREAM_BINDING_META_KEYS = frozenset({
+    "wecom_req_id",
+    "xiaoyi_task_id",
+})
+
+
+def as_text_message(msg: Any, *, delivery_channel_id: str | None = None) -> Any | None:
+    """Rewrite a compression event into a plain-text message, or drop it.
+
+    Returns the original message when it is not a compression event, a rewritten
+    copy shaped like an ordinary ``chat.final`` text reply, or ``None`` when
+    this event should not be delivered to a text-only channel at all.
+
+    Content alone is not enough: WeCom and WeChat only deliver ``CHAT_FINAL`` /
+    plain ``res`` messages, and stream-bound ids/metadata would fold the notice
+    into the in-flight answer. The rewrite therefore also sets
+    ``event_type=CHAT_FINAL``, gives the notice its own id, and strips stream
+    binding keys so each channel's existing text path posts a separate line.
+    """
+    payload = getattr(msg, "payload", None)
+    if not isinstance(payload, Mapping):
+        return msg
+    event_type = str(payload.get("event_type") or getattr(msg, "event_type", "") or "")
+    if not event_type.endswith("context.compression_state"):
+        return msg
+
+    if channel_renders_compression(
+        delivery_channel_id if delivery_channel_id is not None else getattr(msg, "channel_id", None)
+    ):
+        return msg
+
+    notice = format_compression_notice(payload)
+    if not notice:
+        # noop / low-occupancy started: nothing worth interrupting the thread.
+        return None
+
+    status = str(payload.get("status") or "").strip().lower()
+    id_suffix = "compaction-started" if status == "started" else "compaction"
+
+    try:
+        from dataclasses import replace
+
+        from jiuwenswarm.common.schema.message import EventType
+
+        orig_id = str(getattr(msg, "id", "") or "msg")
+        meta = getattr(msg, "metadata", None)
+        cleaned_meta: dict[str, Any] | None = None
+        if isinstance(meta, Mapping):
+            cleaned_meta = {
+                k: v for k, v in meta.items() if k not in _STREAM_BINDING_META_KEYS
+            }
+            # WeChat clears the delta accumulator on every CHAT_FINAL; mark this
+            # as a standalone line so that path keeps the in-flight answer.
+            cleaned_meta["standalone_notice"] = True
+        else:
+            cleaned_meta = {"standalone_notice": True}
+
+        return replace(
+            msg,
+            id=f"{orig_id}-{id_suffix}",
+            type="res",
+            event_type=EventType.CHAT_FINAL,
+            params={"content": notice},
+            payload={
+                "event_type": EventType.CHAT_FINAL.value,
+                "content": notice,
+            },
+            metadata=cleaned_meta,
+        )
+    except Exception:  # noqa: BLE001 - never break delivery over a notice
+        logger.warning(
+            "[compression_notice] failed to rewrite event id=%s; using minimal fallback",
+            getattr(msg, "id", ""),
+            exc_info=True,
+        )
+        # Last resort: deliver the notice text without metadata surgery.
+        try:
+            from dataclasses import replace
+
+            from jiuwenswarm.common.schema.message import EventType
+
+            return replace(
+                msg,
+                id=f"{getattr(msg, 'id', 'msg')}-{id_suffix}",
+                type="res",
+                event_type=EventType.CHAT_FINAL,
+                params={"content": notice},
+                payload={
+                    "event_type": EventType.CHAT_FINAL.value,
+                    "content": notice,
+                },
+                metadata={"standalone_notice": True},
+            )
+        except Exception:  # noqa: BLE001
+            return None
+
+
+def prepare_outbound_message(msg: Any, *, delivery_channel_id: str | None = None) -> Any | None:
+    """Return message to send, or None to drop."""
+    return as_text_message(msg, delivery_channel_id=delivery_channel_id)

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/wechat/wechat_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/wechat/wechat_connect.py
@@ -576,13 +576,19 @@ class WechatChannel(BaseChannel):
             self._stash_overflow_content(msg, content_str)
             return
         await self._send_text_chunks_to_user(msg, content_str)
-        self._clear_delta_session(msg)
-        mk = self._message_session_key(msg)
-        if mk:
-            self._streaming_sessions.discard(mk)
-            self._continue_active_sessions.discard(mk)
-        self.current_round = 0
-        self._current_round_session_key = ""
+        # Standalone system lines (e.g. compaction notices) share the session
+        # but must not wipe the in-flight delta accumulator, streaming guards,
+        # or per-round send counters for the real reply.
+        meta = getattr(msg, "metadata", None) or {}
+        standalone = isinstance(meta, dict) and meta.get("standalone_notice")
+        if not standalone:
+            self._clear_delta_session(msg)
+            mk = self._message_session_key(msg)
+            if mk:
+                self._streaming_sessions.discard(mk)
+                self._continue_active_sessions.discard(mk)
+            self.current_round = 0
+            self._current_round_session_key = ""
 
     def _delta_session_key(self, msg: Message) -> str:
         return str(msg.session_id or msg.id or "")

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/xiaoyi/xiaoyi_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/xiaoyi/xiaoyi_connect.py
@@ -476,6 +476,12 @@ class XiaoyiChannel(BaseChannel):
         except asyncio.CancelledError:
             pass
 
+    @staticmethod
+    def _is_standalone_notice(msg: Message) -> bool:
+        """System lines (e.g. compaction) must not close or merge into the reply stream."""
+        meta = getattr(msg, "metadata", None) or {}
+        return isinstance(meta, dict) and bool(meta.get("standalone_notice"))
+
     def _extract_platform_receive_info(self, msg: Message) -> tuple[str, str]:
         """
         从消息中提取小艺平台会话 ID 与任务 ID。
@@ -608,6 +614,26 @@ class XiaoyiChannel(BaseChannel):
         # 推送消息发送
         if msg.id.startswith("cron-push"):
             await self._send_push_notification(cron_job_name, content)
+            return
+
+        # Standalone system lines (compaction notices): own artifact id, never
+        # clobber the in-flight answer accumulator or finalize the session.
+        if self._is_standalone_notice(msg):
+            notice_task_id = str(msg.id or task_id or session_id)
+            for url_key, ws in self._ws_connections.items():
+                if ws:
+                    try:
+                        await self._send_text_response(
+                            session_id,
+                            notice_task_id,
+                            content,
+                            url_key,
+                            append=True,
+                            last_chunk=True,
+                            is_final=False,
+                        )
+                    except Exception as e:
+                        logger.warning(f"XiaoyiChannel 发送 standalone notice 失败 ({url_key}): {e}")
             return
 
         # 如果禁用流式，总是作为完整消息发送
@@ -771,7 +797,14 @@ class XiaoyiChannel(BaseChannel):
             if push_id and agent_id:
                 logger.info("[XiaoyiChannel] _send_team → push: agent_id=%s push_id=%s", (agent_id or "")[:8],
                             push_id[:8])
-                await self._send_push_to_user(agent_id, push_id, content)
+                # Compaction notices must ship as their own push, not join the
+                # per-agent merge window (which would delay/concat with replies).
+                await self._send_push_to_user(
+                    agent_id,
+                    push_id,
+                    content,
+                    merge=not self._is_standalone_notice(msg),
+                )
             elif self._ws_connections:
                 # ③ 兜底：无 push_id 且无活跃会话，走 legacy（按 metadata 投递）
                 logger.info("[XiaoyiChannel] _send_team → legacy fallback: agent_id=%s", (agent_id or "")[:8])
@@ -832,6 +865,29 @@ class XiaoyiChannel(BaseChannel):
         缓解高频小 chunk 导致的客户端卡顿，同时保持人眼连续的流式实时性。
         final 消息立即冲刷缓冲并发送，保证结尾不延迟。
         """
+        # Compaction (and similar) notices must not flush the in-flight answer
+        # buffer or mark the A2A artifact complete under the active task_id.
+        if self._is_standalone_notice(msg):
+            notice_task_id = str(msg.id or task_id or session_id)
+            for url_key, ws in self._ws_connections.items():
+                if ws:
+                    try:
+                        await self._send_text_response(
+                            session_id, notice_task_id, content, url_key,
+                            append=True, last_chunk=True, is_final=False,
+                        )
+                        logger.info(
+                            "[XiaoyiChannel] team ws standalone notice: sid=%s "
+                            "notice_task=%s active_task=%s len=%d",
+                            (session_id or "")[:8], notice_task_id, task_id,
+                            len(content or ""),
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"XiaoyiChannel team ws standalone notice 失败 ({url_key}): {e}"
+                        )
+            return
+
         last_chunk = msg.event_type == EventType.CHAT_FINAL
         is_final = False
         if isinstance(msg.payload, dict):
@@ -919,17 +975,31 @@ class XiaoyiChannel(BaseChannel):
         finally:
             self._ws_flush_tasks.pop(task_id, None)
 
-    async def _send_push_to_user(self, agent_id: str, push_id: str, content: str) -> None:
+    async def _send_push_to_user(
+        self,
+        agent_id: str,
+        push_id: str,
+        content: str,
+        *,
+        merge: bool = True,
+    ) -> None:
         """后台 push webhook 投递全文 final，带 per-agent_id 合并窗口。
 
         同一 agent_id 在 message_merge_window_ms 内的多条消息累积进 buffer，
         第一条到达时调度延迟 flush 任务，窗口到期统一合并发送一次，
         避免短时多条 mention 轰炸。push_id 作为 webhook 寻址 token 随 flush 一并发出。
+
+        When ``merge`` is False (standalone system notices), send immediately and
+        leave any pending merge buffer untouched.
         """
         if not self.config.api_id:
             logger.debug("[PUSH] team push 跳过：api_id 未配置")
             return
         if not content.strip():
+            return
+
+        if not merge:
+            await self._emit_push(agent_id, push_id, content)
             return
 
         now = time.time()
@@ -942,6 +1012,37 @@ class XiaoyiChannel(BaseChannel):
             self._push_flush_tasks[agent_id] = asyncio.create_task(
                 self._flush_push_buffer(agent_id, window_ms / 1000)
             )
+
+    async def _emit_push(
+        self,
+        agent_id: str,
+        push_id: str,
+        content: str,
+        *,
+        summary: str | None = None,
+    ) -> None:
+        """Send one push webhook (used for immediate notices and merge flush)."""
+        if not push_id:
+            logger.warning("[PUSH] team push skip: empty push_id (agent_id=%s)", (agent_id or "")[:8])
+            return
+        if summary is None:
+            summary = self._build_push_summary(content) or (
+                content[:30] + "..." if len(content) > 30 else content
+            )
+        push_config = PushConfig(
+            mode=self.config.mode,
+            api_id=self.config.api_id,
+            push_id=push_id,
+            push_url=self.config.push_url,
+            ak=self.config.ak,
+            sk=self.config.sk,
+            uid=self.config.uid,
+            api_key=self.config.api_key,
+        )
+        try:
+            await XiaoYiPushService(push_config).send_push(summary, content)
+        except Exception as e:
+            logger.error("[PUSH] team push send failed (agent_id=%s): %s", (agent_id or "")[:8], e)
 
     async def _flush_push_buffer(self, agent_id: str, window_s: float) -> None:
         """延迟 window 秒后合并发送 buffer 全部内容。"""
@@ -963,17 +1064,7 @@ class XiaoyiChannel(BaseChannel):
             if not push_id:
                 logger.warning("[PUSH] team push flush 跳过：buffer 中无有效 push_id (agent_id=%s)", agent_id[:8])
                 return
-            push_config = PushConfig(
-                mode=self.config.mode,
-                api_id=self.config.api_id,
-                push_id=push_id,
-                push_url=self.config.push_url,
-                ak=self.config.ak,
-                sk=self.config.sk,
-                uid=self.config.uid,
-                api_key=self.config.api_key,
-            )
-            await XiaoYiPushService(push_config).send_push(summary, merged_content)
+            await self._emit_push(agent_id, push_id, merged_content, summary=summary)
         except asyncio.CancelledError:
             pass
         except Exception as e:

--- a/jiuwenswarm/gateway/channel_manager/protocol/acp/acp_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/protocol/acp/acp_connect.py
@@ -370,6 +370,7 @@ class AcpGatewayBridge:
             EventType.CHAT_SYMPHONY_STATUS,
             EventType.TODO_UPDATED,
             EventType.CHAT_SUBTASK_UPDATE,
+            EventType.CONTEXT_COMPRESSION_STATE,
         ):
             update = build_acp_session_update(msg, payload, ctx)
             if update is None:
@@ -1365,6 +1366,7 @@ class AcpChannel(BaseChannel):
             EventType.CHAT_SYMPHONY_STATUS,
             EventType.TODO_UPDATED,
             EventType.CHAT_SUBTASK_UPDATE,
+            EventType.CONTEXT_COMPRESSION_STATE,
         ):
             update = self._build_acp_session_update(msg, payload, ctx)
             if update is None:

--- a/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
@@ -844,7 +844,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                     payload[key] = crypto_provider.decrypt(val)
             ctx_cfg = (raw.get("react") or {}).get("context_engine_config") or {}
             payload["context_engine_enabled"] = (
-                "true" if ctx_cfg.get("enabled", False) else "false"
+                "true" if ctx_cfg.get("enabled", True) else "false"
             )
             perm_cfg = raw.get("permissions") or {}
             payload["permissions_enabled"] = (

--- a/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
+++ b/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
@@ -1660,7 +1660,7 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
             react_cfg = raw.get("react") or {}
             ctx_cfg = react_cfg.get("context_engine_config") or {}
             kv_cfg = react_cfg.get("kv_cache_affinity_config") or {}
-            payload["context_engine_enabled"] = "true" if ctx_cfg.get("enabled", False) else "false"
+            payload["context_engine_enabled"] = "true" if ctx_cfg.get("enabled", True) else "false"
             payload["kv_cache_release_enabled"] = (
                 "true" if kv_cfg.get("enable_kv_cache_release", False) else "false"
             )

--- a/jiuwenswarm/gateway/routing/session_sharing.py
+++ b/jiuwenswarm/gateway/routing/session_sharing.py
@@ -484,9 +484,19 @@ class SessionDispatcher:
             return
 
         routing_target = SessionDispatcher._build_routing_target(target, group_subs, delivery)
+        from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.compression_notice import (
+            prepare_outbound_message,
+        )
+
+        outbound = prepare_outbound_message(
+            msg,
+            delivery_channel_id=container_key.channel_id,
+        )
+        if outbound is None:
+            return
         try:
             await asyncio.wait_for(
-                channel.send(msg, routing_target=routing_target),
+                channel.send(outbound, routing_target=routing_target),
                 timeout=10.0,
             )
         except asyncio.TimeoutError:

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import importlib
 import hashlib
 import json
 import logging
@@ -396,6 +397,71 @@ _PERSISTENT_CHECKPOINTER_LOCK: asyncio.Lock | None = None
 _PERSISTENT_CHECKPOINTER_LOCK_LOOP: asyncio.AbstractEventLoop | None = None
 _PERSISTENT_CHECKPOINTER_LOCK_INIT = threading.Lock()
 _PERSISTENT_CHECKPOINTER_READY = False
+
+
+_COMPRESSOR_CONFIG_CLASSES: dict[str, str] = {
+    "DialogueCompressor":
+        "openjiuwen.core.context_engine.processor.forked.compressor.dialogue_compressor"
+        ":DialogueCompressorConfig",
+    "CurrentRoundCompressor":
+        "openjiuwen.core.context_engine.processor.forked.compressor.current_round_compressor"
+        ":CurrentRoundCompressorConfig",
+    "RoundLevelCompressor":
+        "openjiuwen.core.context_engine.processor.forked.compressor.round_level_compressor"
+        ":RoundLevelCompressorConfig",
+}
+
+try:
+    importlib.import_module(
+        "openjiuwen.core.context_engine.processor.forked.compressor.session_memory_compressor"
+    )
+except Exception:  # noqa: BLE001 - optional compressor config class
+    pass
+else:
+    _COMPRESSOR_CONFIG_CLASSES["SessionMemoryCompressor"] = (
+        "openjiuwen.core.context_engine.processor.forked.compressor.session_memory_compressor"
+        ":SessionMemoryCompressorConfig"
+    )
+
+
+def _warn_unknown_processor_keys(processor: str, cfg: dict) -> None:
+    """Say so when a configured key is not a field of the receiving class.
+
+    These configs are Pydantic models without ``extra="forbid"``, so an unknown
+    key is dropped in silence. That is how a live config can carry
+    ``tokens_threshold: 100000`` for the dialogue compressor and still compress
+    at the class default ratio: the compressor tree moved to ratio-based
+    triggering and the config was never migrated, so six keys per section stop
+    doing anything without a word.
+
+    Warning rather than raising is deliberate. ``extra="forbid"`` would turn
+    every stale config into a startup crash, and the keys cannot simply be
+    honoured either -- a token threshold has no meaning in a ratio-based
+    compressor. Making the loss audible is the part that is safe to do here.
+    """
+    target = _COMPRESSOR_CONFIG_CLASSES.get(processor)
+    if not target:
+        return
+    module_path, _, class_name = target.partition(":")
+    try:
+        module = importlib.import_module(module_path)
+        config_cls = getattr(module, class_name)
+        known = set(config_cls.model_fields.keys())
+    except Exception:  # noqa: BLE001 - never block startup over a diagnostic
+        return
+
+    unknown = sorted(k for k in cfg if k not in known)
+    if not unknown:
+        return
+    logger.warning(
+        "[ContextEngine] %s: ignoring %d unsupported config key(s): %s. "
+        "Those settings are not applied -- the processor uses its defaults "
+        "for them (other keys in this section still apply). Supported keys: %s",
+        processor,
+        len(unknown),
+        ", ".join(unknown),
+        ", ".join(sorted(known)),
+    )
 
 
 def _running_loop() -> asyncio.AbstractEventLoop | None:
@@ -883,6 +949,8 @@ def _build_context_processor_rail(config: dict[str, Any]) -> ContextProcessorRai
         raw_context_engine_cfg = config.get("context_engine_config", {})
         context_engine_cfg = raw_context_engine_cfg if isinstance(raw_context_engine_cfg, dict) else {}
         session_memory_cfg = _resolve_session_memory_config(context_engine_cfg)
+        if isinstance(session_memory_cfg, dict) and session_memory_cfg:
+            _warn_unknown_processor_keys("SessionMemoryCompressor", session_memory_cfg)
 
         offloader_cfg = context_engine_cfg.get("message_summary_offloader_config", {})
         if isinstance(offloader_cfg, dict) and offloader_cfg:
@@ -890,14 +958,17 @@ def _build_context_processor_rail(config: dict[str, Any]) -> ContextProcessorRai
 
         compressor_cfg = context_engine_cfg.get("dialogue_compressor_config", {})
         if isinstance(compressor_cfg, dict) and compressor_cfg:
+            _warn_unknown_processor_keys("DialogueCompressor", compressor_cfg)
             user_processors.append(("DialogueCompressor", compressor_cfg))
 
         current_round_cfg = context_engine_cfg.get("current_round_compressor_config", {})
         if isinstance(current_round_cfg, dict) and current_round_cfg:
+            _warn_unknown_processor_keys("CurrentRoundCompressor", current_round_cfg)
             user_processors.append(("CurrentRoundCompressor", current_round_cfg))
 
         round_level_cfg = context_engine_cfg.get("round_level_compressor_config", {})
         if isinstance(round_level_cfg, dict) and round_level_cfg:
+            _warn_unknown_processor_keys("RoundLevelCompressor", round_level_cfg)
             user_processors.append(("RoundLevelCompressor", round_level_cfg))
 
         reasoning_loop_cfg = context_engine_cfg.get("reasoning_tool_loop_compact_config", {})
@@ -5853,7 +5924,7 @@ class JiuWenSwarmDeepAdapter:
         # 外接记忆 rail（mode-independent，注册一次，跨 reload 持久）
         await self._handle_external_memory_rail_by_config()
         # 上下文 rail
-        context_enabled = self._config_cache.get("context_engine_config", {}).get("enabled", False)
+        context_enabled = self._config_cache.get("context_engine_config", {}).get("enabled", True)
 
         if self._context_assemble_rail is None or self._context_assemble_mode != "agent":
             if self._context_assemble_rail is not None:

--- a/tests/unit_tests/agentserver/test_compressor_config_warning.py
+++ b/tests/unit_tests/agentserver/test_compressor_config_warning.py
@@ -1,0 +1,131 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Unsupported compressor config keys must be audible, not silent."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from jiuwenswarm.server.runtime.agent_adapter import interface_deep
+
+
+@pytest.fixture
+def warnings() -> list[str]:
+    """Capture straight off the module logger.
+
+    ``caplog`` attaches to the root logger, and the project installs its own
+    logging setup with propagation disabled, so root never sees these records.
+    Attaching here tests the logger the code actually writes to.
+    """
+    records: list[str] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record.getMessage())
+
+    handler = _Collect(level=logging.WARNING)
+    logger = interface_deep.logger
+    logger.addHandler(handler)
+    previous = logger.level
+    logger.setLevel(logging.WARNING)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous)
+
+
+def test_stale_dialogue_config_is_reported(warnings: list[str]) -> None:
+    """The exact shape found in a live ~/.jiuwenswarm/config/config.yaml.
+
+    The compressor tree moved to ratio-based triggering; this section was never
+    migrated, so every key below is dropped and the processor runs on defaults.
+    Before this warning the loss was completely silent.
+    """
+    stale = {
+        "messages_threshold": None,
+        "tokens_threshold": 100000,
+        "messages_to_keep": 10,
+        "keep_last_round": False,
+        "compression_target_tokens": 1800,
+        "offload_writeback_enabled": False,
+    }
+
+    interface_deep._warn_unknown_processor_keys("DialogueCompressor", stale)
+
+    assert len(warnings) == 1
+    message = warnings[0]
+    for key in stale:
+        assert key in message, f"{key} not named in the warning"
+    # The user must be told those settings are inert, not merely that keys are odd.
+    assert "not applied" in message
+
+
+def test_partial_stale_config_does_not_claim_whole_section_is_inert(
+    warnings: list[str],
+) -> None:
+    """Valid keys still apply; only the unsupported ones are ignored."""
+    interface_deep._warn_unknown_processor_keys(
+        "DialogueCompressor",
+        {"trigger_context_ratio": 0.8, "tokens_threshold": 100000},
+    )
+
+    assert len(warnings) == 1
+    message = warnings[0]
+    assert "tokens_threshold" in message
+    assert "This section is not applied" not in message
+    assert "other keys in this section still apply" in message
+
+
+def test_supported_keys_are_not_reported(warnings: list[str]) -> None:
+    interface_deep._warn_unknown_processor_keys(
+        "DialogueCompressor",
+        {"trigger_context_ratio": 0.8, "min_target_context_ratio": 0.1},
+    )
+    assert warnings == []
+
+
+def test_partially_stale_config_reports_only_the_dropped_keys(warnings: list[str]) -> None:
+    """A section can be half-migrated; the warning must name only what is lost."""
+    interface_deep._warn_unknown_processor_keys(
+        "RoundLevelCompressor",
+        {"trigger_context_ratio": 0.9, "rounds_threshold": 2},
+    )
+
+    assert len(warnings) == 1
+    ignored = warnings[0].split("Supported keys:")[0]
+    assert "rounds_threshold" in ignored
+    assert "trigger_context_ratio" not in ignored
+
+
+def test_unknown_processor_is_ignored(warnings: list[str]) -> None:
+    interface_deep._warn_unknown_processor_keys("NotAProcessor", {"anything": 1})
+    assert warnings == []
+
+
+@pytest.mark.skipif(
+    "SessionMemoryCompressor" not in interface_deep._COMPRESSOR_CONFIG_CLASSES,
+    reason="SessionMemoryCompressor config class unavailable",
+)
+def test_session_memory_unknown_keys_are_reported(warnings: list[str]) -> None:
+    interface_deep._warn_unknown_processor_keys(
+        "SessionMemoryCompressor",
+        {"trigger_context_ratio": 0.8, "totally_fake_key": 1},
+    )
+
+    assert len(warnings) == 1
+    assert "totally_fake_key" in warnings[0]
+    assert "trigger_context_ratio" not in warnings[0].split("Supported keys:")[0]
+
+
+def test_a_diagnostic_never_blocks_startup(monkeypatch, warnings: list[str]) -> None:
+    """If the class cannot be imported, stay quiet rather than raise."""
+    monkeypatch.setitem(
+        interface_deep._COMPRESSOR_CONFIG_CLASSES,
+        "DialogueCompressor",
+        "no.such.module:NoSuchConfig",
+    )
+    interface_deep._warn_unknown_processor_keys("DialogueCompressor", {"x": 1})
+    assert warnings == []

--- a/tests/unit_tests/agentserver/test_context_engine_enabled_default.py
+++ b/tests/unit_tests/agentserver/test_context_engine_enabled_default.py
@@ -1,0 +1,86 @@
+"""Tests for context engine enabled default in JiuWenSwarmDeepAdapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.server.runtime.agent_adapter import interface_deep as interface_deep_module
+from jiuwenswarm.server.runtime.agent_adapter.interface_deep import JiuWenSwarmDeepAdapter
+
+
+class _FakeAbilityManager:
+    @staticmethod
+    def list():
+        return []
+
+
+class _FakeInstance:
+    def __init__(self) -> None:
+        self.registered: list[object] = []
+        self.unregistered: list[object] = []
+        self.ability_manager = _FakeAbilityManager()
+
+    async def register_rail(self, rail: object) -> None:
+        self.registered.append(rail)
+
+    async def unregister_rail(self, rail: object) -> None:
+        self.unregistered.append(rail)
+
+
+async def _noop(*_args, **_kwargs) -> None:
+    return None
+
+
+def _make_adapter(config_cache: dict) -> JiuWenSwarmDeepAdapter:
+    adapter = JiuWenSwarmDeepAdapter()
+    adapter._instance = _FakeInstance()
+    adapter._config_cache = config_cache
+    adapter._context_assemble_rail = None
+    adapter._context_assemble_mode = None
+    adapter._context_processor_rail = None
+    return adapter
+
+
+def _stub_rail_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    adapter: JiuWenSwarmDeepAdapter,
+    processor_rail: object,
+) -> None:
+    monkeypatch.setattr(adapter, "_build_task_planning_rail", lambda: None)
+    monkeypatch.setattr(adapter, "_build_structured_ask_user_rail", lambda: None)
+    monkeypatch.setattr(adapter, "_handle_memory_rail_by_config", _noop)
+    monkeypatch.setattr(adapter, "_handle_external_memory_rail_by_config", _noop)
+    monkeypatch.setattr(
+        interface_deep_module,
+        "_build_context_assemble_rail",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        interface_deep_module,
+        "_build_context_processor_rail",
+        lambda _config: processor_rail,
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_processor_rail_enabled_when_key_missing(monkeypatch):
+    processor_rail = object()
+    adapter = _make_adapter({})
+    _stub_rail_dependencies(monkeypatch, adapter, processor_rail)
+
+    await adapter._update_agent_rails()
+
+    assert adapter._context_processor_rail is processor_rail
+    assert processor_rail in adapter._instance.registered
+
+
+@pytest.mark.asyncio
+async def test_context_processor_rail_respects_explicit_disabled(monkeypatch):
+    processor_rail = object()
+    adapter = _make_adapter({"context_engine_config": {"enabled": False}})
+    _stub_rail_dependencies(monkeypatch, adapter, processor_rail)
+
+    await adapter._update_agent_rails()
+
+    assert adapter._context_processor_rail is None
+    assert processor_rail not in adapter._instance.registered

--- a/tests/unit_tests/channel/test_acp_channel.py
+++ b/tests/unit_tests/channel/test_acp_channel.py
@@ -1643,6 +1643,88 @@ async def test_jsonrpc_session_prompt_emits_plan_update(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_jsonrpc_session_prompt_emits_compression_state_as_session_update(monkeypatch):
+    """P2 fix: stdio ACP must surface context.compression_state, not drop it.
+
+    Rewriting it as CHAT_FINAL is not safe here: it would reuse this
+    request's msg.id and end the turn early.
+    """
+    fake_stdin = FakeStdin(
+        [
+            json_line(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 34,
+                    "method": "session/prompt",
+                    "params": {
+                        "sessionId": "sess-compaction",
+                        "prompt": [{"type": "text", "text": "hello"}],
+                    },
+                }
+            )
+        ]
+    )
+    fake_stdout = FakeStdout()
+    channel = AcpChannel(AcpChannelConfig(enabled=True), DummyBus())
+
+    monkeypatch.setattr("sys.stdin", fake_stdin)
+    monkeypatch.setattr("sys.stdout", fake_stdout)
+    monkeypatch.setattr("jiuwenswarm.gateway.channel_manager.protocol.acp.acp_connect._ACP_STDOUT", fake_stdout)
+
+    async def _on_message(msg):
+        await channel.send(
+            Message(
+                id=msg.id,
+                type="event",
+                channel_id="acp",
+                session_id=msg.session_id,
+                params={},
+                timestamp=time.time(),
+                ok=True,
+                payload={
+                    "event_type": "context.compression_state",
+                    "status": "completed",
+                    "processor": "DialogueCompressor",
+                    "before": {"tokens": 100_000},
+                    "after": {"tokens": 25_000},
+                },
+                event_type=EventType.CONTEXT_COMPRESSION_STATE,
+            )
+        )
+        await channel.send(
+            Message(
+                id=msg.id,
+                type="event",
+                channel_id="acp",
+                session_id=msg.session_id,
+                params={},
+                timestamp=time.time(),
+                ok=True,
+                payload={"is_processing": False},
+                event_type=EventType.CHAT_PROCESSING_STATUS,
+            )
+        )
+
+    channel.on_message(_on_message)
+    await channel.start()
+
+    responses = fake_stdout.buffer.json_lines()
+    assert len(responses) == 3
+
+    compression_update = responses[0]["params"]["update"]
+    assert compression_update["sessionUpdate"] == "agent_message_chunk"
+    assert "75%" in compression_update["content"]["text"]
+    # Must not be smuggled through as chat.final-shaped JSON-RPC.
+    assert "result" not in responses[0]
+    assert "error" not in responses[0]
+
+    idle_update = responses[1]["params"]["update"]
+    assert idle_update["sessionUpdate"] == "session_info_update"
+
+    assert responses[2]["result"]["stopReason"] == "end_turn"
+
+
+@pytest.mark.asyncio
 async def test_jsonrpc_session_prompt_emits_processing_status_update(monkeypatch):
     fake_stdin = FakeStdin(
         [

--- a/tests/unit_tests/e2a/test_acp_session_updates.py
+++ b/tests/unit_tests/e2a/test_acp_session_updates.py
@@ -235,6 +235,50 @@ def test_build_acp_session_update_embeds_terminal_for_create_terminal_result():
     }
 
 
+def test_build_acp_session_update_maps_compression_state_to_agent_message_chunk():
+    """Auto-compact defaults on now; ACP must surface it, not drop it.
+
+    A CHAT_FINAL rewrite is not safe here (same msg.id would end_turn), so
+    compaction must come through as an ordinary, non-final session/update.
+    """
+    state = _build_state()
+    update = build_acp_session_update(
+        _build_message(EventType.CONTEXT_COMPRESSION_STATE),
+        {
+            "event_type": "context.compression_state",
+            "status": "completed",
+            "processor": "DialogueCompressor",
+            "before": {"tokens": 100_000},
+            "after": {"tokens": 25_000},
+        },
+        state,
+    )
+
+    assert update is not None
+    assert update["sessionUpdate"] == "agent_message_chunk"
+    assert "content" in update and update["content"]["type"] == "text"
+    assert "75%" in update["content"]["text"]
+    # A standalone message id, not the turn's own assistant_message_id --
+    # otherwise this would corrupt the running text-delta accumulator.
+    assert update["messageId"] != state.assistant_message_id
+    assert state.assistant_message_id is None
+
+
+def test_build_acp_session_update_drops_noop_compression_state():
+    """noop must stay silent for ACP too, same as the IM notice path."""
+    state = _build_state()
+    update = build_acp_session_update(
+        _build_message(EventType.CONTEXT_COMPRESSION_STATE),
+        {
+            "event_type": "context.compression_state",
+            "status": "noop",
+            "processor": "DialogueCompressor",
+        },
+        state,
+    )
+    assert update is None
+
+
 def test_build_acp_final_text_update_maps_reasoning_final_to_agent_thought_chunk():
     state = _build_state()
 

--- a/tests/unit_tests/gateway/test_app_gateway_acp.py
+++ b/tests/unit_tests/gateway/test_app_gateway_acp.py
@@ -1645,6 +1645,87 @@ async def test_gateway_server_emits_todo_update_then_waits_for_idle():
 
 
 @pytest.mark.asyncio
+async def test_gateway_server_emits_compression_state_as_session_update_not_chat_final():
+    """P2 fix: auto-compact now defaults on, so ACP must surface it.
+
+    A CHAT_FINAL rewrite would reuse this in-flight request's msg.id and
+    end the turn early; the gateway WS path must not fall back to a bare
+    ``{event: chat.final}`` frame either. The only correct shape is a
+    non-final ``session/update``.
+    """
+    server = build_server()
+    ws = FakeWebSocket()
+
+    async def on_message(msg):
+        await server.send(
+            Message(
+                id=msg.id,
+                type="event",
+                channel_id="acp",
+                session_id=msg.session_id,
+                params={},
+                timestamp=time.time(),
+                ok=True,
+                payload={
+                    "event_type": "context.compression_state",
+                    "status": "completed",
+                    "processor": "DialogueCompressor",
+                    "before": {"tokens": 100_000},
+                    "after": {"tokens": 25_000},
+                },
+                event_type=EventType.CONTEXT_COMPRESSION_STATE,
+            )
+        )
+        await server.send(
+            Message(
+                id=msg.id,
+                type="event",
+                channel_id="acp",
+                session_id=msg.session_id,
+                params={},
+                timestamp=time.time(),
+                ok=True,
+                payload={"is_processing": False},
+                event_type=EventType.CHAT_PROCESSING_STATUS,
+            )
+        )
+
+    server.on_message(on_message)
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 403,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": "sess-compaction-gateway",
+                    "text": "hello",
+                },
+            },
+            ensure_ascii=False,
+        ),
+    )
+
+    assert ws.sent_frames[0]["jsonrpc"] == "2.0"
+    assert "method" not in ws.sent_frames[0] or ws.sent_frames[0]["method"] != "chat.final"
+    assert ws.sent_frames[0]["method"] == "session/update"
+    update = ws.sent_frames[0]["params"]["update"]
+    assert update["sessionUpdate"] == "agent_message_chunk"
+    assert "75%" in update["content"]["text"]
+
+    assert ws.sent_frames[1]["method"] == "session/update"
+    assert ws.sent_frames[1]["params"]["update"]["sessionUpdate"] == "session_info_update"
+
+    assert ws.sent_frames[2] == {
+        "jsonrpc": "2.0",
+        "id": 403,
+        "result": {"stopReason": "end_turn"},
+    }
+
+
+@pytest.mark.asyncio
 async def test_gateway_server_delta_only_does_not_trigger_idle_finalize(monkeypatch):
     import jiuwenswarm.gateway.app_gateway as gateway_module
 

--- a/tests/unit_tests/gateway/test_channel_manager_compression_dispatch.py
+++ b/tests/unit_tests/gateway/test_channel_manager_compression_dispatch.py
@@ -1,0 +1,322 @@
+"""Integration tests for compaction notice on ChannelManager dispatch paths.
+
+Exercises real ``_dispatch_robot_messages`` / ``dispatch_to_session`` wiring
+with fakes — not formatter-only unit tests.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from jiuwenswarm.common.schema.message import EventType, Message
+from jiuwenswarm.gateway.channel_manager.channel_manager import ChannelManager
+from jiuwenswarm.gateway.routing.keys import AgentRef, RoutingKey, make_delivery_target
+from jiuwenswarm.gateway.routing.session_sharing import (
+    LogicalTarget,
+    SessionSharingRegistry,
+    SubRole,
+)
+
+
+class _FakeMessageHandler:
+    """Minimal MessageHandler for dispatch-loop tests."""
+
+    def __init__(self, registry: SessionSharingRegistry) -> None:
+        self._session_sharing = registry
+        self._robot_messages: asyncio.Queue[Message] = asyncio.Queue()
+        self._last_originators: dict[str, tuple[str, str]] = {}
+
+    def get_session_sharing_registry(self) -> SessionSharingRegistry:
+        return self._session_sharing
+
+    def get_session_last_originator(self, session_id: str | None) -> tuple[str, str] | None:
+        if not session_id:
+            return None
+        return self._last_originators.get(str(session_id))
+
+    async def consume_robot_messages(self, timeout: float | None = None) -> Message | None:
+        try:
+            if timeout is None:
+                return await self._robot_messages.get()
+            return await asyncio.wait_for(self._robot_messages.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    async def publish_robot_messages(self, msg: Message) -> None:
+        await self._robot_messages.put(msg)
+
+    def resolve_app_id(self, msg: Message) -> str | None:  # noqa: ARG002
+        return "default"
+
+
+class _FakeChannel:
+    """Captures outbound ``send`` calls."""
+
+    def __init__(self, channel_id: str, app_id: str = "default") -> None:
+        self.channel_id = channel_id
+        self.app_id = app_id
+        self.sent: list[tuple[Message, object | None]] = []
+
+    async def send(self, msg: Message, routing_target=None) -> None:
+        self.sent.append((msg, routing_target))
+
+    def on_message(self, callback) -> None:  # noqa: ARG002
+        pass
+
+
+async def _make_subscription(
+    registry: SessionSharingRegistry, session_id: str, member_name: str, channel_id: str,
+) -> None:
+    rk = RoutingKey(
+        user_id=f"u_{channel_id}",
+        channel_id=channel_id,
+        app_id="default",
+        agent_ref=AgentRef("team", "default"),
+        session_id=session_id,
+    )
+    dt = make_delivery_target(
+        channel_id,
+        chat_id=f"chat_{channel_id}",
+        physical_user_id=f"u_{channel_id}",
+        ws_id=f"ws_{channel_id}",
+    )
+    await registry.register(session_id, member_name, rk, dt)
+
+
+def _compression_payload(**overrides) -> dict:
+    payload = {
+        "event_type": "context.compression_state",
+        "status": "completed",
+        "processor": "DialogueCompressor",
+        "before": {"tokens": 100_000},
+        "after": {"tokens": 25_000},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _compression_msg(
+    channel_id: str,
+    *,
+    session_id: str = "s1",
+    metadata: dict | None = None,
+) -> Message:
+    return Message(
+        id="evt-1",
+        type="event",
+        channel_id=channel_id,
+        session_id=session_id,
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload=_compression_payload(),
+        metadata=dict(metadata or {}),
+    )
+
+
+async def _wait_until(predicate, *, timeout: float = 2.5, interval: float = 0.05) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(interval)
+    raise AssertionError("condition not met before timeout")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_robot_messages_rewrites_compression_for_slack() -> None:
+    handler = _FakeMessageHandler(SessionSharingRegistry())
+    cm = ChannelManager(handler)
+    slack = _FakeChannel("slack")
+    cm.register_channel(slack)
+
+    await handler.publish_robot_messages(_compression_msg("slack"))
+
+    await cm.start_dispatch()
+    try:
+        await _wait_until(lambda: bool(slack.sent))
+
+        assert len(slack.sent) == 1
+        out, routing_target = slack.sent[0]
+        assert routing_target is None
+        assert out.event_type == EventType.CHAT_FINAL
+        assert "Compacted" in out.payload["content"]
+        assert out.payload["event_type"] == EventType.CHAT_FINAL.value
+    finally:
+        await cm.stop_dispatch()
+
+
+@pytest.mark.asyncio
+async def test_team_fan_out_rewrites_compression_for_feishu_when_origin_is_web() -> None:
+    registry = SessionSharingRegistry()
+    session_id = "s1"
+    await _make_subscription(registry, session_id, SubRole.GODVIEW, "web")
+    await _make_subscription(registry, session_id, SubRole.GODVIEW, "feishu")
+
+    handler = _FakeMessageHandler(registry)
+    cm = ChannelManager(handler)
+    web = _FakeChannel("web")
+    feishu = _FakeChannel("feishu")
+    cm.register_channel(web)
+    cm.register_channel(feishu)
+
+    msg = _compression_msg(
+        "web",
+        session_id=session_id,
+        metadata={"fan_out_targets": [LogicalTarget(intent="godview")]},
+    )
+    await handler.publish_robot_messages(msg)
+
+    await cm.start_dispatch()
+    try:
+        await _wait_until(lambda: bool(feishu.sent))
+
+        assert len(feishu.sent) == 1
+        feishu_out, _ = feishu.sent[0]
+        assert feishu_out.event_type == EventType.CHAT_FINAL
+        assert "Compacted" in feishu_out.payload["content"]
+        assert feishu_out.payload["event_type"] != "context.compression_state"
+
+        assert len(web.sent) == 1
+        web_out, _ = web.sent[0]
+        assert web_out.payload.get("event_type") == "context.compression_state"
+    finally:
+        await cm.stop_dispatch()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rewrites_high_occupancy_started_for_im_keeps_web_raw() -> None:
+    registry = SessionSharingRegistry()
+    session_id = "s1"
+    await _make_subscription(registry, session_id, SubRole.GODVIEW, "web")
+    await _make_subscription(registry, session_id, SubRole.GODVIEW, "feishu")
+
+    handler = _FakeMessageHandler(registry)
+    cm = ChannelManager(handler)
+    web = _FakeChannel("web")
+    feishu = _FakeChannel("feishu")
+    cm.register_channel(web)
+    cm.register_channel(feishu)
+
+    msg = Message(
+        id="evt-started",
+        type="event",
+        channel_id="web",
+        session_id=session_id,
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload={
+            "event_type": "context.compression_state",
+            "status": "started",
+            "processor": "DialogueCompressor",
+            "before": {"tokens": 100_000, "context_percent": 90},
+        },
+        metadata={"fan_out_targets": [LogicalTarget(intent="godview")]},
+    )
+
+    await handler.publish_robot_messages(msg)
+
+    await cm.start_dispatch()
+    try:
+        await _wait_until(lambda: bool(feishu.sent) and bool(web.sent))
+
+        assert len(feishu.sent) == 1
+        feishu_out, _ = feishu.sent[0]
+        assert feishu_out.event_type == EventType.CHAT_FINAL
+        assert feishu_out.id == "evt-started-compaction-started"
+        assert "compacting" in feishu_out.payload["content"].lower()
+        assert "90%" in feishu_out.payload["content"]
+
+        assert len(web.sent) == 1
+        web_out, _ = web.sent[0]
+        assert web_out.payload.get("event_type") == "context.compression_state"
+        assert web_out.payload.get("status") == "started"
+    finally:
+        await cm.stop_dispatch()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_keeps_raw_compression_event_for_acp_and_it_yields_a_session_update() -> None:
+    """P2 fix: ACP is a rich renderer (event passes through unmodified), but
+    unlike before that raw event must now turn into a real, non-final ACP
+    session/update downstream instead of being silently dropped.
+    """
+    handler = _FakeMessageHandler(SessionSharingRegistry())
+    cm = ChannelManager(handler)
+    acp = _FakeChannel("acp")
+    cm.register_channel(acp)
+
+    msg = Message(
+        id="evt-acp-1",
+        type="event",
+        channel_id="acp",
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload=_compression_payload(),
+        event_type=EventType.CONTEXT_COMPRESSION_STATE,
+    )
+    await handler.publish_robot_messages(msg)
+
+    await cm.start_dispatch()
+    try:
+        await _wait_until(lambda: bool(acp.sent))
+
+        assert len(acp.sent) == 1
+        out, _ = acp.sent[0]
+        # ACP keeps the raw event (it is a rich renderer) -- it must not be
+        # downgraded into the IM CHAT_FINAL rewrite.
+        assert out.event_type == EventType.CONTEXT_COMPRESSION_STATE
+        assert out.payload.get("event_type") == "context.compression_state"
+
+        from jiuwenswarm.common.e2a.acp.session_updates import build_acp_session_update
+
+        class _State:
+            assistant_message_id = None
+            assistant_text = None
+            thought_message_id = None
+            thought_text = None
+            user_message_id = None
+            tool_call_cache: dict = {}
+
+        update = build_acp_session_update(out, out.payload, _State())
+        assert update is not None
+        assert update["sessionUpdate"] == "agent_message_chunk"
+        assert "75%" in update["content"]["text"]
+    finally:
+        await cm.stop_dispatch()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_drops_started_without_occupancy_on_im() -> None:
+    handler = _FakeMessageHandler(SessionSharingRegistry())
+    cm = ChannelManager(handler)
+    slack = _FakeChannel("slack")
+    cm.register_channel(slack)
+
+    msg = Message(
+        id="evt-started",
+        type="event",
+        channel_id="slack",
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload={
+            "event_type": "context.compression_state",
+            "status": "started",
+            "processor": "DialogueCompressor",
+            "before": {"tokens": 3146},
+        },
+    )
+    await handler.publish_robot_messages(msg)
+
+    await cm.start_dispatch()
+    try:
+        await asyncio.sleep(0.3)
+        assert slack.sent == []
+    finally:
+        await cm.stop_dispatch()

--- a/tests/unit_tests/gateway/test_compression_notice.py
+++ b/tests/unit_tests/gateway/test_compression_notice.py
@@ -1,0 +1,426 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""IM-channel notice for context compaction."""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.schema import Message
+from jiuwenswarm.common.schema.message import EventType
+from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.compression_notice import (
+    as_text_message,
+    channel_renders_compression,
+    format_compression_notice,
+    reset_trigger_ratio_cache,
+    started_notice_min_percent,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_ratio_cache():
+    """The threshold is cached, so one test must not decide another's answer."""
+    reset_trigger_ratio_cache()
+    yield
+    reset_trigger_ratio_cache()
+
+
+def _config_with(section: str, ratio) -> dict:
+    return {"react": {"context_engine_config": {section: {"trigger_context_ratio": ratio}}}}
+
+
+def _event(status: str, *, before: int | None = None, after: int | None = None,
+           processor: str = "DialogueCompressor") -> dict:
+    payload: dict = {
+        "event_type": "context.compression_state",
+        "status": status,
+        "processor": processor,
+    }
+    if before is not None:
+        payload["before"] = {"tokens": before, "messages": 12}
+    if after is not None:
+        payload["after"] = {"tokens": after, "messages": 4}
+    return payload
+
+
+def test_started_without_high_occupancy_stays_silent() -> None:
+    """started with only tokens (or low %) must not post unquantified compacting."""
+    assert format_compression_notice(_event("started", before=3146)) is None
+    assert format_compression_notice({
+        "event_type": "context.compression_state",
+        "status": "started",
+        "processor": "DialogueCompressor",
+        "before": {"tokens": 10_000, "context_percent": 79},
+    }) is None
+    assert format_compression_notice(_event("noop", before=3146, after=3146)) is None
+
+
+def test_started_with_high_occupancy_announces_compacting() -> None:
+    notice = format_compression_notice({
+        "event_type": "context.compression_state",
+        "status": "started",
+        "processor": "DialogueCompressor",
+        "before": {"tokens": 100_000, "context_percent": 85},
+    })
+    assert notice is not None
+    assert "85%" in notice
+    assert "compacting" in notice.lower()
+
+
+# ------------------------------------------------- threshold follows config
+
+
+def test_a_lowered_trigger_ratio_still_announces(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bug this replaces: compaction fired and the warning went missing.
+
+    With the threshold hard-coded at 80, an operator who compacts at 50% kept
+    the outcome line and silently lost the heads-up.
+    """
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config",
+        lambda: _config_with("dialogue_compressor_config", 0.5),
+    )
+    notice = format_compression_notice({
+        "event_type": "context.compression_state",
+        "status": "started",
+        "processor": "DialogueCompressor",
+        "before": {"tokens": 50_000, "context_percent": 52},
+    })
+    assert notice is not None
+    assert "52%" in notice
+
+
+def test_a_raised_trigger_ratio_stays_silent_below_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config",
+        lambda: _config_with("dialogue_compressor_config", 0.95),
+    )
+    assert format_compression_notice({
+        "event_type": "context.compression_state",
+        "status": "started",
+        "processor": "DialogueCompressor",
+        "before": {"tokens": 90_000, "context_percent": 90},
+    }) is None
+
+
+def test_each_processor_reads_its_own_section(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three compressors, three ratios; the notice must not use one for all."""
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config",
+        lambda: {
+            "react": {
+                "context_engine_config": {
+                    "dialogue_compressor_config": {"trigger_context_ratio": 0.5},
+                    "round_level_compressor_config": {"trigger_context_ratio": 0.9},
+                }
+            }
+        },
+    )
+    assert started_notice_min_percent("DialogueCompressor") == 50
+    assert started_notice_min_percent("RoundLevelCompressor") == 90
+    # No section of its own -> the compressor-tree default.
+    assert started_notice_min_percent("CurrentRoundCompressor") == 80
+
+
+@pytest.mark.parametrize("ratio", [0, -0.5, 1.5, "high", None])
+def test_a_ratio_that_is_not_a_ratio_falls_back(
+    monkeypatch: pytest.MonkeyPatch, ratio,
+) -> None:
+    """A threshold no percentage can cross would silence the notice forever."""
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config",
+        lambda: _config_with("dialogue_compressor_config", ratio),
+    )
+    assert started_notice_min_percent("DialogueCompressor") == 80
+
+
+def test_an_unreadable_config_never_breaks_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom():
+        raise OSError("config gone")
+
+    monkeypatch.setattr("jiuwenswarm.common.config.get_config", _boom)
+    assert started_notice_min_percent("DialogueCompressor") == 80
+
+
+def test_the_threshold_is_cached_between_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """This runs per compression event; it must not re-read YAML each time."""
+    calls = {"n": 0}
+
+    def _counted():
+        calls["n"] += 1
+        return _config_with("dialogue_compressor_config", 0.6)
+
+    monkeypatch.setattr("jiuwenswarm.common.config.get_config", _counted)
+    for _ in range(5):
+        assert started_notice_min_percent("DialogueCompressor") == 60
+    assert calls["n"] == 1
+
+    reset_trigger_ratio_cache()
+    assert started_notice_min_percent("DialogueCompressor") == 60
+    assert calls["n"] == 2
+
+
+def test_a_real_compaction_quotes_what_it_freed() -> None:
+    notice = format_compression_notice(_event("completed", before=100_000, after=25_000))
+    assert notice is not None
+    assert "100.0k" in notice
+    assert "25.0k" in notice
+    assert "75% freed" in notice
+    assert "earlier messages" in notice
+
+
+def test_done_without_numbers_still_tells_the_user() -> None:
+    """Missing before/after must not silence the notice — the history still changed."""
+    notice = format_compression_notice(_event("completed"))
+    assert notice is not None
+    assert "Compacted" in notice
+
+
+def test_done_that_shrank_nothing_claims_no_saving() -> None:
+    notice = format_compression_notice(_event("completed", before=5_000, after=5_000))
+    assert notice is not None
+    assert "freed" not in notice
+
+
+def test_failure_is_announced_because_the_next_turn_may_suffer() -> None:
+    notice = format_compression_notice(_event("failed", processor="RoundLevelCompressor"))
+    assert notice is not None
+    assert "Could not compact" in notice
+    assert "the whole conversation" in notice
+
+
+def test_unknown_processor_falls_back_to_generic_wording() -> None:
+    notice = format_compression_notice(_event("completed", processor="SomeNewCompressor"))
+    assert notice is not None
+    assert "conversation history" in notice
+
+
+def test_malformed_payloads_never_raise() -> None:
+    """A bad payload must not break delivery of the turn it rode in on."""
+    assert format_compression_notice({}) is None
+    assert format_compression_notice({"status": None}) is None
+    assert format_compression_notice({"status": "completed", "before": "not-a-dict"}) is not None
+    assert format_compression_notice({"status": "completed", "before": {"tokens": "x"}}) is not None
+
+
+def test_token_scaling_is_readable() -> None:
+    notice = format_compression_notice(_event("completed", before=2_000_000, after=500_000))
+    assert notice is not None
+    assert "2.0M" in notice
+    assert "500.0k" in notice
+
+
+# ------------------------------------------------- dispatch-point substitution
+
+
+def _msg(channel_id: str, payload: dict) -> Message:
+    return Message(
+        id="evt-1",
+        type="event",
+        channel_id=channel_id,
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload=payload,
+    )
+
+
+def test_rich_renderers_keep_the_raw_event() -> None:
+    """Web and the TUI already render compression inline and must not be downgraded."""
+    for channel in ("web", "tui", "acp", "ssh"):
+        assert channel_renders_compression(channel)
+        original = _msg(channel, _event("completed", before=100_000, after=25_000))
+        assert as_text_message(original) is original
+
+
+def test_acp_raw_event_keeps_context_compression_state_event_type() -> None:
+    """ACP is a rich renderer: the raw event must reach it untouched so the
+    downstream ACP session/update builder (build_acp_session_update) can
+    still recognize ``context.compression_state`` by its real event_type
+    instead of receiving a CHAT_FINAL rewrite that would end the turn.
+    """
+    original = Message(
+        id="evt-acp-1",
+        type="event",
+        channel_id="acp",
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload=_event("completed", before=100_000, after=25_000),
+        event_type=EventType.CONTEXT_COMPRESSION_STATE,
+    )
+    out = as_text_message(original)
+    assert out is original
+    assert out.event_type == EventType.CONTEXT_COMPRESSION_STATE
+    assert out.payload["event_type"] == "context.compression_state"
+
+
+def test_im_channels_receive_the_notice_as_payload_content() -> None:
+    """payload["content"] is the field every IM channel reads to extract text."""
+    for channel in ("feishu", "slack", "telegram", "discord", "whatsapp",
+                    "wecom", "wechat", "dingtalk", "xiaoyi"):
+        assert not channel_renders_compression(channel)
+        out = as_text_message(_msg(channel, _event("completed", before=100_000, after=25_000)))
+        assert out is not None, channel
+        assert "75% freed" in out.payload["content"], channel
+        assert out.params["content"] == out.payload["content"], channel
+
+
+def test_im_notice_is_shaped_like_ordinary_chat_final() -> None:
+    """WeCom/WeChat only deliver CHAT_FINAL / plain res; content alone is dropped."""
+    original = Message(
+        id="req-42",
+        type="event",
+        channel_id="wecom",
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload=_event("completed", before=100_000, after=25_000),
+        metadata={"wecom_req_id": "stream-1", "chat_type": "dm"},
+    )
+    out = as_text_message(original)
+    assert out is not None
+    assert out is not original
+    assert out.type == "res"
+    assert out.event_type == EventType.CHAT_FINAL
+    assert out.id == "req-42-compaction"
+    assert out.payload["event_type"] == "chat.final"
+    assert "wecom_req_id" not in (out.metadata or {})
+    assert out.metadata.get("standalone_notice") is True
+    assert out.metadata.get("chat_type") == "dm"
+
+
+def test_events_worth_no_notice_are_not_delivered_to_im_channels() -> None:
+    """Low-occupancy started and noop stay dropped on IM."""
+    assert as_text_message(_msg("slack", _event("started", before=3146))) is None
+    assert as_text_message(_msg("slack", _event("noop", before=3146, after=3146))) is None
+
+
+def test_high_occupancy_started_is_rewritten_for_im() -> None:
+    """Surface context N% — compacting as a standalone IM line."""
+    original = Message(
+        id="req-1",
+        type="event",
+        channel_id="xiaoyi",
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload={
+            "event_type": "context.compression_state",
+            "status": "started",
+            "processor": "DialogueCompressor",
+            "before": {"tokens": 100_000, "context_percent": 90.4},
+        },
+        metadata={
+            "xiaoyi_task_id": "task-ABC",
+            "xiaoyi_session_id": "sid-1",
+        },
+    )
+    out = as_text_message(original, delivery_channel_id="xiaoyi")
+    assert out is not None
+    assert out.id == "req-1-compaction-started"
+    assert out.type == "res"
+    assert out.event_type == EventType.CHAT_FINAL
+    assert "90%" in out.payload["content"]
+    assert "compacting" in out.payload["content"].lower()
+    assert out.metadata.get("standalone_notice") is True
+    assert "xiaoyi_task_id" not in (out.metadata or {})
+    assert out.metadata.get("xiaoyi_session_id") == "sid-1"
+
+
+def test_delivery_channel_id_overrides_msg_channel_for_rich_renderer_check() -> None:
+    """Compression from a web session must still become plain text on Slack."""
+    msg = Message(
+        id="evt-1",
+        type="event",
+        channel_id="web",  # origin channel
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload={
+            "event_type": "context.compression_state",
+            "status": "completed",
+            "processor": "DialogueCompressor",
+            "before": {"tokens": 100_000},
+            "after": {"tokens": 25_000},
+        },
+    )
+    out = as_text_message(msg, delivery_channel_id="slack")
+    assert out is not None
+    assert out.event_type == EventType.CHAT_FINAL
+    assert "75% freed" in out.payload["content"]
+
+
+def test_rewrite_strips_xiaoyi_stream_binding_keys() -> None:
+    """Notices must not share the in-flight A2A task stream key."""
+    original = Message(
+        id="req-1",
+        type="event",
+        channel_id="xiaoyi",
+        session_id="s1",
+        params={},
+        timestamp=0.0,
+        ok=True,
+        payload=_event("completed", before=10_000, after=2_000),
+        metadata={
+            "xiaoyi_task_id": "task-ABC",
+            "xiaoyi_session_id": "sid-1",
+            "wecom_req_id": "stream-1",
+            "chat_type": "dm",
+        },
+    )
+    out = as_text_message(original, delivery_channel_id="xiaoyi")
+    assert out is not None
+    assert out.id == "req-1-compaction"
+    assert "xiaoyi_task_id" not in (out.metadata or {})
+    assert "wecom_req_id" not in (out.metadata or {})
+    assert out.metadata.get("xiaoyi_session_id") == "sid-1"
+    assert out.metadata.get("standalone_notice") is True
+    assert out.metadata.get("chat_type") == "dm"
+
+
+def test_unrelated_messages_pass_through_untouched() -> None:
+    """The dispatch point sees every outbound message; only this event may change."""
+    other = _msg("slack", {"event_type": "chat.final", "content": "hello"})
+    assert as_text_message(other) is other
+
+    no_payload = Message(
+        id="x", type="event", channel_id="slack", session_id="s",
+        params={}, timestamp=0.0, ok=True,
+    )
+    assert as_text_message(no_payload) is no_payload
+
+
+def test_rewrite_falls_back_when_primary_replace_fails(monkeypatch) -> None:
+    """If metadata surgery fails, still deliver a minimal notice with the text."""
+    import dataclasses
+
+    calls = {"n": 0}
+    real_replace = dataclasses.replace
+
+    def flaky_replace(obj, /, **changes):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("simulated replace failure")
+        return real_replace(obj, **changes)
+
+    monkeypatch.setattr(dataclasses, "replace", flaky_replace)
+
+    out = as_text_message(
+        _msg("slack", _event("completed", before=100_000, after=25_000))
+    )
+    assert out is not None
+    assert out.event_type == EventType.CHAT_FINAL
+    assert "75% freed" in out.payload["content"]
+    assert out.metadata.get("standalone_notice") is True

--- a/tests/unit_tests/gateway/test_feishu_standalone_notice.py
+++ b/tests/unit_tests/gateway/test_feishu_standalone_notice.py
@@ -1,0 +1,87 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Feishu standalone notices must not open a second CardKit streaming card."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jiuwenswarm.common.schema.message import EventType, Message
+from jiuwenswarm.gateway.channel_manager.base import RobotMessageRouter
+from jiuwenswarm.gateway.channel_manager.im_platforms.feishu.feishu_connect import (
+    FeishuChannel,
+    FeishuConfig,
+)
+
+
+def _make_channel() -> FeishuChannel:
+    config = FeishuConfig(
+        enabled=True,
+        app_id="test_app_id",
+        app_secret="test_app_secret",
+        enable_streaming=True,
+    )
+    channel = FeishuChannel(config, MagicMock(spec=RobotMessageRouter))
+    channel._api_client = MagicMock()
+    channel._send_feishu_message = AsyncMock()
+    channel._handle_cardkit_streaming_event = AsyncMock(return_value=True)
+    return channel
+
+
+def _standalone_notice() -> Message:
+    return Message(
+        id="req-1-compaction",
+        type="res",
+        channel_id="feishu",
+        session_id="s1",
+        params={"content": "🗜️ Compacted earlier messages."},
+        timestamp=0.0,
+        ok=True,
+        payload={
+            "event_type": "chat.final",
+            "content": "🗜️ Compacted earlier messages.",
+        },
+        event_type=EventType.CHAT_FINAL,
+        metadata={
+            "standalone_notice": True,
+            "feishu_open_id": "ou_test",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_standalone_notice_skips_cardkit_and_sends_plain() -> None:
+    channel = _make_channel()
+
+    await channel.send(_standalone_notice())
+
+    channel._handle_cardkit_streaming_event.assert_not_awaited()
+    assert channel._cardkit_sessions == {}
+    channel._send_feishu_message.assert_awaited_once()
+    args = channel._send_feishu_message.await_args.args
+    assert args[0] == "ou_test"
+    assert "Compacted" in args[2]
+
+
+@pytest.mark.asyncio
+async def test_ordinary_chat_final_still_uses_cardkit() -> None:
+    channel = _make_channel()
+    msg = Message(
+        id="req-1",
+        type="res",
+        channel_id="feishu",
+        session_id="s1",
+        params={"content": "hello"},
+        timestamp=0.0,
+        ok=True,
+        payload={"event_type": "chat.final", "content": "hello"},
+        event_type=EventType.CHAT_FINAL,
+        metadata={"feishu_open_id": "ou_test"},
+    )
+
+    await channel.send(msg)
+
+    channel._handle_cardkit_streaming_event.assert_awaited_once()
+    channel._send_feishu_message.assert_not_awaited()

--- a/tests/unit_tests/gateway/test_wechat_standalone_notice.py
+++ b/tests/unit_tests/gateway/test_wechat_standalone_notice.py
@@ -1,0 +1,91 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""WeChat standalone notices must not tear down in-flight streaming state."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jiuwenswarm.common.schema.message import EventType, Message
+from jiuwenswarm.gateway.channel_manager.im_platforms.wechat.wechat_connect import (
+    WechatChannel,
+    WechatConfig,
+)
+
+
+def _ready_channel() -> WechatChannel:
+    channel = WechatChannel(
+        WechatConfig(enabled=True, bot_token="test-token"),
+        bus=MagicMock(),
+    )
+    channel._http = MagicMock()
+    channel._send_text_chunks_to_user = AsyncMock()
+    channel._should_skip_due_to_send_limit = AsyncMock(return_value=False)
+    return channel
+
+
+@pytest.mark.asyncio
+async def test_standalone_notice_keeps_streaming_session_and_round() -> None:
+    channel = _ready_channel()
+    channel._streaming_sessions.add("user-1")
+    channel._continue_active_sessions.add("user-1")
+    channel.current_round = 3
+    channel._current_round_session_key = "user-1"
+
+    msg = Message(
+        id="req-1-compaction",
+        type="res",
+        channel_id="wechat",
+        session_id="s1",
+        params={"content": "🗜️ Compacted earlier messages."},
+        timestamp=0.0,
+        ok=True,
+        payload={
+            "event_type": "chat.final",
+            "content": "🗜️ Compacted earlier messages.",
+        },
+        event_type=EventType.CHAT_FINAL,
+        user_id="user-1",
+        metadata={
+            "standalone_notice": True,
+            "im_sender_user_id": "user-1",
+        },
+    )
+
+    await channel.send(msg)
+
+    channel._send_text_chunks_to_user.assert_awaited_once()
+    assert "user-1" in channel._streaming_sessions
+    assert "user-1" in channel._continue_active_sessions
+    assert channel.current_round == 3
+    assert channel._current_round_session_key == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_ordinary_chat_final_still_clears_streaming_state() -> None:
+    channel = _ready_channel()
+    channel._streaming_sessions.add("user-1")
+    channel.current_round = 3
+    channel._current_round_session_key = "user-1"
+
+    msg = Message(
+        id="req-1",
+        type="res",
+        channel_id="wechat",
+        session_id="s1",
+        params={"content": "hello"},
+        timestamp=0.0,
+        ok=True,
+        payload={"event_type": "chat.final", "content": "hello"},
+        event_type=EventType.CHAT_FINAL,
+        user_id="user-1",
+        metadata={"im_sender_user_id": "user-1"},
+    )
+
+    await channel.send(msg)
+
+    assert "user-1" not in channel._streaming_sessions
+    assert channel.current_round == 0
+    assert channel._current_round_session_key == ""

--- a/tests/unit_tests/gateway/test_xiaoyi_standalone_notice.py
+++ b/tests/unit_tests/gateway/test_xiaoyi_standalone_notice.py
@@ -1,0 +1,116 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Xiaoyi must not merge compaction notices into the in-flight A2A stream."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jiuwenswarm.common.schema.message import EventType, Message
+from jiuwenswarm.gateway.channel_manager.im_platforms.xiaoyi.xiaoyi_connect import (
+    XiaoyiChannel,
+    XiaoyiChannelConfig,
+)
+from jiuwenswarm.gateway.routing.keys import XiaoyiDeliveryTarget
+from jiuwenswarm.gateway.routing.session_sharing import RoutingTarget
+
+
+def _make_channel(*, api_id: str = "") -> XiaoyiChannel:
+    config = XiaoyiChannelConfig(
+        enabled=True,
+        channel_id="xiaoyi",
+        enable_streaming=True,
+        api_id=api_id,
+    )
+    channel = XiaoyiChannel(config, router=MagicMock())
+    channel._ws_connections = {"ws1": object()}
+    channel._send_text_response = AsyncMock()
+    return channel
+
+
+def _standalone_notice(*, content: str = "🗜️ Compacted earlier messages.") -> Message:
+    return Message(
+        id="req-1-compaction",
+        type="res",
+        channel_id="xiaoyi",
+        session_id="logical-sess",
+        params={"content": content},
+        timestamp=0.0,
+        ok=True,
+        payload={"event_type": "chat.final", "content": content},
+        event_type=EventType.CHAT_FINAL,
+        metadata={
+            "standalone_notice": True,
+            "xiaoyi_session_id": "sid-1",
+            # task id stripped by compression_notice rewrite
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_standalone_notice_does_not_flush_ws_buffer() -> None:
+    channel = _make_channel()
+    channel._ws_flush_buffers["task-ABC"] = "partial answer"
+
+    await channel._send_ws_to_user(
+        "sid-1",
+        "task-ABC",
+        _standalone_notice(),
+        "🗜️ Compacted earlier messages.",
+    )
+
+    assert channel._ws_flush_buffers["task-ABC"] == "partial answer"
+    channel._send_text_response.assert_awaited_once()
+    kwargs = channel._send_text_response.await_args
+    assert kwargs.args[1] == "req-1-compaction"  # notice task id, not active stream
+    assert kwargs.kwargs["is_final"] is False
+    assert kwargs.kwargs["last_chunk"] is True
+    assert "Compacted" in kwargs.args[2]
+
+
+@pytest.mark.asyncio
+async def test_standalone_notice_legacy_does_not_clobber_accumulated_text() -> None:
+    channel = _make_channel()
+    channel._accumulated_texts["sid-1"] = "partial answer so far"
+
+    await channel._send_legacy(_standalone_notice())
+
+    assert channel._accumulated_texts["sid-1"] == "partial answer so far"
+    channel._send_text_response.assert_awaited_once()
+    kwargs = channel._send_text_response.await_args
+    assert kwargs.kwargs["is_final"] is False
+    assert kwargs.args[1] == "req-1-compaction"
+
+
+@pytest.mark.asyncio
+async def test_standalone_notice_team_push_sends_immediately_without_merge() -> None:
+    """Inactive team users use push; notices must not enter the merge window."""
+    channel = _make_channel(api_id="api-1")
+    channel._active_push_sessions.clear()
+    pending = "other team reply still buffering"
+    channel._push_merge_buffers["agent-1"] = [
+        (time.time(), pending, pending[:30], "push-1"),
+    ]
+
+    mock_service = MagicMock()
+    mock_service.send_push = AsyncMock()
+    delivery = XiaoyiDeliveryTarget(agent_id="agent-1", push_id="push-1")
+    target = RoutingTarget(intent="godview", delivery=delivery)
+    notice = _standalone_notice(content="Context 85% — compacting…")
+
+    with patch(
+        "jiuwenswarm.gateway.channel_manager.im_platforms.xiaoyi.xiaoyi_connect.XiaoYiPushService",
+        return_value=mock_service,
+    ):
+        await channel._send_team(notice, target)
+
+    mock_service.send_push.assert_awaited_once()
+    _summary, pushed = mock_service.send_push.await_args.args
+    assert "compacting" in pushed
+    assert pending not in pushed
+    assert channel._push_merge_buffers["agent-1"][0][1] == pending
+    assert all("compacting" not in entry[1] for entry in channel._push_merge_buffers["agent-1"])
+    assert "agent-1" not in channel._push_flush_tasks or channel._push_flush_tasks["agent-1"].done()


### PR DESCRIPTION
Paired: [GitHub #2639](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2639) ↔ [GitCode !4676](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4676)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bug fix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind feature


**What does this PR do / why do we need it**:
* Turn context compression on by default so long-running chats actually auto-compact when `react.context_engine_config.enabled` is omitted.
* Surface compression on text (IM) channels as standalone `CHAT_FINAL` lines:
  * pre: `Context {N}% — compacting…` when `status=started` and occupancy reaches that processor's `trigger_context_ratio` (from `react.context_engine_config`, not a hard-coded 80%)
  * post: compacted / failure outcomes when history actually changes
* Apply the rewrite per delivery channel (ChannelManager + team fan-out), so a web-origin session still notifies Feishu/Slack correctly.
* Keep Web/TUI/ACP/SSH on the rich `context.compression_state` event; do not break mid-stream Xiaoyi / WeChat / Feishu replies.
* Warn on stale compressor config keys without failing startup.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2638


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* **Unit (function)**: compression notice (config-driven started threshold, drop below-ratio / missing `%` / `noop`), destination-aware dispatch (web origin → Feishu/Slack rewrite; Web/TUI/ACP/SSH keep raw event), Xiaoyi/WeChat/Feishu `standalone_notice` bypass, default `enabled=true` + explicit `false`, stale compressor config key warnings. Result: suite passed.
* **Web (function)**: with temporary low `trigger_context_ratio` / `min_target_context_ratio` (and fixed `context_window_tokens` when the resolved window is huge), chat until compact → rich “Compressing context” / completed UI; DevTools WS shows `context.compression_state` `started` then `completed`. Explicit `enabled: false` disables compression UI.
* **IM (function / reliability)**: Feishu or WeChat or Xiaoyi shows two standalone lines (`Context N% — compacting…` then `Compacted…` / failure) without merging into or tearing down the in-flight model stream; Feishu streaming stays a short notice, not a second CardKit stream card.
* **Team fan-out (function)**: web session with Feishu subscriber → Feishu gets plain-text notice; Web keeps the rich event.
* **Config threshold (function)**: lowering `trigger_context_ratio` still produces the started notice (threshold follows config, not a constant 80%).
* **Performance / smoke hygiene**: turns without compact send no extra IM messages; restore production ratios (`0.8` / `0.8` / `0.9`, `min_target` `0.1`) after smoke.
* **Security / reliability notes**: stream-binding keys (`xiaoyi_task_id`, `wecom_req_id`) stripped from notice ids; ACP does not get the IM `type=res` rewrite; config-read failures fall back without breaking outbound delivery.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [x] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [x] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2638
<!-- /bot1-related-issues -->
