### PR TITLE
feat(commands): add user-defined slash commands for the TUI

### DIFF
--- a/jiuwenswarm/channels/tui/frontend/package.json
+++ b/jiuwenswarm/channels/tui/frontend/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "build:bun": "npm run clean && bun build src/index.ts --target=node --outdir dist --format=esm --sourcemap && tsc --emitDeclarationOnly",
     "typecheck": "tsc --noEmit",
-    "test": "node tests/run-tests.mjs && node tests/editor-handoff.test.mjs && node tests/supervised-env.test.mjs && node tests/handoff-port.test.mjs && node tests/task-lifecycle-port.test.mjs && node tests/reauth-port.test.mjs && node tests/switch-command.test.mjs && node tests/session-registration.test.mjs && node tests/memory-view-permissions.test.mjs && node tests/evolution-command-gate.test.mjs",
+    "test": "node tests/run-tests.mjs && node tests/editor-handoff.test.mjs && node tests/supervised-env.test.mjs && node tests/handoff-port.test.mjs && node tests/task-lifecycle-port.test.mjs && node tests/reauth-port.test.mjs && node tests/switch-command.test.mjs && node tests/session-registration.test.mjs && node tests/memory-view-permissions.test.mjs && node tests/evolution-command-gate.test.mjs && node tests/user-commands.test.mjs",
     "lint": "oxlint --deny-warnings src",
     "format": "oxfmt --write src package.json tsconfig.json",
     "format:check": "oxfmt --check src package.json tsconfig.json",

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/CommandService.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/CommandService.ts
@@ -1,5 +1,14 @@
-import type { CommandContext, CommandSuggestion, SlashCommand } from "./types.js";
+import type {
+  CommandContext,
+  CommandSuggestion,
+  SlashCommand,
+  UserCommandDefinition,
+} from "./types.js";
 import { flattenArrayPayload, makeItem, parseArgs } from "./helpers.js";
+import {
+  buildUserCommands,
+  type InactiveUserCommand,
+} from "./user-commands.js";
 
 export function parseSlashCommand(raw: string, commands: readonly SlashCommand[]) {
   const trimmed = raw.trim();
@@ -58,17 +67,50 @@ export class CommandService {
   private installedSkills: InstalledSkillEntry[] = [];
   /** 配置未成功读取前保持关闭，避免演进命令意外暴露。 */
   private skillEvolutionEnabled = false;
+  /**
+   * Built-ins and user commands are kept apart because they refresh on
+   * different clocks: built-ins are registered once at boot, user commands are
+   * re-read from disk whenever `refreshUserCommands` runs. Rebuilding from the
+   * two lists is what lets a reload replace user commands without disturbing
+   * the built-ins.
+   */
+  private builtinCommands: SlashCommand[] = [];
+  private userCommands: SlashCommand[] = [];
+  private inactiveUserCommands: InactiveUserCommand[] = [];
 
   /**
-   * Optional callback invoked whenever the installed-skills cache is successfully
-   * refreshed.  The UI layer registers this to rebuild its autocomplete provider
-   * so that `/<skillName>` shorthands appear in the command-name dropdown.
+   * Optional callback invoked whenever the command registry changes (user
+   * commands loaded/refreshed or installed skills updated). The UI layer uses
+   * this to rebuild its autocomplete provider.
    */
+  onCommandRegistryChange?: (skills: readonly InstalledSkillEntry[]) => void;
+
+  /** @deprecated Use {@link onCommandRegistryChange}. */
   onInstalledSkillsChange?: (skills: readonly InstalledSkillEntry[]) => void;
 
   register(commands: readonly SlashCommand[]): void {
-    this.topLevelCommands = [...commands];
-    for (const command of commands) {
+    this.builtinCommands = [...commands];
+    this.rebuild();
+  }
+
+  /**
+   * Re-register everything from the two source lists.
+   *
+   * A colliding user command is dropped here rather than ordered around.
+   * Lookup happens two ways -- `resolve` reads the name map, `parseSlashCommand`
+   * scans the array -- and the two would disagree under any ordering that let
+   * both entries exist. `buildUserCommands` and the server already refuse these
+   * names, so this is the third guard, not the only one.
+   */
+  private rebuild(): void {
+    this.commands.clear();
+    this.aliases.clear();
+    const builtinNames = this.builtinNameSet();
+    this.topLevelCommands = [
+      ...this.builtinCommands,
+      ...this.userCommands.filter((command) => !builtinNames.has(command.name)),
+    ];
+    for (const command of this.topLevelCommands) {
       this.registerCommand(command);
     }
     this.applySkillEvolutionVisibility();
@@ -99,6 +141,21 @@ export class CommandService {
       }
     };
     visit(this.topLevelCommands);
+  }
+
+  /** Top-level built-in names only (not nested subcommands). */
+  private topLevelBuiltinNameSet(): Set<string> {
+    const names = new Set<string>();
+    for (const command of this.builtinCommands) {
+      names.add(command.name.toLowerCase());
+      for (const alias of command.altNames ?? []) names.add(alias.toLowerCase());
+    }
+    return names;
+  }
+
+  /** @deprecated Use {@link topLevelBuiltinNameSet}. Subcommand names are not reserved. */
+  private builtinNameSet(): Set<string> {
+    return this.topLevelBuiltinNameSet();
   }
 
   private registerCommand(command: SlashCommand): void {
@@ -149,18 +206,130 @@ export class CommandService {
       });
       // Notify the UI so it can rebuild the autocomplete provider with the
       // fresh `/<skillName>` shorthands.
-      this.onInstalledSkillsChange?.(this.installedSkills);
+      this.notifyRegistryChange();
     } catch {
       // Keep the previous cache if the RPC fails.
     }
+  }
+
+  private notifyRegistryChange(): void {
+    const skills = this.installedSkills;
+    this.onCommandRegistryChange?.(skills);
+    this.onInstalledSkillsChange?.(skills);
   }
 
   getInstalledSkills(): readonly InstalledSkillEntry[] {
     return this.installedSkills;
   }
 
+  isTopLevelBuiltin(name: string): boolean {
+    return this.topLevelBuiltinNameSet().has(name.toLowerCase());
+  }
+
+  /**
+   * Fetch user-defined commands from the backend and merge them in.
+   *
+   * Called from {@link execute} before every slash dispatch, and eagerly on
+   * WebSocket connect so autocomplete and `/help` see user commands before
+   * the first submit. Re-reading the directory is the whole reload story; the
+   * server globs disk per call, so there is no cache to invalidate.
+   *
+   * The built-in names travel with the request. The server cannot know them --
+   * they are defined here, not there -- so it can only refuse `model.md` if we
+   * say `model` is taken. Without that the server would report a command as
+   * active that this client silently never runs.
+   */
+  async refreshUserCommands(ctx: CommandContext): Promise<void> {
+    const builtinNames = this.topLevelBuiltinNameSet();
+    try {
+      const payload = await ctx.request<{
+        commands?: UserCommandDefinition[];
+        workspace_resolved?: boolean;
+      }>(
+        "commands.list",
+        { builtin_names: [...builtinNames] },
+      );
+      if (payload?.workspace_resolved === false) {
+        return;
+      }
+      const definitions = (payload?.commands ?? []) as UserCommandDefinition[];
+      const { commands, inactive } = buildUserCommands(
+        definitions,
+        builtinNames,
+        (def, args, runCtx) => this.runUserCommand(def, args, runCtx),
+      );
+      this.userCommands = commands;
+      this.inactiveUserCommands = inactive;
+      this.rebuild();
+      this.notifyRegistryChange();
+    } catch {
+      // Keep the previous set if the RPC fails. A dropped connection should not
+      // make the user's own commands disappear mid-session.
+    }
+  }
+
+  /** User commands that will not run, and why, for `/help` to explain. */
+  getInactiveUserCommands(): readonly InactiveUserCommand[] {
+    return this.inactiveUserCommands;
+  }
+
+  /**
+   * Expand a user command server-side, then send the result as a message.
+   *
+   * The expansion is a separate round trip so failures are visible before
+   * anything reaches the model: a `@file` that could not be read is reported
+   * here, next to the command that asked for it, instead of arriving as a gap
+   * in a prompt the user never sees.
+   */
+  private async runUserCommand(
+    def: UserCommandDefinition,
+    args: string,
+    ctx: CommandContext,
+  ): Promise<void> {
+    let payload: { text?: string; errors?: string[] };
+    try {
+      payload = await ctx.request<{ text?: string; errors?: string[] }>(
+        "commands.expand",
+        {
+          name: def.name,
+          args,
+          builtin_names: [...this.builtinNameSet()],
+        },
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      ctx.addItem(
+        makeItem(ctx.sessionId, "error", `/${def.name} failed to expand: ${message}`),
+      );
+      return;
+    }
+
+    const text = payload?.text ?? "";
+    if (!text.trim()) {
+      ctx.addItem(
+        makeItem(ctx.sessionId, "error", `/${def.name} expanded to nothing.`),
+      );
+      return;
+    }
+    // Errors do not block the send: the text is usable, with each unreadable
+    // reference marked inline. Say so, then send it.
+    for (const problem of payload?.errors ?? []) {
+      ctx.addItem(makeItem(ctx.sessionId, "error", `/${def.name}: ${problem}`));
+    }
+    ctx.sendMessage(text);
+  }
+
   async execute(raw: string, ctx: CommandContext): Promise<void> {
-    const parsed = parseSlashCommand(raw.trim(), this.getAll(true));
+    const trimmed = raw.trim();
+    // Re-read user commands before lookup when the first token is not a
+    // top-level built-in, so a newly created file is visible on first use.
+    if (trimmed.startsWith("/")) {
+      const firstToken = trimmed.substring(1).trim().split(/\s+/)[0]?.toLowerCase() ?? "";
+      if (!this.topLevelBuiltinNameSet().has(firstToken)) {
+        await this.refreshUserCommands(ctx);
+      }
+    }
+    const parsed = parseSlashCommand(trimmed, this.getAll(true));
     const command = parsed.command;
     if (!command) {
       // 注：/<skill> 已在 app-screen.handleSubmit 的行首分流里落到普通消息分支

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/help.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/help.ts
@@ -1,5 +1,6 @@
 import { CommandKind, type SlashCommand, type SlashCommandListProvider } from "../types.js";
 import { makeItem } from "../helpers.js";
+import type { InactiveUserCommand } from "../user-commands.js";
 
 const COMMAND_GROUPS: Record<string, { name: string; commands: string[] }> = {
   core: {
@@ -38,7 +39,10 @@ function getCommandGroup(commandName: string): string | null {
   return null;
 }
 
-export function createHelpCommand(getCommands: SlashCommandListProvider): SlashCommand {
+export function createHelpCommand(
+  getCommands: SlashCommandListProvider,
+  getInactiveUserCommands?: () => readonly InactiveUserCommand[],
+): SlashCommand {
   return {
     name: "help",
     description: "Show available commands",
@@ -50,6 +54,10 @@ export function createHelpCommand(getCommands: SlashCommandListProvider): SlashC
 
       const groupedCommands: Record<string, Array<{ label: string; value?: string; description: string }>> = {};
       const ungroupedCommands: Array<{ label: string; value?: string; description: string }> = [];
+      // User-defined commands get their own group rather than falling into
+      // "Other": which of these came from a file the user can edit is the first
+      // thing they need to know, and it is not derivable from the name.
+      const userCommands: Array<{ label: string; value?: string; description: string }> = [];
 
       for (const command of commands) {
         const item = {
@@ -57,6 +65,11 @@ export function createHelpCommand(getCommands: SlashCommandListProvider): SlashC
           value: command.usage?.replace(/^\/[^\s]+/, "").trim() || undefined,
           description: command.description,
         };
+
+        if (command.kind === CommandKind.USER) {
+          userCommands.push(item);
+          continue;
+        }
 
         const groupKey = getCommandGroup(command.name);
         if (groupKey) {
@@ -80,6 +93,27 @@ export function createHelpCommand(getCommands: SlashCommandListProvider): SlashC
         groups.push({
           name: "Other",
           items: ungroupedCommands,
+        });
+      }
+
+      if (userCommands.length > 0) {
+        groups.push({
+          name: "User-defined",
+          items: userCommands,
+        });
+      }
+
+      // A file the user wrote that does nothing is an unanswerable support
+      // question. Listing it with the reason is the whole point of the server
+      // reporting losers instead of dropping them.
+      const inactive = getInactiveUserCommands?.() ?? [];
+      if (inactive.length > 0) {
+        groups.push({
+          name: "User-defined (not loaded)",
+          items: inactive.map((entry) => ({
+            label: `/${entry.name}`,
+            description: `${entry.reason} — ${entry.filePath}`,
+          })),
         });
       }
 

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/registry.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/registry.ts
@@ -1,5 +1,6 @@
 /** 内置 slash 与 Gateway 受控指令对齐时参见仓库 `jiuwenswarm/gateway/slash_command.py`（SSOT）与 `docs/zh/CLI_COMMANDS.md`。 */
-import type { SlashCommand } from "./types.js";
+import type { SlashCommand, SlashCommandListProvider } from "./types.js";
+import type { InactiveUserCommand } from "./user-commands.js";
 import { createBranchCommand } from "./builtins/branch.js";
 import { createBtwCommand } from "./builtins/btw.js";
 import { createClearCommand } from "./builtins/clear.js";
@@ -62,6 +63,17 @@ export interface BuiltinCommandsOptions {
    */
   harmonyosEnabled?: boolean;
   /**
+   * Every registered command, user-defined ones included, for `/help` to list.
+   *
+   * Without it `/help` closes over the local built-in array and can only ever
+   * describe itself -- a user command would be runnable and undiscoverable at
+   * the same time. Defaults to the built-ins so a caller that does not have a
+   * registry yet still gets the old behaviour.
+   */
+  listAll?: SlashCommandListProvider;
+  /** User command files that were found but will not run, and why. */
+  getInactiveUserCommands?: () => readonly InactiveUserCommand[];
+  /**
    * 是否激活 /switch 命令。
    * 仅一体机场景（launcher 注入 AGENTOS_TUI_SUPERVISED=1）时为 true，
    * 此时命令可见且可执行；否则不注册，命令在 help、补全、执行中均不可见。
@@ -78,7 +90,7 @@ export function isHarmonyOSCommandsEnabled(
 export function createBuiltinCommands(options: BuiltinCommandsOptions = {}): SlashCommand[] {
   const commands: SlashCommand[] = [
     createAgentsCommand(),
-    createHelpCommand(() => commands),
+    createHelpCommand(options.listAll ?? (() => commands), options.getInactiveUserCommands),
     ...(options.harmonyosEnabled
       ? [createHarmonyOSDevInitCommand(), createHarmonyOSProjectInitCommand()]
       : []),

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/types.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/types.ts
@@ -19,6 +19,29 @@ export type StatusViewTab = "status" | "usage" | "config";
 
 export enum CommandKind {
   BUILT_IN = "built-in",
+  /** Loaded from a Markdown file under .jiuwenswarm/commands/. */
+  USER = "user",
+}
+
+/** Where a user-defined command was found; precedence is project > user > local. */
+export type UserCommandSource = "project" | "user" | "local";
+
+/** One command as returned by the `commands.list` RPC. */
+export interface UserCommandDefinition {
+  name: string;
+  description: string;
+  /** Omitted from list payloads; expansion reads the file server-side. */
+  body?: string;
+  source: UserCommandSource;
+  file_path: string;
+  argument_hint: string;
+  allowed_tools: string[] | null;
+  /** Set when the body uses $ARGUMENTS, $1..$9, or argument-hint. */
+  accepts_args?: boolean;
+  /** Set when a higher-precedence source defines the same name. */
+  shadowed_by: UserCommandSource | null;
+  /** Set when the name collides with a built-in, which always wins. */
+  reserved: boolean;
 }
 
 export interface CommandSuggestion {

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/user-commands.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/user-commands.ts
@@ -1,0 +1,97 @@
+import {
+  CommandKind,
+  type CommandContext,
+  type SlashCommand,
+  type UserCommandDefinition,
+} from "./types.js";
+
+/**
+ * Turn the `commands.list` RPC result into runnable slash commands.
+ *
+ * Expansion of `$ARGUMENTS`, `$1..$9` and `@file` happens **server-side**, via
+ * a separate `commands.expand` round trip: resolving a file reference needs the
+ * workspace boundary the server owns and the TUI does not.
+ */
+
+/** A command that will not run, and the reason, for `/help` to explain. */
+export interface InactiveUserCommand {
+  name: string;
+  reason: string;
+  filePath: string;
+}
+
+export interface UserCommandsResult {
+  commands: SlashCommand[];
+  inactive: InactiveUserCommand[];
+}
+
+function describe(def: UserCommandDefinition): string {
+  const base = def.description || "User-defined command";
+  return `${base} (${def.source})`;
+}
+
+/**
+ * Build the runnable set, dropping the ones that lost.
+ *
+ * `builtinNames` wins every collision. A file cannot take over `/help` or
+ * `/compact`: making the system undiscoverable, or shadowing the command that
+ * saves a conversation, is not something a directory in a cloned repo should be
+ * able to do. Losers are returned in `inactive` rather than discarded, so the
+ * user can be told why their file does nothing.
+ */
+export function buildUserCommands(
+  definitions: UserCommandDefinition[],
+  builtinNames: Set<string>,
+  runCommand: (
+    def: UserCommandDefinition,
+    args: string,
+    ctx: CommandContext,
+  ) => void | Promise<void>,
+): UserCommandsResult {
+  const commands: SlashCommand[] = [];
+  const inactive: InactiveUserCommand[] = [];
+  const claimed = new Set<string>();
+
+  for (const def of definitions) {
+    const name = def.name.toLowerCase();
+    if (def.reserved || builtinNames.has(name)) {
+      inactive.push({
+        name,
+        reason: "name is reserved by a built-in command",
+        filePath: def.file_path,
+      });
+      continue;
+    }
+    if (def.shadowed_by) {
+      inactive.push({
+        name,
+        reason: `shadowed by the ${def.shadowed_by} definition`,
+        filePath: def.file_path,
+      });
+      continue;
+    }
+    // Defensive: the server already resolves precedence, but a duplicate here
+    // would silently register two commands with one name.
+    if (claimed.has(name)) {
+      inactive.push({
+        name,
+        reason: "duplicate name",
+        filePath: def.file_path,
+      });
+      continue;
+    }
+    claimed.add(name);
+
+    commands.push({
+      name,
+      description: describe(def),
+      usage: def.argument_hint ? `/${name} ${def.argument_hint}` : `/${name}`,
+      argGuide: def.argument_hint || undefined,
+      kind: CommandKind.USER,
+      takesArgs: def.accepts_args ?? Boolean(def.argument_hint),
+      action: (ctx, args) => runCommand(def, args, ctx),
+    });
+  }
+
+  return { commands, inactive };
+}

--- a/jiuwenswarm/channels/tui/frontend/src/index.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/index.ts
@@ -154,12 +154,14 @@ wsClient.onAuthExpired = () => {
 };
 
 const commandService = new CommandService();
-commandService.register(
-  createBuiltinCommands({
-    harmonyosEnabled: isHarmonyOSCommandsEnabled(),
-    switchEnabled: supervisionEnv.supervised,
-  }),
-);
+commandService.register(createBuiltinCommands({
+  harmonyosEnabled: isHarmonyOSCommandsEnabled(),
+  switchEnabled: supervisionEnv.supervised,
+  // /help reads the live registry, not the built-in array it was built from,
+  // so user-defined commands are discoverable and not merely runnable.
+  listAll: () => commandService.getAll(true),
+  getInactiveUserCommands: () => commandService.getInactiveUserCommands(),
+}));
 
 /** 正常退出 CLI 前显式通知服务端；异常崩溃不走该路径。 */
 async function notifyDisconnectBeforeExit(): Promise<void> {

--- a/jiuwenswarm/channels/tui/frontend/src/ui/app-screen.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/ui/app-screen.ts
@@ -39,6 +39,7 @@ import {
   type InstalledSkillEntry,
 } from "../core/commands/CommandService.js";
 import type { SlashCommand } from "../core/commands/types.js";
+import { CommandKind } from "../core/commands/types.js";
 import { addCommandEcho, addError, addInfo } from "../core/commands/helpers.js";
 import { copyToClipboard } from "../core/commands/clipboard.js";
 import { CheckboxList, CheckboxGroup as CheckboxGroupType } from "./components/checkbox-list.js";
@@ -1752,7 +1753,7 @@ export class AppScreen implements Component, Focusable {
     // WebSocket connection and after every execute() call), rebuild the
     // CombinedAutocompleteProvider so that the /<skillName> shorthands appear
     // in the command-name dropdown.
-    this.commands.onInstalledSkillsChange = (skills: readonly InstalledSkillEntry[]) => {
+    this.commands.onCommandRegistryChange = (skills: readonly InstalledSkillEntry[]) => {
       this.composerAutocompleteProvider = this.rebuildAutocompleteProvider(skills);
       this.editor.setAutocompleteProvider(this.composerAutocompleteProvider);
     };
@@ -3457,16 +3458,31 @@ export class AppScreen implements Component, Focusable {
     }
 
     if (text.startsWith("/")) {
+      const slashMatch = text.match(/^\/(\S+)/);
+      const firstToken = slashMatch?.[1] ?? "";
       // /<installedSkill> 行首分流：命中已装 skill 时当普通消息发送（content 原样
       // 保留 /<skill> 前缀，skill 名由 extractSkillsFromContent 提取注入 params.skills）。
       // 未命中已装 skill 的 /xxx 不在此拦截，继续走下面的命令分支（仍可能 Unknown command）。
       {
-        const slashMatch = text.match(/^\/(\S+)/);
-        const firstToken = slashMatch?.[1] ?? "";
+        const tokenLower = firstToken.toLowerCase();
         const installedSkill = firstToken
-          ? this.commands.getInstalledSkills().find((s) => s.name === firstToken)
+          ? this.commands.getInstalledSkills().find(
+              (s) => s.name.toLowerCase() === tokenLower,
+            )
           : undefined;
-        if (installedSkill) {
+        // Refresh only when a skill might collide with a user command. Pure user
+        // commands refresh once in CommandService.execute(); a blanket refresh
+        // here duplicated that RPC on every non-built-in slash.
+        if (installedSkill && !this.commands.isTopLevelBuiltin(firstToken)) {
+          await this.commands.refreshUserCommands(this.state.getCommandContext());
+        }
+        const registeredCommand = firstToken
+          ? this.commands.resolve(firstToken)
+          : undefined;
+        if (
+          installedSkill &&
+          !(registeredCommand?.kind === CommandKind.USER)
+        ) {
           // 只有 /<skill> 而没有内容时没什么可发的。pi-tui 在补全弹窗上按回车会
           // 「应用补全」并顺势提交（见其 editor 的 tui.select.confirm 分支），这一下
           // 只是补全，所以把补全结果放回输入框等用户补内容；用户自己再回车才提示为空。
@@ -3735,6 +3751,9 @@ export class AppScreen implements Component, Focusable {
     if (!this.didEagerFetchSkills && snapshot.connectionStatus === "connected") {
       this.didEagerFetchSkills = true;
       void this.commands.refreshSkills(this.state.getCommandContext());
+      // User-defined commands have to be in the registry before the first
+      // /help or the first autocomplete, so they load on the same signal.
+      void this.commands.refreshUserCommands(this.state.getCommandContext());
     }
     // Hide /sandbox subcommand inline hints when sandbox.type=yuanrong.
     if (!this.didEagerFetchSandboxMeta && snapshot.connectionStatus === "connected") {

--- a/jiuwenswarm/channels/tui/frontend/tests/user-commands.test.mjs
+++ b/jiuwenswarm/channels/tui/frontend/tests/user-commands.test.mjs
@@ -1,0 +1,352 @@
+import assert from "node:assert/strict";
+
+import { CommandService } from "../dist/core/commands/CommandService.js";
+import { CommandKind } from "../dist/core/commands/types.js";
+import { createHelpCommand } from "../dist/core/commands/builtins/help.js";
+import { buildUserCommands } from "../dist/core/commands/user-commands.js";
+
+/** One definition as `commands.list` returns it. */
+function definition(overrides = {}) {
+  return {
+    name: "review",
+    description: "Review a file",
+    source: "project",
+    file_path: "/ws/.jiuwenswarm/commands/review.md",
+    argument_hint: "<path>",
+    allowed_tools: null,
+    accepts_args: true,
+    shadowed_by: null,
+    reserved: false,
+    ...overrides,
+  };
+}
+
+function makeMockContext({ responses = {}, failOn = new Set() } = {}) {
+  const requests = [];
+  const sent = [];
+  const items = [];
+  const ctx = {
+    sessionId: "s-1",
+    addItem: (item) => items.push(item),
+    sendMessage: (content) => {
+      sent.push(content);
+      return "msg-1";
+    },
+    request: async (method, params) => {
+      requests.push({ method, params });
+      if (failOn.has(method)) throw new Error(`${method} exploded`);
+      return responses[method] ?? {};
+    },
+  };
+  return { ctx, requests, sent, items };
+}
+
+function builtin(name) {
+  return {
+    name,
+    description: `built-in ${name}`,
+    kind: CommandKind.BUILT_IN,
+    action: () => {},
+  };
+}
+
+// ------------------------------------------------------------ registration
+
+{
+  // A user command becomes runnable, and the built-ins survive the merge.
+  const service = new CommandService();
+  service.register([builtin("model"), builtin("help")]);
+  const { ctx, requests } = makeMockContext({
+    responses: { "commands.list": { commands: [definition()] } },
+  });
+
+  await service.refreshUserCommands(ctx);
+
+  const resolved = service.resolve("review");
+  assert.ok(resolved, "user command should be registered");
+  assert.equal(resolved.kind, CommandKind.USER);
+  assert.equal(resolved.usage, "/review <path>");
+  assert.match(resolved.description, /\(project\)/, "scope should be visible");
+  assert.ok(service.resolve("model"), "built-ins must survive the rebuild");
+
+  // The server cannot know the built-ins; it can only refuse a name we declare.
+  const listCall = requests.find((r) => r.method === "commands.list");
+  assert.ok(listCall.params.builtin_names.includes("model"));
+  assert.ok(listCall.params.builtin_names.includes("help"));
+}
+
+{
+  // A user file cannot take over a built-in, even if the server let it through.
+  const service = new CommandService();
+  service.register([builtin("model")]);
+  const { ctx } = makeMockContext({
+    responses: {
+      "commands.list": { commands: [definition({ name: "model" })] },
+    },
+  });
+
+  await service.refreshUserCommands(ctx);
+
+  assert.equal(service.resolve("model").kind, CommandKind.BUILT_IN);
+  const inactive = service.getInactiveUserCommands();
+  assert.equal(inactive.length, 1);
+  assert.match(inactive[0].reason, /reserved/);
+}
+
+{
+  // Wire names are normalized to lowercase for collision guards.
+  const { commands, inactive } = buildUserCommands(
+    [definition({ name: "Review" })],
+    new Set(["model"]),
+    () => {},
+  );
+  assert.equal(commands.length, 1);
+  assert.equal(commands[0].name, "review");
+  assert.equal(inactive.length, 0);
+
+  const reserved = buildUserCommands(
+    [definition({ name: "Model" })],
+    new Set(["model"]),
+    () => {},
+  );
+  assert.equal(reserved.commands.length, 0);
+  assert.equal(reserved.inactive.length, 1);
+  assert.match(reserved.inactive[0].reason, /reserved/);
+
+  const dup = buildUserCommands(
+    [
+      definition({ name: "Review", source: "project" }),
+      definition({ name: "review", source: "user", shadowed_by: null }),
+    ],
+    new Set(),
+    () => {},
+  );
+  assert.equal(dup.commands.length, 1);
+  assert.equal(dup.inactive.length, 1);
+  assert.match(dup.inactive[0].reason, /duplicate/);
+}
+
+{
+  // A shadowed definition is reported, not silently absent.
+  const service = new CommandService();
+  service.register([]);
+  const { ctx } = makeMockContext({
+    responses: {
+      "commands.list": {
+        commands: [
+          definition({ source: "user", shadowed_by: "project" }),
+          definition({ source: "project" }),
+        ],
+      },
+    },
+  });
+
+  await service.refreshUserCommands(ctx);
+
+  assert.ok(service.resolve("review"));
+  const inactive = service.getInactiveUserCommands();
+  assert.equal(inactive.length, 1);
+  assert.match(inactive[0].reason, /shadowed by the project/);
+}
+
+{
+  // A dropped connection must not make the user's commands disappear.
+  const service = new CommandService();
+  service.register([]);
+  const ok = makeMockContext({
+    responses: { "commands.list": { commands: [definition()] } },
+  });
+  await service.refreshUserCommands(ok.ctx);
+  assert.ok(service.resolve("review"));
+
+  const broken = makeMockContext({ failOn: new Set(["commands.list"]) });
+  await service.refreshUserCommands(broken.ctx);
+  assert.ok(service.resolve("review"), "previous set should be kept");
+}
+
+{
+  // An unresolved workspace must not wipe a previously loaded registry.
+  const service = new CommandService();
+  service.register([]);
+  const loaded = makeMockContext({
+    responses: {
+      "commands.list": { commands: [definition()], workspace_resolved: true },
+    },
+  });
+  await service.refreshUserCommands(loaded.ctx);
+  assert.ok(service.resolve("review"));
+
+  const unresolved = makeMockContext({
+    responses: {
+      "commands.list": { commands: [], workspace_resolved: false },
+    },
+  });
+  await service.refreshUserCommands(unresolved.ctx);
+  assert.ok(service.resolve("review"), "cache kept when workspace unresolved");
+}
+
+{
+  // Refreshing replaces user commands without disturbing the built-ins.
+  const service = new CommandService();
+  service.register([builtin("model")]);
+  const first = makeMockContext({
+    responses: { "commands.list": { commands: [definition({ name: "old" })] } },
+  });
+  await service.refreshUserCommands(first.ctx);
+  assert.ok(service.resolve("old"));
+
+  const second = makeMockContext({
+    responses: { "commands.list": { commands: [definition({ name: "new" })] } },
+  });
+  await service.refreshUserCommands(second.ctx);
+  assert.equal(service.resolve("old"), undefined, "removed file should go away");
+  assert.ok(service.resolve("new"));
+  assert.ok(service.resolve("model"));
+}
+
+// ------------------------------------------------------------ execution
+
+{
+  // The first /name after creating a command file must work without a prior
+  // refreshUserCommands call — execute() re-reads the registry first.
+  const service = new CommandService();
+  service.register([]);
+  const { ctx, requests, sent } = makeMockContext({
+    responses: {
+      "commands.list": { commands: [definition()] },
+      "commands.expand": { text: "Review CODE", embedded: ["src/a.py"], errors: [] },
+    },
+  });
+
+  await service.execute("/review src/a.py", ctx);
+
+  const listCalls = requests.filter((r) => r.method === "commands.list");
+  assert.equal(listCalls.length, 1, "execute must refresh before lookup");
+  assert.ok(requests.some((r) => r.method === "commands.expand"));
+  assert.deepEqual(sent, ["Review CODE"]);
+}
+
+{
+  // Running a command expands it server-side and sends the result.
+  const service = new CommandService();
+  service.register([]);
+  const { ctx, requests, sent } = makeMockContext({
+    responses: {
+      "commands.list": { commands: [definition()] },
+      "commands.expand": { text: "Review CODE", embedded: ["src/a.py"], errors: [] },
+    },
+  });
+  await service.refreshUserCommands(ctx);
+
+  await service.execute("/review src/a.py", ctx);
+
+  const expandCall = requests.find((r) => r.method === "commands.expand");
+  assert.ok(expandCall, "execution must go through commands.expand");
+  assert.equal(expandCall.params.name, "review");
+  assert.equal(expandCall.params.args, "src/a.py");
+  assert.deepEqual(sent, ["Review CODE"]);
+}
+
+{
+  // An unreadable @file is reported, and the usable text still goes out.
+  const service = new CommandService();
+  service.register([]);
+  const { ctx, sent, items } = makeMockContext({
+    responses: {
+      "commands.list": { commands: [definition()] },
+      "commands.expand": {
+        text: "Review [could not read @gone.py: not found]",
+        embedded: [],
+        errors: ["gone.py: not found"],
+      },
+    },
+  });
+  await service.refreshUserCommands(ctx);
+
+  await service.execute("/review gone.py", ctx);
+
+  assert.equal(sent.length, 1, "a partial expansion is still worth sending");
+  assert.ok(items.some((i) => JSON.stringify(i).includes("gone.py")));
+}
+
+{
+  // A failed expansion sends nothing.
+  const service = new CommandService();
+  service.register([]);
+  const failing = makeMockContext({
+    responses: { "commands.list": { commands: [definition()] } },
+    failOn: new Set(["commands.expand"]),
+  });
+  await service.execute("/review x", failing.ctx);
+
+  assert.equal(failing.sent.length, 0, "nothing should reach the model");
+  assert.ok(failing.items.some((i) => JSON.stringify(i).includes("failed to expand")));
+}
+
+{
+  // An expansion that resolves to nothing sends nothing.
+  const service = new CommandService();
+  service.register([]);
+  const { ctx, sent, items } = makeMockContext({
+    responses: {
+      "commands.list": { commands: [definition()] },
+      "commands.expand": { text: "   ", errors: [] },
+    },
+  });
+  await service.refreshUserCommands(ctx);
+
+  await service.execute("/review", ctx);
+
+  assert.equal(sent.length, 0);
+  assert.ok(items.some((i) => JSON.stringify(i).includes("expanded to nothing")));
+}
+
+{
+  // Top-level built-ins should not trigger a commands.list round trip.
+  const service = new CommandService();
+  const help = createHelpCommand(
+    () => service.getAll(true),
+    () => service.getInactiveUserCommands(),
+  );
+  service.register([help]);
+  const { ctx, requests } = makeMockContext({});
+  await service.execute("/help", ctx);
+  assert.equal(
+    requests.filter((r) => r.method === "commands.list").length,
+    0,
+    "built-ins must not refresh user commands",
+  );
+}
+
+// ------------------------------------------------------------ /help
+
+{
+  // /help must describe the live registry, or a command is runnable and
+  // undiscoverable at the same time.
+  const service = new CommandService();
+  const help = createHelpCommand(
+    () => service.getAll(true),
+    () => service.getInactiveUserCommands(),
+  );
+  service.register([help, builtin("model")]);
+  const { ctx, items } = makeMockContext({
+    responses: {
+      "commands.list": {
+        commands: [definition(), definition({ name: "model" })],
+      },
+    },
+  });
+  await service.refreshUserCommands(ctx);
+
+  await service.execute("/help", ctx);
+
+  const rendered = items.find((i) => JSON.stringify(i).includes("Slash Commands"));
+  assert.ok(rendered, "help should render");
+  const flat = JSON.stringify(rendered);
+  assert.ok(flat.includes("User-defined"), "user commands need their own group");
+  assert.ok(flat.includes("/review"), "the user command should be listed");
+  assert.ok(flat.includes("not loaded"), "a file that does nothing must say why");
+  assert.ok(flat.includes("reserved"), "the reason should be shown");
+}
+
+console.log("user-commands.test.mjs: ok");

--- a/jiuwenswarm/common/command_expansion.py
+++ b/jiuwenswarm/common/command_expansion.py
@@ -1,0 +1,190 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Expand a user-defined slash command body into the prompt that gets sent.
+
+Two substitutions, in one pass each:
+
+- ``$ARGUMENTS`` — everything the user typed after the command name.
+- ``$1`` .. ``$9`` — positional arguments, shell-style quoting.
+- ``@path`` — embed a workspace file's contents.
+
+The file resolver is injected rather than reached for directly, so the
+substitution rules can be tested without a filesystem and so the caller keeps
+ownership of what "inside the workspace" means. This module never opens a file
+itself.
+"""
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+# ``$1``..``$9``. Deliberately not ``$0`` -- the command name is not an argument.
+#
+# The two lookaheads earn their place. ``(?!\d)`` stops ``$10`` becoming ``$1``
+# followed by a literal ``0``. ``(?!\.\d)`` keeps ``$5.00`` as money: a prompt
+# body is prose far more often than it is shell, and silently turning a price
+# into ``.00`` is a corruption the author would never think to look for.
+# ``use $1.`` at the end of a sentence still substitutes, because the ``.`` is
+# not followed by a digit.
+_POSITIONAL = re.compile(r"\$([1-9])(?!\d)(?!\.\d)")
+_ARGUMENTS = "$ARGUMENTS"
+
+# ``@`` followed by a path, taken greedily to whitespace, or a ``"quoted
+# path"`` when the reference needs to contain a space -- ``@$1`` substituting
+# an argument like ``src/a b.py`` (see ``substitute_arguments``) would
+# otherwise only see ``src/a``, exactly like an unquoted shell word. The
+# earlier unquoted-only version stopped at the first ``.``, which turned
+# ``@src/a.py`` into ``src/a``; trailing prose punctuation is stripped
+# afterwards instead, where the distinction between ``a.py`` and ``a.py,`` can
+# actually be made. ``(?<![\w@])`` keeps ``me@example.com`` from looking like
+# a reference.
+_FILE_REF = re.compile(r'(?<![\w@])@(?:"([^"]*)"|([^\s]+))')
+
+# Punctuation that ends a sentence rather than a filename.
+_TRAILING_PUNCTUATION = ",.;:)]}!?'\""
+
+# One embedded file cannot dominate the prompt.
+MAX_EMBED_CHARS = 20_000
+# Cap how many @file references one expansion will read.
+MAX_EMBED_COUNT = 20
+
+#: Resolver contract: given the raw reference, return the file text, or raise.
+FileResolver = Callable[[str], str]
+
+
+@dataclass
+class ExpansionResult:
+    text: str
+    #: Files successfully embedded, in the order encountered.
+    embedded: list[str] = field(default_factory=list)
+    #: Human-readable problems. Non-empty does **not** mean expansion failed:
+    #: the text is still usable, with the failures marked inline.
+    errors: list[str] = field(default_factory=list)
+
+
+def split_arguments(raw: str) -> list[str]:
+    """Split the argument string shell-style, falling back to whitespace.
+
+    ``shlex`` gives the quoting users expect -- ``/review "src/a b.py"`` is one
+    argument -- but it raises on an unbalanced quote, which is a typo, not a
+    reason to refuse the command.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return []
+    try:
+        return shlex.split(raw)
+    except ValueError:
+        return raw.split()
+
+
+def substitute_arguments(body: str, raw_args: str) -> str:
+    """Replace ``$ARGUMENTS`` and ``$1``..``$9``.
+
+    A positional with no corresponding argument becomes the empty string, the
+    same as an unset shell variable. Substituting the literal ``$3`` instead
+    would put a stray token in the prompt the model then tries to interpret.
+    """
+    positionals = split_arguments(raw_args)
+
+    def _positional(match: re.Match[str]) -> str:
+        index = int(match.group(1)) - 1
+        value = positionals[index] if index < len(positionals) else ""
+        # Quote the value when it lands right after ``@`` and contains
+        # whitespace, so ``_FILE_REF`` -- which runs after this substitution
+        # -- treats it as one path instead of stopping at the first space.
+        # Elsewhere in the body a positional is substituted verbatim.
+        preceded_by_at = match.start() > 0 and match.string[match.start() - 1] == "@"
+        if preceded_by_at and any(ch.isspace() for ch in value):
+            return f'"{value}"'
+        return value
+
+    # $ARGUMENTS first: a body using both should see the whole string there and
+    # the split pieces in the positionals, not the positionals substituted into
+    # a string that then gets re-scanned.
+    text = body.replace(_ARGUMENTS, (raw_args or "").strip())
+    return _POSITIONAL.sub(_positional, text)
+
+
+def expand_file_refs(
+    body: str,
+    resolver: Optional[FileResolver],
+    *,
+    max_chars: int = MAX_EMBED_CHARS,
+    max_embeds: int = MAX_EMBED_COUNT,
+) -> ExpansionResult:
+    """Replace ``@path`` with the file's contents.
+
+    A reference that cannot be read is replaced by a visible marker rather than
+    by nothing. An empty section would make the model answer about a file it
+    never saw, which is worse than an obvious error in the prompt.
+    """
+    result = ExpansionResult(text=body)
+    if resolver is None:
+        return result
+
+    def _embed(match: re.Match[str]) -> str:
+        quoted = match.group(1)
+        if quoted is not None:
+            # The quotes are the boundary; there is no trailing prose
+            # punctuation to split off because it was never inside them.
+            ref = quoted
+            suffix = ""
+        else:
+            raw = match.group(2)
+            # Split the path from any prose punctuation that trailed it, and
+            # put that punctuation back after the embedded block so the
+            # sentence still reads correctly.
+            ref = raw.rstrip(_TRAILING_PUNCTUATION)
+            suffix = raw[len(ref):]
+        if not ref:
+            return match.group(0)
+
+        if len(result.embedded) >= max_embeds:
+            result.errors.append(f"{ref}: embed limit reached ({max_embeds})")
+            return f"[could not read @{ref}: embed limit reached]{suffix}"
+
+        try:
+            content = resolver(ref)
+        except Exception as exc:  # noqa: BLE001 - surfaced inline, see docstring
+            result.errors.append(f"{ref}: {exc}")
+            return f"[could not read @{ref}: {exc}]{suffix}"
+        if content is None:
+            result.errors.append(f"{ref}: not found")
+            return f"[could not read @{ref}: not found]{suffix}"
+        truncated = ""
+        if len(content) > max_chars:
+            content = content[:max_chars]
+            truncated = f"\n[… truncated at {max_chars} characters]"
+        result.embedded.append(ref)
+        return f"\n--- {ref} ---\n{content}{truncated}\n--- end {ref} ---\n{suffix}"
+
+    result.text = _FILE_REF.sub(_embed, body)
+    return result
+
+
+def expand_command(
+    body: str,
+    raw_args: str,
+    resolver: Optional[FileResolver] = None,
+    *,
+    max_chars: int = MAX_EMBED_CHARS,
+    max_embeds: int = MAX_EMBED_COUNT,
+) -> ExpansionResult:
+    """Full expansion: arguments first, then file references.
+
+    Order matters and is load-bearing. Arguments are substituted **before**
+    file references so that ``@$1`` works -- a command that takes a path and
+    embeds it. Doing it the other way round would look for a file literally
+    named ``$1``.
+
+    It also means a user-supplied argument can name a file to embed, which is
+    exactly the intended power and exactly why the resolver, not this module,
+    must enforce the workspace boundary.
+    """
+    with_args = substitute_arguments(body, raw_args)
+    return expand_file_refs(
+        with_args, resolver, max_chars=max_chars, max_embeds=max_embeds,
+    )

--- a/jiuwenswarm/common/schema/message.py
+++ b/jiuwenswarm/common/schema/message.py
@@ -77,6 +77,14 @@ class ReqMethod(Enum):
     TTS_SYNTHESIZE = "tts.synthesize"
 
     AGENTS_LIST = "agents.list"
+    # User-defined slash commands, discovered from Markdown files in the same
+    # three scopes as agents. Loaded server-side because expanding @file and
+    # bounding it to the workspace are the server's job, not a client's.
+    COMMANDS_LIST = "commands.list"
+    # Expand one command body into the prompt to send. Separate from the send
+    # itself so the client can show the user what a command actually resolved
+    # to -- including which files it embedded and which it could not read.
+    COMMANDS_EXPAND = "commands.expand"
     AGENTS_GET = "agents.get"
     AGENTS_CREATE = "agents.create"
     AGENTS_UPDATE = "agents.update"

--- a/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
@@ -319,6 +319,9 @@ CLI_FORWARD_REQ_METHODS = frozenset(
         "agents.enable",
         "agents.disable",
         "agents.tools_list",
+        # User-defined slash commands
+        "commands.list",
+        "commands.expand",
         # Schedule task management
         "schedule.check_config",
         "schedule.update_config",
@@ -418,6 +421,9 @@ CLI_FORWARD_NO_LOCAL_HANDLER_METHODS = frozenset(
         "agents.enable",
         "agents.disable",
         "agents.tools_list",
+        # User-defined slash commands
+        "commands.list",
+        "commands.expand",
         # Schedule task management
         "schedule.check_config",
         "schedule.update_config",

--- a/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
+++ b/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
@@ -644,6 +644,9 @@ _FORWARD_REQ_METHODS = frozenset({
     "agents.enable",
     "agents.disable",
     "agents.tools_list",
+    # User-defined slash commands
+    "commands.list",
+    "commands.expand",
     # Schedule task management
     "schedule.check_config",
     "schedule.update_config",
@@ -734,6 +737,9 @@ _FORWARD_NO_LOCAL_HANDLER_METHODS = frozenset({
     "agents.enable",
     "agents.disable",
     "agents.tools_list",
+    # User-defined slash commands
+    "commands.list",
+    "commands.expand",
 })
 
 # 配置信息：config.get 返回、config.set 可修改的键（前端 param 名 -> 环境变量名）

--- a/jiuwenswarm/server/agent_ws_server.py
+++ b/jiuwenswarm/server/agent_ws_server.py
@@ -492,6 +492,87 @@ def resolve_request_project_dir(request: AgentRequest) -> str | None:
     return None
 
 
+def resolve_command_workspace_dir(request: AgentRequest) -> str | None:
+    """Resolve the root that bounds ``@file`` embedding for slash commands.
+
+    The session's locked ``project_dir`` wins over anything in the request.
+    ``commands.expand`` returns file **contents**, so its root must not be a
+    per-request claim by the caller: a client free to name the root could name
+    ``/`` and read whatever the server can. The session already locks a
+    project identity on its first chat turn; reusing it means the boundary is
+    the one the user was working in, not the one this frame asked for.
+
+    ``resolve_request_project_dir`` remains the fallback, for a session that
+    has not locked a value yet -- refusing to list commands before the first
+    message would be a worse trade than trusting the same value agent
+    construction already trusts at that point.
+    """
+    session_id = (request.session_id or "").strip()
+    if session_id:
+        try:
+            from jiuwenswarm.server.runtime.session.session_metadata import (
+                get_session_metadata,
+            )
+
+            # enable_writeback=False: this is a read path. Inferring the value
+            # is welcome; persisting it as a side effect of listing commands
+            # is not.
+            metadata = get_session_metadata(session_id, enable_writeback=False)
+            locked = metadata.get("project_dir") if isinstance(metadata, dict) else None
+            if isinstance(locked, str) and locked.strip():
+                return locked.strip()
+        except (OSError, ValueError) as exc:
+            logger.warning(
+                "[AgentWebSocketServer] failed to read locked project_dir for %s: %s",
+                session_id, exc,
+            )
+    return resolve_request_project_dir(request)
+
+
+def resolve_locked_command_workspace_dir(request: AgentRequest) -> str | None:
+    """Return the session-locked ``project_dir`` only — no request fallback.
+
+    ``commands.expand`` returns file contents, so it must not trust a
+    per-request root the client names before the session has locked one.
+    """
+    session_id = (request.session_id or "").strip()
+    if not session_id:
+        return None
+    try:
+        from jiuwenswarm.server.runtime.session.session_metadata import (
+            get_session_metadata,
+        )
+
+        metadata = get_session_metadata(session_id, enable_writeback=False)
+        locked = metadata.get("project_dir") if isinstance(metadata, dict) else None
+        if isinstance(locked, str) and locked.strip():
+            return locked.strip()
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "[AgentWebSocketServer] failed to read locked project_dir for %s: %s",
+            session_id, exc,
+        )
+    return None
+
+
+def _request_builtin_names(request: AgentRequest) -> set[str]:
+    """Command names the calling client says it already owns.
+
+    Built-ins live in the client, so the server cannot enumerate them. A client
+    that sends nothing still gets ``RESERVED_NAMES`` enforced underneath.
+    """
+    from jiuwenswarm.server.runtime.command_config_service import RESERVED_NAMES
+
+    params = request.params or {}
+    raw = params.get("builtin_names")
+    declared: set[str] = set()
+    if isinstance(raw, (list, tuple)):
+        declared = {
+            n.strip().lower() for n in raw if isinstance(n, str) and n.strip()
+        }
+    return declared | set(RESERVED_NAMES)
+
+
 def _sync_chat_request_metadata(
     request: AgentRequest,
     project_dir: str | None,
@@ -1672,6 +1753,12 @@ class AgentWebSocketServer:
                 return
             if request.req_method == ReqMethod.AGENTS_LIST:
                 await self._handle_agents_list(ws, request, send_lock)
+                return
+            if request.req_method == ReqMethod.COMMANDS_LIST:
+                await self._handle_commands_list(ws, request, send_lock)
+                return
+            if request.req_method == ReqMethod.COMMANDS_EXPAND:
+                await self._handle_commands_expand(ws, request, send_lock)
                 return
             if request.req_method == ReqMethod.AGENTS_GET:
                 await self._handle_agents_get(ws, request, send_lock)
@@ -6928,6 +7015,123 @@ class AgentWebSocketServer:
             )
         except Exception as e:
             logger.exception("[AgentWebSocketServer] agents.list failed: %s", e)
+            resp = AgentResponse(
+                request_id=request.request_id,
+                channel_id=request.channel_id,
+                ok=False,
+                payload={"error": str(e)},
+            )
+
+        wire = encode_agent_response_for_wire(resp, response_id=request.request_id)
+        async with send_lock:
+            await send_wire_payload(ws, wire)
+
+    async def _handle_commands_list(
+        self, ws: Any, request: AgentRequest, send_lock: asyncio.Lock,
+    ) -> None:
+        """User-defined slash commands, mirroring ``agents.list``.
+
+        Returns every discovered command, including the shadowed and reserved
+        ones, so the client can explain why a file the user wrote does nothing
+        instead of leaving it silently absent.
+        """
+        from jiuwenswarm.server.runtime.command_config_service import (
+            CommandConfigService,
+            command_for_wire,
+        )
+
+        try:
+            workspace = resolve_command_workspace_dir(request)
+            if not workspace:
+                commands = []
+                workspace_resolved = False
+            else:
+                service = CommandConfigService(
+                    workspace,
+                    builtin_names=_request_builtin_names(request),
+                )
+                commands = [command_for_wire(c) for c in service.list_commands()]
+                workspace_resolved = True
+            resp = AgentResponse(
+                request_id=request.request_id,
+                channel_id=request.channel_id,
+                ok=True,
+                payload={
+                    "commands": commands,
+                    "workspace_resolved": workspace_resolved,
+                },
+            )
+        except Exception as e:
+            logger.exception("[AgentWebSocketServer] commands.list failed: %s", e)
+            resp = AgentResponse(
+                request_id=request.request_id,
+                channel_id=request.channel_id,
+                ok=False,
+                payload={"error": str(e)},
+            )
+
+        wire = encode_agent_response_for_wire(resp, response_id=request.request_id)
+        async with send_lock:
+            await send_wire_payload(ws, wire)
+
+    async def _handle_commands_expand(
+        self, ws: Any, request: AgentRequest, send_lock: asyncio.Lock,
+    ) -> None:
+        """Expand one user-defined command into the prompt to send.
+
+        Deliberately separate from ``chat.send``. The client asks what the
+        command resolved to, then sends that text as an ordinary message, so a
+        command whose ``@file`` could not be read reports the failure instead of
+        sending a prompt with a hole in it -- and the send path keeps one
+        meaning rather than growing a second, command-shaped one.
+
+        Only **active** commands expand. A shadowed or reserved definition is
+        listed so the UI can explain it, never run.
+        """
+        from jiuwenswarm.common.command_expansion import expand_command
+        from jiuwenswarm.server.runtime.command_config_service import CommandConfigService
+
+        try:
+            params = request.params or {}
+            name = str(params.get("name") or "").strip().lower()
+            raw_args = str(params.get("args") or "")
+            if not name:
+                raise ValueError("command name is required")
+
+            workspace = resolve_locked_command_workspace_dir(request)
+            if not workspace:
+                raise ValueError(
+                    "session workspace not locked; cannot expand command with @file references"
+                )
+
+            service = CommandConfigService(
+                workspace,
+                builtin_names=_request_builtin_names(request),
+            )
+            command = next(
+                (c for c in service.active_commands() if c.name == name), None
+            )
+            if command is None:
+                raise ValueError(f"unknown or inactive command: /{name}")
+
+            expansion = expand_command(command.body, raw_args, service.file_resolver())
+            resp = AgentResponse(
+                request_id=request.request_id,
+                channel_id=request.channel_id,
+                ok=True,
+                payload={
+                    "name": command.name,
+                    "text": expansion.text,
+                    "embedded": expansion.embedded,
+                    # Non-empty errors do not mean failure: the text is usable,
+                    # with each unreadable reference marked inline.
+                    "errors": expansion.errors,
+                    "source": command.source,
+                    "file_path": command.file_path,
+                },
+            )
+        except Exception as e:
+            logger.exception("[AgentWebSocketServer] commands.expand failed: %s", e)
             resp = AgentResponse(
                 request_id=request.request_id,
                 channel_id=request.channel_id,

--- a/jiuwenswarm/server/runtime/command_config_service.py
+++ b/jiuwenswarm/server/runtime/command_config_service.py
@@ -1,0 +1,358 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""User-defined slash commands loaded from Markdown files.
+
+Sources, highest precedence first -- the same three scopes and the same order
+as :mod:`agent_config_service`, deliberately: two different precedence rules for
+two kinds of ``.md`` file in the same tree is how confident wrong answers get
+made.
+
+- project: ``<workspace>/.jiuwenswarm/commands/*.md``
+- user:    ``~/.jiuwenswarm/commands/*.md``
+- local:   ``<workspace>/.jiuwenswarm/commands-local/*.md``
+
+Built-in commands live in the TUI and are **not** loaded here. They always win a
+name collision; see ``list_commands`` for why the loser is reported rather than
+dropped.
+
+File format is YAML frontmatter + Markdown body, where the body is the prompt.
+The command's name is its **filename**, not a frontmatter field: a file called
+``review.md`` is ``/review``. Frontmatter carries only what the UI needs to
+describe and gate the command.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+import yaml
+
+from jiuwenswarm.common.utils import get_user_workspace_dir
+
+logger = logging.getLogger(__name__)
+
+CommandSource = Literal["user", "project", "local"]
+
+# Built-ins a user file must never take over, enforced even when the client
+# declares nothing. Shadowing /help would make the system undiscoverable;
+# shadowing /compact or /rewind would risk a conversation. The list is
+# intentionally short: only commands whose loss is not recoverable by typing
+# something else.
+#
+# It is a floor, not the built-in list. The real built-ins live in the client
+# -- the TUI has ~97 of them and the Web has its own set -- so the server
+# cannot enumerate them. Clients pass their own names via ``builtin_names``;
+# see :class:`CommandConfigService`.
+RESERVED_NAMES = frozenset({
+    "help", "compact", "rewind", "clear", "exit", "quit", "config", "statusline",
+})
+
+_MAX_BODY_CHARS = 100_000
+
+# Gate applied to the file on disk, before anything is read into memory. A
+# command body is capped at `_MAX_BODY_CHARS` *after* parsing, which still
+# means reading the whole file first; a symlink to something like `/dev/zero`
+# would hang the eager `commands.list` scan long before that cap applies.
+_MAX_COMMAND_FILE_BYTES = 1_000_000
+
+
+@dataclass
+class CommandDefinition:
+    """One user-defined slash command."""
+
+    name: str
+    description: str
+    body: str
+    source: CommandSource
+    file_path: str
+    argument_hint: str = ""
+    # Parsed and reported, **not enforced**. Restricting tools for the duration
+    # of one command needs a per-turn tool scope that does not exist yet -- the
+    # only filtering today (``_filter_tool_cards``) is scoped to an agent
+    # definition. Surfaced so a client can show it; treating it as a guarantee
+    # would be a false one.
+    allowed_tools: list[str] | None = None
+    # Set when a higher-precedence source defines the same name.
+    shadowed_by: CommandSource | None = None
+    # Set when the name collides with a built-in, which always wins.
+    reserved: bool = False
+
+
+_POSITIONAL_HINT = re.compile(r"\$[1-9](?!\d)(?!\.\d)")
+
+
+def command_accepts_args(command: CommandDefinition) -> bool:
+    """Whether the UI should treat this command as taking arguments."""
+    if command.argument_hint:
+        return True
+    if "$ARGUMENTS" in command.body:
+        return True
+    return bool(_POSITIONAL_HINT.search(command.body))
+
+
+def command_for_wire(command: CommandDefinition) -> dict:
+    """Serialize for ``commands.list`` without shipping the full prompt body."""
+    data = asdict(command)
+    data["accepts_args"] = command_accepts_args(command)
+    data.pop("body", None)
+    return data
+
+
+def _first(frontmatter: dict, *keys: str, default=None):
+    """Read the first present key.
+
+    Frontmatter is hand-written, so accept both ``argument-hint`` and
+    ``argument_hint``. Rejecting a file over a hyphen would be a bad trade.
+    """
+    for key in keys:
+        if key in frontmatter and frontmatter[key] is not None:
+            return frontmatter[key]
+    return default
+
+
+def _coerce_tools(value) -> list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [t.strip() for t in value.split(",") if t.strip()]
+    if isinstance(value, (list, tuple)):
+        return [str(t).strip() for t in value if str(t).strip()]
+    return None
+
+
+def _is_invocable_name(name: str) -> bool:
+    """Whether the slash parser can ever match this name.
+
+    ``parseSlashCommand`` (the TUI) splits raw input on whitespace before
+    comparing it to a command's name, so a stem like ``foo bar`` would be
+    listed as ``/foo bar`` and then never match anything a user can actually
+    type. Treated the same as a reserved name: still returned, never active.
+    """
+    return bool(name) and not any(ch.isspace() for ch in name)
+
+
+def parse_command_file(file_path: Path, source: CommandSource) -> CommandDefinition | None:
+    """Parse one file, or return None when it is not a command definition.
+
+    Returning None rather than raising keeps one malformed file from hiding
+    every other command in the directory -- the failure mode that matters most
+    for user-authored content.
+    """
+    content = file_path.read_text(encoding="utf-8")
+
+    frontmatter: dict = {}
+    body = content
+    if content.startswith("---"):
+        parts = content.split("---", 2)
+        if len(parts) >= 3:
+            loaded = yaml.safe_load(parts[1])
+            if isinstance(loaded, dict):
+                frontmatter = loaded
+            body = parts[2]
+
+    body = body.strip()
+    if not body:
+        # A command with no prompt has nothing to send.
+        return None
+    if len(body) > _MAX_BODY_CHARS:
+        logger.warning(
+            "Command file %s body is %d chars, truncating to %d",
+            file_path, len(body), _MAX_BODY_CHARS,
+        )
+        body = body[:_MAX_BODY_CHARS]
+
+    name = file_path.stem.strip().lower()
+    if not name:
+        return None
+
+    return CommandDefinition(
+        name=name,
+        description=str(_first(frontmatter, "description", default="") or "").strip(),
+        body=body,
+        source=source,
+        file_path=str(file_path),
+        argument_hint=str(
+            _first(frontmatter, "argument-hint", "argument_hint", default="") or ""
+        ).strip(),
+        allowed_tools=_coerce_tools(_first(frontmatter, "allowed-tools", "allowed_tools")),
+        reserved=name in RESERVED_NAMES or not _is_invocable_name(name),
+    )
+
+
+class CommandConfigService:
+    """Discovers user-defined commands across the three scopes.
+
+    ``builtin_names`` is the set of command names the calling client already
+    owns. The server cannot know them -- built-ins are defined in the TUI and
+    in the Web UI, not here -- so the client declares them and the server
+    enforces the result for both listing and expansion. Without it, a file
+    named ``model.md`` would be reported active and would be expandable, while
+    the TUI quietly never ran it: two answers to one question.
+    """
+
+    def __init__(
+        self,
+        workspace_dir: Path | str | None = None,
+        builtin_names: set[str] | frozenset[str] | None = None,
+    ):
+        self._workspace_dir = Path(workspace_dir) if workspace_dir else Path.cwd()
+        self._builtin_names = frozenset(
+            n.strip().lower() for n in (builtin_names or ()) if n and n.strip()
+        )
+
+    @staticmethod
+    def _user_dir() -> Path:
+        return get_user_workspace_dir() / "commands"
+
+    def _project_dir(self) -> Path:
+        return self._workspace_dir / ".jiuwenswarm" / "commands"
+
+    def _local_dir(self) -> Path:
+        return self._workspace_dir / ".jiuwenswarm" / "commands-local"
+
+    @staticmethod
+    def _load_from_dir(dir_path: Path, source: CommandSource) -> list[CommandDefinition]:
+        if not dir_path.exists():
+            return []
+        root = dir_path.resolve()
+        found: list[CommandDefinition] = []
+        for md_file in sorted(dir_path.glob("*.md")):
+            try:
+                _confine_command_file(md_file, root)
+            except ValueError as exc:
+                logger.warning("Skipping command file %s: %s", md_file, exc)
+                continue
+            try:
+                command = parse_command_file(md_file, source)
+                if command is not None:
+                    found.append(command)
+            except Exception:
+                logger.warning("Failed to parse command file: %s", md_file, exc_info=True)
+        return found
+
+    def list_commands(self) -> list[CommandDefinition]:
+        """All discovered commands, with losers marked rather than dropped.
+
+        A shadowed or reserved command is still returned, flagged. Silently
+        losing a file the user wrote is how "my command does nothing" becomes an
+        unanswerable support question; the UI can show why instead.
+        """
+        # Load order sets precedence: later wins, so project > user > local.
+        ordered: list[tuple[list[CommandDefinition], CommandSource]] = [
+            (self._load_from_dir(self._local_dir(), "local"), "local"),
+            (self._load_from_dir(self._user_dir(), "user"), "user"),
+            (self._load_from_dir(self._project_dir(), "project"), "project"),
+        ]
+
+        grouped: dict[str, list[CommandDefinition]] = {}
+        for commands, _ in ordered:
+            for command in commands:
+                grouped.setdefault(command.name, []).append(command)
+
+        result: list[CommandDefinition] = []
+        for name, group in sorted(grouped.items()):
+            # A client-declared built-in reserves the name for every definition
+            # of it, winner and losers alike: the reason none of them run is
+            # the built-in, not the shadowing.
+            if name in self._builtin_names:
+                for command in group:
+                    command.reserved = True
+            winner = group[-1]
+            for loser in group[:-1]:
+                loser.shadowed_by = winner.source
+                result.append(loser)
+            result.append(winner)
+        return result
+
+    def active_commands(self) -> list[CommandDefinition]:
+        """Only the commands that will actually run."""
+        return [
+            c for c in self.list_commands()
+            if c.shadowed_by is None and not c.reserved
+        ]
+
+    # ---- @file resolution --------------------------------------------------
+
+    def file_resolver(self):
+        """Resolver for ``@path`` embedding, bounded to the workspace.
+
+        The boundary is enforced here rather than in the expansion module
+        because a ``@path`` can come from a user-supplied argument -- a command
+        body containing ``@$1`` embeds whatever file the caller names. That is
+        the intended power, and it is exactly why the check must be real:
+        ``../../.ssh/id_rsa`` has to fail.
+
+        Resolution walks path components without following symlinks. Hardlinks
+        to files outside the workspace remain a known limitation on Unix.
+        """
+        root = _validate_workspace_root(self._workspace_dir)
+
+        def _resolve(ref: str) -> str:
+            return _read_file_under_root(root, ref)
+
+        return _resolve
+
+
+def _confine_command_file(md_file: Path, root: Path) -> None:
+    """Refuse a command file the same way ``_read_file_under_root`` refuses an
+    ``@file`` reference that escapes the workspace.
+
+    A project ``.md`` file's *contents* become a command's body, and
+    ``commands.expand`` returns that body to the client, so a symlink such as
+    ``.jiuwenswarm/commands/leak.md -> ~/.ssh/id_rsa`` must not be ingested any
+    more than an ``@file`` reference to it would be allowed to resolve. The
+    size gate runs before any read, and before ``parse_command_file`` opens
+    the file: a link to a device like ``/dev/zero`` must not be able to hang
+    the eager ``commands.list`` scan.
+    """
+    if md_file.is_symlink():
+        raise ValueError("symlinks are not allowed in the commands directory")
+    resolved = md_file.resolve()
+    if resolved != root and root not in resolved.parents:
+        raise ValueError("resolves outside the commands directory")
+    try:
+        size = resolved.stat().st_size
+    except OSError as exc:
+        raise ValueError(f"cannot stat command file: {exc}") from exc
+    if size > _MAX_COMMAND_FILE_BYTES:
+        raise ValueError(f"command file too large ({size} bytes)")
+
+
+def _validate_workspace_root(workspace_dir: Path | str) -> Path:
+    """Reject roots that cannot meaningfully bound ``@file`` reads."""
+    root = Path(workspace_dir).resolve()
+    if root == Path(root.anchor):
+        raise ValueError("invalid workspace root")
+    if not root.is_dir():
+        raise ValueError("invalid workspace root")
+    return root
+
+
+def _read_file_under_root(root: Path, ref: str) -> str:
+    """Read one file under ``root``, rejecting escapes and symlink hops."""
+    ref_path = Path(ref)
+    if ref_path.is_absolute() or ".." in ref_path.parts:
+        raise ValueError("outside the workspace")
+
+    current = root
+    for part in ref_path.parts:
+        if part in (".", ""):
+            continue
+        next_path = current / part
+        if next_path.is_symlink():
+            raise ValueError("symlinks not allowed")
+        if not next_path.exists():
+            raise ValueError("not found")
+        current = next_path
+
+    if not current.is_file():
+        raise ValueError("not found")
+
+    resolved = current.resolve()
+    if resolved != root and root not in resolved.parents:
+        raise ValueError("outside the workspace")
+    return resolved.read_text(encoding="utf-8", errors="replace")

--- a/tests/unit_tests/agentserver/test_command_config_service.py
+++ b/tests/unit_tests/agentserver/test_command_config_service.py
@@ -1,0 +1,310 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Discovery of user-defined slash commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jiuwenswarm.server.runtime.command_config_service import (
+    CommandConfigService,
+    command_accepts_args,
+    command_for_wire,
+    parse_command_file,
+)
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A workspace with an isolated user dir, so the test never reads ~/."""
+    user_home = tmp_path / "userhome"
+    (user_home / "commands").mkdir(parents=True)
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.command_config_service.get_user_workspace_dir",
+        lambda: user_home,
+    )
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir()
+    return ws_dir
+
+
+# ---------------------------------------------------------------- parsing
+
+
+def test_the_filename_is_the_command_name(tmp_path: Path) -> None:
+    f = _write(tmp_path / "Review.md", "---\ndescription: x\n---\nBody here")
+    command = parse_command_file(f, "project")
+    assert command is not None
+    assert command.name == "review"  # lower-cased, no frontmatter needed
+
+
+def test_frontmatter_accepts_hyphen_and_underscore(tmp_path: Path) -> None:
+    """Frontmatter is hand-written; refusing a file over a hyphen is a bad trade."""
+    hyphen = parse_command_file(
+        _write(tmp_path / "a.md", "---\nargument-hint: <path>\nallowed-tools: Read, Grep\n---\nB"),
+        "project",
+    )
+    underscore = parse_command_file(
+        _write(tmp_path / "b.md", "---\nargument_hint: <path>\nallowed_tools: [Read, Grep]\n---\nB"),
+        "project",
+    )
+    assert hyphen is not None and underscore is not None
+    assert hyphen.argument_hint == underscore.argument_hint == "<path>"
+    assert hyphen.allowed_tools == underscore.allowed_tools == ["Read", "Grep"]
+
+
+def test_a_file_without_frontmatter_is_still_a_command(tmp_path: Path) -> None:
+    command = parse_command_file(_write(tmp_path / "plain.md", "Just a prompt"), "user")
+    assert command is not None
+    assert command.body == "Just a prompt"
+    assert command.description == ""
+
+
+def test_an_empty_body_is_not_a_command(tmp_path: Path) -> None:
+    """Nothing to send."""
+    assert parse_command_file(_write(tmp_path / "empty.md", "---\ndescription: x\n---\n"), "user") is None
+
+
+def test_a_reserved_name_is_flagged(tmp_path: Path) -> None:
+    command = parse_command_file(_write(tmp_path / "help.md", "Body"), "project")
+    assert command is not None
+    assert command.reserved is True
+
+
+def test_a_name_with_whitespace_is_reserved_not_invocable(tmp_path: Path) -> None:
+    """``parseSlashCommand`` (TUI) splits raw input on whitespace, so
+    ``foo bar.md`` would list as ``/foo bar`` and then match nothing anyone
+    can type. It must still be returned (so the UI can explain it), just
+    flagged the same way a reserved name is."""
+    command = parse_command_file(_write(tmp_path / "foo bar.md", "Body"), "project")
+    assert command is not None
+    assert command.name == "foo bar"
+    assert command.reserved is True
+
+
+# ---------------------------------------------------------------- scopes
+
+
+def test_precedence_matches_the_agent_loader(workspace: Path, tmp_path: Path) -> None:
+    """project > user > local, the same order agents use."""
+    _write(workspace / ".jiuwenswarm" / "commands-local" / "dup.md", "LOCAL")
+    _write(tmp_path / "userhome" / "commands" / "dup.md", "USER")
+    _write(workspace / ".jiuwenswarm" / "commands" / "dup.md", "PROJECT")
+
+    active = CommandConfigService(workspace).active_commands()
+    assert [c.name for c in active] == ["dup"]
+    assert active[0].body == "PROJECT"
+    assert active[0].source == "project"
+
+
+def test_shadowed_commands_are_reported_not_dropped(workspace: Path, tmp_path: Path) -> None:
+    """Silently losing a file the user wrote is an unanswerable support question."""
+    _write(tmp_path / "userhome" / "commands" / "dup.md", "USER")
+    _write(workspace / ".jiuwenswarm" / "commands" / "dup.md", "PROJECT")
+
+    everything = CommandConfigService(workspace).list_commands()
+    shadowed = [c for c in everything if c.shadowed_by]
+    assert len(shadowed) == 1
+    assert shadowed[0].source == "user"
+    assert shadowed[0].shadowed_by == "project"
+
+
+def test_a_reserved_name_never_becomes_active(workspace: Path) -> None:
+    _write(workspace / ".jiuwenswarm" / "commands" / "help.md", "Body")
+    _write(workspace / ".jiuwenswarm" / "commands" / "mine.md", "Body")
+
+    service = CommandConfigService(workspace)
+    assert [c.name for c in service.active_commands()] == ["mine"]
+    # ...but it is still listed, so the UI can explain why it does nothing.
+    assert "help" in {c.name for c in service.list_commands()}
+
+
+# ------------------------------------------------- client-declared built-ins
+
+
+def test_a_client_builtin_reserves_the_name(workspace: Path) -> None:
+    """RESERVED_NAMES is a floor, not the built-in list.
+
+    ``/model`` is a TUI built-in and is not in RESERVED_NAMES, so without the
+    client declaring it the server would report ``model.md`` as active while
+    the TUI never ran it -- two answers to one question.
+    """
+    _write(workspace / ".jiuwenswarm" / "commands" / "model.md", "Body")
+    _write(workspace / ".jiuwenswarm" / "commands" / "mine.md", "Body")
+
+    undeclared = CommandConfigService(workspace)
+    assert "model" in {c.name for c in undeclared.active_commands()}
+
+    declared = CommandConfigService(workspace, builtin_names={"model", "skills"})
+    assert [c.name for c in declared.active_commands()] == ["mine"]
+    reserved = [c for c in declared.list_commands() if c.name == "model"]
+    assert reserved and reserved[0].reserved is True
+
+
+def test_a_client_builtin_reserves_every_definition_of_the_name(
+    workspace: Path, tmp_path: Path
+) -> None:
+    """The reason none of them run is the built-in, not the shadowing."""
+    _write(tmp_path / "userhome" / "commands" / "model.md", "USER")
+    _write(workspace / ".jiuwenswarm" / "commands" / "model.md", "PROJECT")
+
+    listed = CommandConfigService(workspace, builtin_names={"model"}).list_commands()
+    assert len(listed) == 2
+    assert all(c.reserved for c in listed)
+
+
+def test_declared_builtins_are_matched_case_insensitively(workspace: Path) -> None:
+    _write(workspace / ".jiuwenswarm" / "commands" / "model.md", "Body")
+    service = CommandConfigService(workspace, builtin_names={"  MODEL  ", ""})
+    assert service.active_commands() == []
+
+
+def test_one_malformed_file_does_not_hide_the_others(workspace: Path) -> None:
+    """The failure mode that matters most for user-authored content."""
+    _write(workspace / ".jiuwenswarm" / "commands" / "broken.md", "---\n[[[not yaml\n---\nB")
+    _write(workspace / ".jiuwenswarm" / "commands" / "good.md", "---\ndescription: ok\n---\nB")
+
+    names = {c.name for c in CommandConfigService(workspace).active_commands()}
+    assert "good" in names
+
+
+def test_no_directories_means_no_commands(workspace: Path) -> None:
+    assert CommandConfigService(workspace).active_commands() == []
+
+
+def test_a_name_with_whitespace_is_never_active(workspace: Path) -> None:
+    _write(workspace / ".jiuwenswarm" / "commands" / "foo bar.md", "Body")
+
+    service = CommandConfigService(workspace)
+    assert service.active_commands() == []
+    # ...but still listed, so the UI can explain why it does nothing.
+    assert "foo bar" in {c.name for c in service.list_commands()}
+
+
+# ---------------------------------------------------------------- @file bounds
+
+
+def test_the_resolver_reads_inside_the_workspace(workspace: Path) -> None:
+    _write(workspace / "src" / "a.py", "CODE")
+    assert CommandConfigService(workspace).file_resolver()("src/a.py") == "CODE"
+
+
+def test_the_resolver_refuses_to_escape_the_workspace(workspace: Path, tmp_path: Path) -> None:
+    """A @path can come from a user argument, so this check has to be real."""
+    _write(tmp_path / "secret.txt", "SECRET")
+    resolve = CommandConfigService(workspace).file_resolver()
+
+    with pytest.raises(ValueError, match="outside the workspace"):
+        resolve("../secret.txt")
+    with pytest.raises(ValueError, match="outside the workspace"):
+        resolve("/etc/passwd")
+
+
+def test_a_symlink_cannot_step_outside(workspace: Path, tmp_path: Path) -> None:
+    """Resolution happens on the real path, after symlinks."""
+    outside = _write(tmp_path / "outside.txt", "SECRET")
+    workspace.mkdir(parents=True, exist_ok=True)
+    link = workspace / "link.txt"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+
+    with pytest.raises(ValueError, match="symlinks not allowed"):
+        CommandConfigService(workspace).file_resolver()("link.txt")
+
+
+def test_a_missing_file_says_so(workspace: Path) -> None:
+    workspace.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError, match="not found"):
+        CommandConfigService(workspace).file_resolver()("nope.py")
+
+
+def test_command_for_wire_omits_body_and_sets_accepts_args(workspace: Path) -> None:
+    _write(
+        workspace / ".jiuwenswarm" / "commands" / "review.md",
+        "---\nargument-hint: <path>\n---\nReview @$1",
+    )
+    command = CommandConfigService(workspace).active_commands()[0]
+    wire = command_for_wire(command)
+    assert "body" not in wire
+    assert wire["accepts_args"] is True
+
+
+def test_command_accepts_args_from_body_without_hint(workspace: Path) -> None:
+    command = parse_command_file(
+        _write(workspace / "noop.md", "Use $ARGUMENTS here"),
+        "project",
+    )
+    assert command is not None
+    assert command_accepts_args(command) is True
+
+
+def test_the_resolver_rejects_the_filesystem_root() -> None:
+    with pytest.raises(ValueError, match="invalid workspace root"):
+        CommandConfigService("/").file_resolver()
+
+
+# ------------------------------------------------ command file confinement
+
+
+def test_a_symlinked_command_file_is_not_ingested(workspace: Path, tmp_path: Path) -> None:
+    """A project ``.md`` command file must not be able to leak an arbitrary
+    file's contents through ``commands.expand``, the same rule ``@file``
+    enforces via ``_read_file_under_root``."""
+    secret = _write(tmp_path / "secret.txt", "SECRET")
+    commands_dir = workspace / ".jiuwenswarm" / "commands"
+    commands_dir.mkdir(parents=True)
+    link = commands_dir / "leak.md"
+    try:
+        link.symlink_to(secret)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+
+    commands = CommandConfigService(workspace).list_commands()
+    assert "leak" not in {c.name for c in commands}
+    assert all("SECRET" not in c.body for c in commands)
+
+
+def test_a_symlink_escaping_via_a_subpath_is_also_refused(
+    workspace: Path, tmp_path: Path
+) -> None:
+    """The confinement check runs on the resolved path, not just ``is_symlink``
+    on the direct entry, so a symlinked directory containing the ``.md`` file
+    is covered too -- exercised here by linking straight to a file outside a
+    deeper tree, matching how ``_read_file_under_root`` treats resolution."""
+    outside = _write(tmp_path / "outside" / "id_rsa", "PRIVATE KEY")
+    commands_dir = workspace / ".jiuwenswarm" / "commands"
+    commands_dir.mkdir(parents=True)
+    link = commands_dir / "leak.md"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+
+    commands = CommandConfigService(workspace).list_commands()
+    assert all("PRIVATE KEY" not in c.body for c in commands)
+
+
+def test_an_oversized_command_file_is_skipped_before_reading(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The size gate has to run before the read completes, or a link to a
+    device like ``/dev/zero`` can hang the eager ``commands.list`` scan."""
+    import jiuwenswarm.server.runtime.command_config_service as service_module
+
+    monkeypatch.setattr(service_module, "_MAX_COMMAND_FILE_BYTES", 5)
+    _write(workspace / ".jiuwenswarm" / "commands" / "huge.md", "x" * 100)
+    _write(workspace / ".jiuwenswarm" / "commands" / "fine.md", "ok")
+
+    commands = CommandConfigService(workspace).list_commands()
+    assert "huge" not in {c.name for c in commands}
+    assert "fine" in {c.name for c in commands}

--- a/tests/unit_tests/agentserver/test_commands_expand_handler.py
+++ b/tests/unit_tests/agentserver/test_commands_expand_handler.py
@@ -1,0 +1,308 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""The ``commands.expand`` handler and the root it is bounded to.
+
+The handler is the point where a user-defined command stops being a file and
+becomes a prompt, so the two things worth pinning here are that it refuses to
+run a command that is not active, and that the ``@file`` root is the session's
+locked project, never the one the request asked for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from jiuwenswarm.server.agent_ws_server import (
+    AgentWebSocketServer,
+    _request_builtin_names,
+    resolve_command_workspace_dir,
+    resolve_locked_command_workspace_dir,
+)
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _request(**params) -> SimpleNamespace:
+    """A duck-typed AgentRequest: the handler only reads attributes."""
+    return SimpleNamespace(
+        request_id="req-1",
+        channel_id="chan-1",
+        session_id=params.pop("session_id", "s-1"),
+        req_method="commands.expand",
+        metadata={},
+        params=params,
+    )
+
+
+class _FakeWs:
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(payload)
+
+
+def _expand(request: SimpleNamespace) -> dict:
+    """Drive the handler and return the decoded payload it sent.
+
+    ``_handle_commands_expand`` never touches ``self``, so an unbound call
+    avoids constructing a whole server for a read-only RPC.
+    """
+    ws = _FakeWs()
+
+    async def _run() -> None:
+        await AgentWebSocketServer._handle_commands_expand(
+            None, ws, request, asyncio.Lock()
+        )
+
+    asyncio.run(_run())
+    assert len(ws.sent) == 1
+    wire = json.loads(ws.sent[0])
+    return wire
+
+
+def _payload(wire: dict) -> dict:
+    """Dig the payload out of the wire frame, whichever shape it took."""
+    found = _find_key(wire, "text") or _find_key(wire, "error")
+    assert found is not None, f"no payload in {wire}"
+    return found
+
+
+def _find_key(node, key):
+    if isinstance(node, dict):
+        if key in node:
+            return node
+        for value in node.values():
+            hit = _find_key(value, key)
+            if hit is not None:
+                return hit
+    elif isinstance(node, list):
+        for value in node:
+            hit = _find_key(value, key)
+            if hit is not None:
+                return hit
+    return None
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    user_home = tmp_path / "userhome"
+    (user_home / "commands").mkdir(parents=True)
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.command_config_service.get_user_workspace_dir",
+        lambda: user_home,
+    )
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir()
+    return ws_dir
+
+
+@pytest.fixture
+def locked_session(monkeypatch: pytest.MonkeyPatch, workspace: Path) -> Path:
+    """Expand only runs against a session-locked project_dir."""
+
+    def _metadata(session_id, **kw):
+        return {"project_dir": str(workspace)}
+
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.session.session_metadata.get_session_metadata",
+        _metadata,
+    )
+    return workspace
+
+
+# ---------------------------------------------------------------- expansion
+
+
+def test_a_command_expands_arguments_and_files(locked_session: Path) -> None:
+    workspace = locked_session
+    _write(workspace / "src" / "a.py", "CODE")
+    _write(
+        workspace / ".jiuwenswarm" / "commands" / "review.md",
+        "Review @$1 for $ARGUMENTS",
+    )
+
+    payload = _payload(_expand(_request(name="review", args="src/a.py carefully")))
+    assert "CODE" in payload["text"]
+    assert "src/a.py carefully" in payload["text"]
+    assert payload["embedded"] == ["src/a.py"]
+    assert payload["errors"] == []
+
+
+def test_an_unreadable_file_is_reported_not_silently_dropped(locked_session: Path) -> None:
+    """A prompt with a hole in it is worse than a visible error."""
+    _write(locked_session / ".jiuwenswarm" / "commands" / "review.md", "Look at @gone.py")
+
+    payload = _payload(_expand(_request(name="review", args="")))
+    assert payload["errors"]
+    assert "could not read @gone.py" in payload["text"]
+
+
+def test_an_unknown_command_fails(locked_session: Path) -> None:
+    payload = _payload(_expand(_request(name="nope", args="")))
+    assert "unknown or inactive" in payload["error"]
+
+
+def test_a_reserved_command_never_expands(locked_session: Path) -> None:
+    """Listed so the UI can explain it; never run."""
+    _write(locked_session / ".jiuwenswarm" / "commands" / "help.md", "Body")
+
+    payload = _payload(_expand(_request(name="help", args="")))
+    assert "unknown or inactive" in payload["error"]
+
+
+def test_a_client_builtin_never_expands(locked_session: Path) -> None:
+    """Listing and expansion must agree on what is active."""
+    _write(locked_session / ".jiuwenswarm" / "commands" / "model.md", "Body")
+
+    allowed = _payload(_expand(_request(name="model", args="")))
+    assert "text" in allowed
+
+    refused = _payload(
+        _expand(_request(name="model", args="", builtin_names=["model"]))
+    )
+    assert "unknown or inactive" in refused["error"]
+
+
+def test_a_shadowed_definition_never_expands(
+    locked_session: Path, tmp_path: Path,
+) -> None:
+    _write(tmp_path / "userhome" / "commands" / "dup.md", "USER BODY")
+    _write(locked_session / ".jiuwenswarm" / "commands" / "dup.md", "PROJECT BODY")
+
+    payload = _payload(_expand(_request(name="dup", args="")))
+    assert "PROJECT BODY" in payload["text"]
+    assert "USER BODY" not in payload["text"]
+
+
+def test_expansion_cannot_escape_the_workspace(
+    locked_session: Path, tmp_path: Path,
+) -> None:
+    """The root bounds a user-supplied argument, so the check has to be real."""
+    _write(tmp_path / "secret.txt", "SECRET")
+    _write(locked_session / ".jiuwenswarm" / "commands" / "leak.md", "Show @$1")
+
+    payload = _payload(_expand(_request(name="leak", args="../secret.txt")))
+    assert "SECRET" not in payload["text"]
+    assert payload["errors"]
+
+
+def test_a_symlinked_command_file_never_expands(
+    locked_session: Path, tmp_path: Path,
+) -> None:
+    """A command body sourced from a symlink escaping the commands dir must
+    not be ingested at all, so ``commands.expand`` cannot leak it -- the same
+    guarantee ``@file`` gives, applied to the command file itself."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SECRET", encoding="utf-8")
+    commands_dir = locked_session / ".jiuwenswarm" / "commands"
+    commands_dir.mkdir(parents=True)
+    link = commands_dir / "leak.md"
+    try:
+        link.symlink_to(secret)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+
+    payload = _payload(_expand(_request(name="leak", args="")))
+    assert "unknown or inactive" in payload["error"]
+
+
+def test_a_command_name_with_whitespace_never_expands(locked_session: Path) -> None:
+    """``foo bar.md`` would be typed as ``/foo bar``, which the slash parser
+    cannot route -- it must not be invocable through ``commands.expand``
+    either."""
+    _write(locked_session / ".jiuwenswarm" / "commands" / "foo bar.md", "Body")
+
+    payload = _payload(_expand(_request(name="foo bar", args="")))
+    assert "unknown or inactive" in payload["error"]
+
+
+def test_a_missing_name_fails(locked_session: Path) -> None:
+    payload = _payload(_expand(_request(name="", args="x")))
+    assert "required" in payload["error"]
+
+
+def test_expand_without_locked_session_fails() -> None:
+    payload = _payload(_expand(_request(name="review", args="", session_id="")))
+    assert "session workspace not locked" in payload["error"]
+
+
+def test_expand_rejects_an_unlocked_project_dir_claim(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.session.session_metadata.get_session_metadata",
+        lambda session_id, **kw: {},
+    )
+    _write(workspace / ".jiuwenswarm" / "commands" / "review.md", "Body")
+    payload = _payload(
+        _expand(_request(name="review", args="", project_dir=str(workspace)))
+    )
+    assert "session workspace not locked" in payload["error"]
+
+
+# ---------------------------------------------------------------- the root
+
+
+def test_the_locked_session_project_dir_wins_over_the_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client free to name the root could name ``/`` and read anything."""
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.session.session_metadata.get_session_metadata",
+        lambda session_id, **kw: {"project_dir": "/locked/project"},
+    )
+    request = _request(session_id="s-1", project_dir="/attacker/claim")
+    assert resolve_command_workspace_dir(request) == "/locked/project"
+    assert resolve_locked_command_workspace_dir(request) == "/locked/project"
+
+
+def test_the_request_is_the_fallback_before_a_value_is_locked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Refusing to list commands before the first message is a worse trade."""
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.session.session_metadata.get_session_metadata",
+        lambda session_id, **kw: {},
+    )
+    request = _request(session_id="s-1", project_dir="/from/request")
+    assert resolve_command_workspace_dir(request) == "/from/request"
+    assert resolve_locked_command_workspace_dir(request) is None
+
+
+def test_an_unreadable_session_falls_back_instead_of_failing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(session_id, **kw):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.session.session_metadata.get_session_metadata",
+        _boom,
+    )
+    request = _request(session_id="s-1", project_dir="/from/request")
+    assert resolve_command_workspace_dir(request) == "/from/request"
+    assert resolve_locked_command_workspace_dir(request) is None
+
+
+def test_declared_builtin_names_are_normalised() -> None:
+    request = _request(builtin_names=["Help", "  model  ", "", 7, None])
+    from jiuwenswarm.server.runtime.command_config_service import RESERVED_NAMES
+
+    assert _request_builtin_names(request) == {"help", "model"} | set(RESERVED_NAMES)
+
+
+def test_a_client_that_declares_nothing_gets_the_reserved_floor() -> None:
+    from jiuwenswarm.server.runtime.command_config_service import RESERVED_NAMES
+
+    assert _request_builtin_names(_request()) == set(RESERVED_NAMES)
+    assert _request_builtin_names(_request(builtin_names="help")) == set(RESERVED_NAMES)

--- a/tests/unit_tests/common/test_command_expansion.py
+++ b/tests/unit_tests/common/test_command_expansion.py
@@ -1,0 +1,163 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Argument and @file substitution for user-defined slash commands."""
+
+from __future__ import annotations
+
+from jiuwenswarm.common.command_expansion import (
+    expand_command,
+    expand_file_refs,
+    split_arguments,
+    substitute_arguments,
+)
+
+
+# ---------------------------------------------------------------- arguments
+
+
+def test_arguments_placeholder_gets_the_whole_string() -> None:
+    assert substitute_arguments("Review: $ARGUMENTS", "src/a.py and be brief") == (
+        "Review: src/a.py and be brief"
+    )
+
+
+def test_positionals_split_shell_style() -> None:
+    body = "compare $1 with $2"
+    assert substitute_arguments(body, "alpha beta") == "compare alpha with beta"
+
+
+def test_a_quoted_argument_stays_one_positional() -> None:
+    """/review "src/a b.py" is one path, not two."""
+    assert split_arguments('"src/a b.py" other') == ["src/a b.py", "other"]
+    assert substitute_arguments("read $1", '"src/a b.py"') == "read src/a b.py"
+
+
+def test_an_unbalanced_quote_falls_back_instead_of_failing() -> None:
+    """A typo must not refuse the command."""
+    assert split_arguments('unclosed "quote here') == ["unclosed", '"quote', "here"]
+
+
+def test_a_positional_embedded_via_at_is_quoted_when_it_contains_spaces() -> None:
+    """``@$1`` must carry a space-containing path through to ``_FILE_REF`` whole.
+
+    ``_FILE_REF`` stops at the first whitespace, so a bare substitution would
+    turn ``@src/a b.py`` into a reference to ``src/a``. Quoting only kicks in
+    right after ``@``, so a plain ``$1`` elsewhere in the body is untouched.
+    """
+    assert substitute_arguments("review @$1", '"src/a b.py"') == 'review @"src/a b.py"'
+
+
+def test_a_missing_positional_becomes_empty_not_literal() -> None:
+    """Leaving a literal $3 would put a stray token in the prompt."""
+    assert substitute_arguments("a=$1 b=$2 c=$3", "one") == "a=one b= c="
+
+
+def test_arguments_and_positionals_coexist() -> None:
+    """$ARGUMENTS sees the whole string; positionals see the split pieces."""
+    out = substitute_arguments("all=[$ARGUMENTS] first=$1", "x y")
+    assert out == "all=[x y] first=x"
+
+
+def test_a_dollar_that_is_not_a_placeholder_survives() -> None:
+    assert substitute_arguments("cost is $5.00 and $0 and $x", "arg") == (
+        "cost is $5.00 and $0 and $x"
+    )
+
+
+def test_no_arguments_leaves_placeholders_empty() -> None:
+    assert substitute_arguments("[$ARGUMENTS] [$1]", "") == "[] []"
+
+
+# ---------------------------------------------------------------- @file
+
+
+def _resolver(files: dict[str, str]):
+    def _resolve(ref: str) -> str:
+        if ref not in files:
+            raise ValueError("not found")
+        return files[ref]
+
+    return _resolve
+
+
+def test_a_file_reference_is_embedded_with_delimiters() -> None:
+    result = expand_file_refs("look at @src/a.py please", _resolver({"src/a.py": "CODE"}))
+    assert "CODE" in result.text
+    assert "--- src/a.py ---" in result.text
+    assert result.embedded == ["src/a.py"]
+    assert result.errors == []
+
+
+def test_an_unreadable_file_is_marked_not_silently_dropped() -> None:
+    """An empty section would make the model answer about a file it never saw."""
+    result = expand_file_refs("check @missing.py", _resolver({}))
+    assert "could not read @missing.py" in result.text
+    assert result.errors
+    assert result.embedded == []
+
+
+def test_embedded_content_is_capped() -> None:
+    # The payload character must not appear in the filename, or the assertion
+    # counts the delimiters too -- "big.txt" contains an "x".
+    result = expand_file_refs("@big.log", _resolver({"big.log": "x" * 500}), max_chars=100)
+    assert "truncated at 100" in result.text
+    assert result.text.count("x") == 100
+
+
+def test_trailing_punctuation_is_not_part_of_the_path() -> None:
+    result = expand_file_refs("see @a.py, then stop", _resolver({"a.py": "OK"}))
+    assert result.embedded == ["a.py"]
+    assert result.text.rstrip().endswith("then stop")
+
+
+def test_an_email_like_token_is_not_a_file_reference() -> None:
+    result = expand_file_refs("ping me@example.com about it", _resolver({}))
+    assert result.embedded == []
+    assert result.errors == []
+    assert result.text == "ping me@example.com about it"
+
+
+def test_without_a_resolver_nothing_is_embedded() -> None:
+    result = expand_file_refs("see @a.py", None)
+    assert result.text == "see @a.py"
+
+
+# ---------------------------------------------------------------- ordering
+
+
+def test_arguments_are_substituted_before_file_refs() -> None:
+    """@$1 must embed the file the caller named — the load-bearing ordering.
+
+    Expanding files first would look for a file literally called "$1".
+    """
+    result = expand_command("review @$1", "src/a.py", _resolver({"src/a.py": "CODE"}))
+    assert "CODE" in result.text
+    assert result.embedded == ["src/a.py"]
+
+
+def test_at_dollar_one_embeds_a_quoted_path_with_spaces() -> None:
+    """``expand_command("review @$1", '"src/a b.py"', …)`` embeds ``src/a b.py``."""
+    result = expand_command("review @$1", '"src/a b.py"', _resolver({"src/a b.py": "CODE"}))
+    assert "CODE" in result.text
+    assert result.embedded == ["src/a b.py"]
+
+
+def test_a_command_with_neither_is_returned_unchanged() -> None:
+    result = expand_command("just a prompt", "", _resolver({}))
+    assert result.text == "just a prompt"
+    assert result.errors == []
+
+
+def test_embed_count_is_capped() -> None:
+    body = " ".join(f"@{i}.txt" for i in range(25))
+    resolver = _resolver({f"{i}.txt": "x" for i in range(25)})
+    result = expand_file_refs(body, resolver, max_embeds=20)
+    assert len(result.embedded) == 20
+    assert any("embed limit reached" in err for err in result.errors)
+
+
+def test_expand_command_forwards_max_embeds() -> None:
+    body = "@a.txt @b.txt"
+    result = expand_command(body, "", _resolver({"a.txt": "A", "b.txt": "B"}), max_embeds=1)
+    assert len(result.embedded) == 1
+    assert any("embed limit reached" in err for err in result.errors)


### PR DESCRIPTION
Paired: [GitHub #2648](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2648) ↔ [GitCode !4683](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4683)

Load slash commands from Markdown files under `.jiuwenswarm/commands/` (three scopes: project > user > local), expose `commands.list` and `commands.expand` RPCs, and wire discovery, `/help`, autocomplete, and execution in the TUI. Expansion runs server-side (`$ARGUMENTS`, `$1..$9`, `@file`) with session-locked workspace bounds, embed caps, and built-in name collision handling.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
/kind feature


**What does this PR do / why do we need it**:
* **Discovery:** `CommandConfigService` loads user commands from Markdown files at three scopes with the same precedence as agent definitions (`project > user > local`). Shadowed and reserved definitions are reported, not silently dropped.
* **RPC:** adds `commands.list` and `commands.expand` on `AgentWebSocketServer`; gateway whitelist updated for TUI and Web channels.
* **Expansion:** `command_expansion.py` substitutes `$ARGUMENTS`, `$1..$9`, and embeds `@file` references server-side. `@file` reads are bounded to the session-locked `project_dir`; embed count and per-file size are capped.
* **TUI:** `CommandService` merges user commands with built-ins, refreshes on connect and on execute, shows a **User-defined** group in `/help`, and runs commands via expand → `chat.send`.
* **Why:** the TUI today only supports built-in slash commands. Teams need repeatable prompts (review, summarize, lint) as first-class `/commands` without pasting prompts manually or wrapping every workflow in a skill.

**Example:**

```bash
mkdir -p .jiuwenswarm/commands
cat > .jiuwenswarm/commands/pr-review.md << 'EOF'
---
description: Review a file for bugs
argument-hint: "<path>"
---
Review @$1 for correctness, security issues, and missing tests.
Focus on: $ARGUMENTS
EOF
```

In the TUI: `/help` lists `/pr-review`; `/pr-review src/main.py` sends the expanded prompt with the file embedded.

**Which issue(s) this PR fixes**:
Fixes #2647


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* **Unit tests (Python, 52 passed):**
  ```bash
  pytest tests/unit_tests/common/test_command_expansion.py \
         tests/unit_tests/agentserver/test_command_config_service.py \
         tests/unit_tests/agentserver/test_commands_expand_handler.py -q
  ```
  Covers argument substitution, `@file` embedding and truncation, three-scope discovery and precedence, shadowed/reserved reporting, malformed file isolation, locked-workspace expand, path escape rejection, and inactive command refusal.
* **Unit tests (TUI frontend):**
  ```bash
  cd jiuwenswarm/channels/tui/frontend && node tests/user-commands.test.mjs
  ```
  Covers registration merge, execute via `commands.expand`, `/help` groups, cache retention on failed `commands.list`, and refresh-on-execute.
* **Manual (recommended before merge):**
  1. Create `.jiuwenswarm/commands/pr-review.md` → `/help` shows **User-defined** with `/pr-review`; autocomplete suggests it.
  2. `/pr-review src/foo.py` → expanded prompt sent with file content embedded.
  3. Same command name in user and project scopes → project wins; user copy listed under **not loaded**.
  4. `model.md` or `help.md` in user commands → listed as reserved; built-in `/model` and `/help` unchanged.
  5. Create a new command file while TUI is open → first `/name` works without restart.
  6. `/command ../../.ssh/id_rsa` → no secret content leaked; expansion error surfaced.
* **Security / reliability:** expand uses session-locked workspace only (no request fallback for `@file`); failed `commands.list` does not wipe previously loaded commands; built-in behavior unchanged; new RPCs are additive.
* **Performance:** no hot-path regression expected; command bodies capped at 100k chars; at most 20 file embeds per expansion.
* **Known follow-ups (out of scope):** `!bash` preexec, `allowed-tools` enforcement, Web UI slash UI, `CLI_COMMANDS.md` docs.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [x] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2647
<!-- /bot1-related-issues -->
