### PR TITLE
fix(gateway): handle agent_ref request keys on disconnect

### DIFF
--- a/tests/unit_tests/gateway/test_message_handler_stream_cancel.py
+++ b/tests/unit_tests/gateway/test_message_handler_stream_cancel.py
@@ -683,6 +683,25 @@ def test_disconnect_accepts_agent_ref_scoped_route_keys() -> None:
 
 
 @pytest.mark.asyncio
+async def test_disconnect_recovers_session_from_agent_ref_request_key() -> None:
+    handler = _TestMessageHandler.create()
+    _seed_stream_task(
+        handler,
+        rid="rid-agent-ref",
+        channel_id="tui",
+        session_id="sess_agent_ref",
+    )
+
+    await handler.cancel_agent_sessions_on_disconnect(
+        [],
+        stale_request_keys=[("tui", "rid-agent-ref", "code.normal:default")],
+    )
+
+    await asyncio.sleep(0)
+    assert len(_FakeAgentClient.sent_requests) == 1
+
+
+@pytest.mark.asyncio
 async def test_disconnect_cancel_marks_request_as_client_disconnect() -> None:
     handler = _TestMessageHandler.create()
     _seed_stream_task(


### PR DESCRIPTION
Paired: [GitHub #2694](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2694) ↔ [GitCode !4699](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4699)

/kind bug

## Summary
- Handle request route keys containing `agent_ref` during disconnect cleanup.
- Add regression coverage for two- and three-element route keys.

Fixes #2670

## Tests
- 61 gateway unit tests passed

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2670
<!-- /bot1-related-issues -->
