### PR TITLE
feat(reasoning): map reasoning_level to real provider knobs

### DIFF
--- a/jiuwenswarm/agents/harness/team/config_loader.py
+++ b/jiuwenswarm/agents/harness/team/config_loader.py
@@ -12,6 +12,7 @@ from typing import Any
 from openjiuwen.agent_teams.paths import get_agent_teams_home
 
 from jiuwenswarm.common.config import get_config
+from jiuwenswarm.common.reasoning_injector import build_reasoning_model_request_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -250,11 +251,32 @@ def _build_default_model_dict(
         requested_model_name=requested_model_name,
     )
     model_client_config = dict(model_config.get("model_client_config", {}))
-    model_request_config = dict(model_config.get("model_config_obj", {}))
+    raw_request_config = dict(model_config.get("model_config_obj", {}))
 
     model_name = model_client_config.get("model_name", "")
-    if model_name and "model" not in model_request_config:
-        model_request_config["model"] = model_name
+    # Preserve the previous ``model`` precedence: an explicit value in
+    # ``model_config_obj`` wins, and no name at all means no ``model`` key.
+    # Detection must follow the same precedence -- the provider knob has to be
+    # picked for the id that actually goes out on the wire, not the client
+    # config's name, or a client name from one provider paired with an
+    # explicit override for another provider's model leaks that provider's
+    # knob onto the wrong request.
+    explicit_model = raw_request_config.get("model")
+    request_model_name = str(explicit_model).strip() if explicit_model else model_name
+    # ``reasoning_level`` is an internal hint, not an OpenAI request parameter.
+    # Map it to the provider-specific payload here; forwarding it raw lets
+    # ``ModelRequestConfig`` (extra=allow) pass it through to
+    # ``AsyncCompletions.create()``, which fails every model call with
+    # ``unexpected keyword argument 'reasoning_level'``.
+    model_request_config = build_reasoning_model_request_kwargs(
+        model_client_config=model_client_config,
+        model_config_obj=raw_request_config,
+        model_name=request_model_name,
+    )
+    if explicit_model:
+        model_request_config["model"] = explicit_model
+    elif not model_name:
+        model_request_config.pop("model", None)
 
     logger.info(
         "[TeamConfigLoader] model config loaded: model_name=%s, provider=%s",
@@ -295,6 +317,34 @@ def _build_agent_defaults() -> tuple[dict[str, Any], int, float]:
     )
 
 
+def _sanitize_agent_model_override(model_raw: Any) -> Any:
+    """Map ``reasoning_level`` inside an explicit per-agent model override.
+
+    Same hazard as ``_build_default_model_dict``: the value is an internal hint
+    and must never reach the OpenAI SDK as a request parameter. Per-agent
+    overrides arrive already shaped as ``model_client_config`` /
+    ``model_request_config`` and therefore bypass the default model path.
+    """
+    if not isinstance(model_raw, dict):
+        return model_raw
+
+    request_config = model_raw.get("model_request_config")
+    if not isinstance(request_config, dict) or "reasoning_level" not in request_config:
+        return model_raw
+
+    client_config_raw = model_raw.get("model_client_config")
+    client_config = dict(client_config_raw) if isinstance(client_config_raw, dict) else {}
+    model_name = client_config.get("model_name", "") or request_config.get("model", "")
+
+    sanitized = dict(model_raw)
+    sanitized["model_request_config"] = build_reasoning_model_request_kwargs(
+        model_client_config=client_config,
+        model_config_obj=request_config,
+        model_name=model_name,
+    )
+    return sanitized
+
+
 def _build_agent_spec_dict(
     agent_config: dict[str, Any],
     *,
@@ -304,6 +354,8 @@ def _build_agent_spec_dict(
     completion_timeout: float,
 ) -> dict[str, Any]:
     merged = deepcopy(agent_config)
+    if "model" in merged:
+        merged["model"] = _sanitize_agent_model_override(merged["model"])
     merged.setdefault("model", deepcopy(default_model))
     merged.setdefault("workspace", deepcopy(default_workspace))
     merged.setdefault("max_iterations", max_iterations)

--- a/jiuwenswarm/common/reasoning_config.py
+++ b/jiuwenswarm/common/reasoning_config.py
@@ -1,15 +1,37 @@
 # coding: utf-8
+"""Reasoning levels, provider detection, and per-provider level tables.
+
+``reasoning_level`` (``off|low|medium|high``) is product-facing, not a provider
+parameter. Mapping:
+
+| level      | OpenAI                       | Anthropic                 | DeepSeek / DashScope              |
+| ---------- | ---------------------------- | ------------------------- | --------------------------------- |
+| ``off``    | omit ``reasoning_effort``    | omit ``thinking``         | thinking disabled                 |
+| ``low``    | ``reasoning_effort=low``     | ``budget_tokens=1024``    | thinking enabled                  |
+| ``medium`` | ``reasoning_effort=medium``  | ``budget_tokens=8000``    | thinking enabled                  |
+| ``high``   | ``reasoning_effort=high``    | ``budget_tokens=16000``   | thinking enabled + effort         |
+
+Anthropic Claude 4.6+ minors are excluded (adaptive thinking / budget reject).
+Anthropic payloads also need agent-core to forward ``thinking``.
+"""
+
 from __future__ import annotations
 
+import re
 from enum import Enum
 from typing import Any, Literal
 from urllib.parse import urlparse
 
 
-ReasoningProviderKind = Literal["deepseek_official", "dashscope_bailian"]
+ReasoningProviderKind = Literal[
+    "deepseek_official",
+    "dashscope_bailian",
+    "openai_reasoning",
+    "anthropic",
+]
 ReasoningLevel = Literal["off", "low", "medium", "high"]
-ReasoningEffort = Literal["off", "high"]
 
+# Anthropic is detected separately; do not gate it on this set.
 OPENAI_SDK_REASONING_PROVIDERS = {
     "openai",
     "deepseek",
@@ -21,12 +43,42 @@ SUPPORTED_DEEPSEEK_V4_MODELS = {
     "deepseek-v4-flash",
 }
 
-LEVEL_MAPPING: dict[ReasoningLevel, ReasoningEffort] = {
-    "off": "off",
-    "low": "high",
-    "medium": "high",
-    "high": "high",
+ANTHROPIC_PROVIDER_NAMES = {"anthropic", "claude"}
+ANTHROPIC_API_HOSTS = {"api.anthropic.com"}
+OPENAI_API_HOSTS = {"api.openai.com"}
+
+# Models that accept thinking.budget_tokens (Claude 3.7 / 4.x below 4.6).
+ANTHROPIC_THINKING_MODEL_PREFIXES: tuple[str, ...] = (
+    "claude-3-7",
+    "claude-opus-4",
+    "claude-sonnet-4",
+    "claude-haiku-4",
+)
+
+# Match on hyphen boundary so "o1" does not match "o1lama".
+OPENAI_REASONING_MODEL_PREFIXES: tuple[str, ...] = (
+    "o1",
+    "o3",
+    "o4",
+    "gpt-5",
+)
+
+# ChatGPT-instant ids inside the gpt-5 family (``gpt-5-chat-latest``,
+# ``gpt-5.1-chat``, ...). These are not reasoning models and 400 on
+# ``reasoning_effort``, the same reason ``gpt-4o`` is refused below.
+_GPT5_CHAT_VARIANT_RE = re.compile(r"(?:^|[-.])chat(?:[-.]|$)")
+
+ANTHROPIC_BUDGET_TOKENS: dict[str, int] = {
+    "low": 1024,
+    "medium": 8000,
+    "high": 16000,
 }
+
+# Anthropic requires budget_tokens < max_tokens; keep room for the answer.
+ANTHROPIC_MAX_TOKENS_HEADROOM = 4096
+
+# Claude 4.x: ``-4``, ``-4-5``, or date stamp; minor >= 6 is excluded.
+_CLAUDE_4_FAMILY_RE = re.compile(r"^claude-(?:opus|sonnet|haiku)-4(?:-(\d+))?(?:-|$)")
 
 
 def _normalize_provider(provider: Any) -> str:
@@ -42,9 +94,14 @@ def _parse_api_base(api_base: str | None):
     return urlparse(value)
 
 
+def _host_of(api_base: str | None) -> str:
+    return (_parse_api_base(api_base).hostname or "").lower()
+
+
 def resolve_reasoning_provider_kind(
     api_base: str | None,
 ) -> ReasoningProviderKind | None:
+    """Detect DeepSeek-family kinds from host alone."""
     parsed = _parse_api_base(api_base)
     host = (parsed.hostname or "").lower()
     path = (parsed.path or "").rstrip("/")
@@ -56,6 +113,46 @@ def resolve_reasoning_provider_kind(
         return "dashscope_bailian"
 
     return None
+
+
+def _matches_prefix(model: str, prefixes: tuple[str, ...]) -> bool:
+    """Exact name or hyphen-boundary prefix match."""
+    return any(model == prefix or model.startswith(f"{prefix}-") for prefix in prefixes)
+
+
+def _claude_4_minor_allows_budget_tokens(model: str) -> bool:
+    """Allow Claude 4.x minors below 6; treat 8-digit segments as date stamps."""
+    match = _CLAUDE_4_FAMILY_RE.match(model)
+    if match is None:
+        return True
+    segment = match.group(1)
+    if segment is None:
+        return True
+    if len(segment) >= 8:
+        return True
+    return int(segment) < 6
+
+
+def is_anthropic_thinking_model(model_name: str | None) -> bool:
+    """Whether this model accepts a ``thinking`` budget block."""
+    model = str(model_name or "").strip().lower()
+    if not model:
+        return False
+    if not _matches_prefix(model, ANTHROPIC_THINKING_MODEL_PREFIXES):
+        return False
+    return _claude_4_minor_allows_budget_tokens(model)
+
+
+def is_openai_reasoning_model(model_name: str | None) -> bool:
+    """Whether this model accepts ``reasoning_effort``."""
+    model = str(model_name or "").strip().lower()
+    if not model:
+        return False
+    if model == "gpt-5" or model.startswith("gpt-5-") or model.startswith("gpt-5."):
+        # ``gpt-5-chat-latest`` / ``gpt-5.1-chat`` are ChatGPT-instant ids, not
+        # reasoning models; sending them ``reasoning_effort`` is a 400.
+        return not _GPT5_CHAT_VARIANT_RE.search(model)
+    return _matches_prefix(model, tuple(p for p in OPENAI_REASONING_MODEL_PREFIXES if p != "gpt-5"))
 
 
 def normalize_reasoning_level(raw: Any) -> ReasoningLevel | None:
@@ -82,27 +179,40 @@ def resolve_reasoning_target(
     api_base: str | None,
     model_name: str | None,
 ) -> tuple[ReasoningProviderKind, str] | None:
+    """Return ``(kind, model)`` for the provider knob, or ``None``."""
     provider = _normalize_provider(client_provider)
-    if provider not in OPENAI_SDK_REASONING_PROVIDERS:
-        return None
-
-    provider_kind = resolve_reasoning_provider_kind(api_base)
-    if provider_kind is None:
-        return None
-
+    host = _host_of(api_base)
     model = str(model_name or "").strip().lower()
-    if model not in SUPPORTED_DEEPSEEK_V4_MODELS:
-        return None
-    return provider_kind, model
+
+    if provider in OPENAI_SDK_REASONING_PROVIDERS:
+        deepseek_kind = resolve_reasoning_provider_kind(api_base)
+        if deepseek_kind is not None:
+            if model not in SUPPORTED_DEEPSEEK_V4_MODELS:
+                return None
+            return deepseek_kind, model
+
+    if provider in ANTHROPIC_PROVIDER_NAMES or host in ANTHROPIC_API_HOSTS:
+        if not is_anthropic_thinking_model(model):
+            return None
+        return "anthropic", model
+
+    if host in OPENAI_API_HOSTS and is_openai_reasoning_model(model):
+        return "openai_reasoning", model
+
+    return None
 
 
 __all__ = [
-    "LEVEL_MAPPING",
+    "ANTHROPIC_BUDGET_TOKENS",
+    "ANTHROPIC_MAX_TOKENS_HEADROOM",
+    "ANTHROPIC_THINKING_MODEL_PREFIXES",
+    "OPENAI_REASONING_MODEL_PREFIXES",
     "OPENAI_SDK_REASONING_PROVIDERS",
     "SUPPORTED_DEEPSEEK_V4_MODELS",
-    "ReasoningEffort",
     "ReasoningLevel",
     "ReasoningProviderKind",
+    "is_anthropic_thinking_model",
+    "is_openai_reasoning_model",
     "normalize_reasoning_level",
     "resolve_reasoning_provider_kind",
     "resolve_reasoning_target",

--- a/jiuwenswarm/common/reasoning_injector.py
+++ b/jiuwenswarm/common/reasoning_injector.py
@@ -5,8 +5,9 @@ from collections.abc import Mapping
 from typing import Any
 
 from jiuwenswarm.common.reasoning_config import (
-    LEVEL_MAPPING,
-    ReasoningEffort,
+    ANTHROPIC_BUDGET_TOKENS,
+    ANTHROPIC_MAX_TOKENS_HEADROOM,
+    ReasoningLevel,
     normalize_reasoning_level,
     resolve_reasoning_target,
 )
@@ -48,32 +49,121 @@ def _runtime_config_copy(model_config_dict: dict[str, Any]) -> dict[str, Any]:
 
 def inject_deepseek_official_payload(
     model_config_obj: dict[str, Any],
-    mapped_level: ReasoningEffort,
+    level: ReasoningLevel,
 ) -> None:
+    """DeepSeek takes an on/off switch, plus an effort hint only at ``high``.
+
+    ``low`` and ``medium`` enable thinking and send no effort. They used to send
+    ``reasoning_effort="high"``, which discarded the level the user picked.
+    """
     model_config_obj.pop("reasoning_effort", None)
 
     extra_body = _copy_extra_body(model_config_obj.get("extra_body"))
     extra_body["thinking"] = {
-        "type": "disabled" if mapped_level == "off" else "enabled",
+        "type": "disabled" if level == "off" else "enabled",
     }
     model_config_obj["extra_body"] = extra_body
 
-    if mapped_level == "high":
-        model_config_obj["reasoning_effort"] = mapped_level
+    if level == "high":
+        model_config_obj["reasoning_effort"] = "high"
 
 
 def inject_dashscope_bailian_payload(
     model_config_obj: dict[str, Any],
-    mapped_level: ReasoningEffort,
+    level: ReasoningLevel,
 ) -> None:
+    """Bailian spells the same switch as ``enable_thinking``."""
     model_config_obj.pop("reasoning_effort", None)
 
     extra_body = _copy_extra_body(model_config_obj.get("extra_body"))
-    extra_body["enable_thinking"] = mapped_level != "off"
+    extra_body["enable_thinking"] = level != "off"
     model_config_obj["extra_body"] = extra_body
 
-    if mapped_level == "high":
-        model_config_obj["reasoning_effort"] = mapped_level
+    if level == "high":
+        model_config_obj["reasoning_effort"] = "high"
+
+
+def inject_openai_reasoning_payload(
+    model_config_obj: dict[str, Any],
+    level: ReasoningLevel,
+) -> None:
+    """OpenAI's enum is the product axis, so the level passes straight through.
+
+    ``off`` omits the field rather than sending ``"none"``: omission is what
+    every model accepts, and the caller has already established that this model
+    is reasoning-capable.
+    """
+    model_config_obj.pop("reasoning_effort", None)
+    if level == "off":
+        return
+    model_config_obj["reasoning_effort"] = level
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    """Parse a configured ceiling; reject bools and non-numeric junk."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            parsed = int(text)
+        except ValueError:
+            return None
+        return parsed
+    return None
+
+
+def inject_anthropic_thinking_payload(
+    model_config_obj: dict[str, Any],
+    level: ReasoningLevel,
+) -> None:
+    """Anthropic wants an integer budget, and it must fit inside ``max_tokens``.
+
+    The budget is thinking tokens taken *out of* ``max_tokens``, so a maximum
+    that cannot hold the budget *and* leave answer headroom is raised to
+    ``budget`` plus :data:`ANTHROPIC_MAX_TOKENS_HEADROOM`. This applies to an
+    unset maximum too, which is the case that looks safe and is not: the client
+    substitutes 8192, and against that default ``high`` (16000) is rejected
+    outright while ``medium`` (8000) is *accepted* and leaves 192 tokens for the
+    actual answer. A ceiling of ``budget + 1`` is the same trap. A 400 is
+    recoverable; a near-empty reply that reads like the model had nothing to
+    say is not.
+
+    Extended thinking also rejects non-default sampling: ``temperature`` may
+    only be ``1`` (or omitted), and ``top_p`` / ``top_k`` are incompatible.
+    Stale OpenAI ``reasoning_effort`` is cleared for the same reason the other
+    injectors clear it -- an OpenAI-only knob on a Messages request is a hard
+    error once agent-core forwards extras.
+
+    ``off`` omits the block instead of sending ``{"type": "disabled"}``, because
+    a model without extended thinking rejects the field either way.
+    """
+    model_config_obj.pop("thinking", None)
+    model_config_obj.pop("reasoning_effort", None)
+    if level == "off":
+        return
+
+    budget = ANTHROPIC_BUDGET_TOKENS[level]
+    configured = _coerce_positive_int(model_config_obj.get("max_tokens"))
+    if configured is None or configured - budget < ANTHROPIC_MAX_TOKENS_HEADROOM:
+        model_config_obj["max_tokens"] = budget + ANTHROPIC_MAX_TOKENS_HEADROOM
+    else:
+        # Normalise string/float ceilings so the request carries an int.
+        model_config_obj["max_tokens"] = configured
+
+    # Thinking is incompatible with custom sampling. Omit rather than force 1:
+    # omission is what every Messages model accepts.
+    model_config_obj.pop("temperature", None)
+    model_config_obj.pop("top_p", None)
+    model_config_obj.pop("top_k", None)
+
+    model_config_obj["thinking"] = {"type": "enabled", "budget_tokens": budget}
 
 
 def inject_reasoning_params(
@@ -99,12 +189,15 @@ def inject_reasoning_params(
         return runtime_model_config
 
     provider_kind, _model = target
-    mapped_level = LEVEL_MAPPING[level]
 
     if provider_kind == "deepseek_official":
-        inject_deepseek_official_payload(runtime_model_config, mapped_level)
+        inject_deepseek_official_payload(runtime_model_config, level)
     elif provider_kind == "dashscope_bailian":
-        inject_dashscope_bailian_payload(runtime_model_config, mapped_level)
+        inject_dashscope_bailian_payload(runtime_model_config, level)
+    elif provider_kind == "openai_reasoning":
+        inject_openai_reasoning_payload(runtime_model_config, level)
+    elif provider_kind == "anthropic":
+        inject_anthropic_thinking_payload(runtime_model_config, level)
 
     return runtime_model_config
 
@@ -144,7 +237,9 @@ def build_reasoning_model_request_kwargs(
 
 __all__ = [
     "build_reasoning_model_request_kwargs",
+    "inject_anthropic_thinking_payload",
     "inject_dashscope_bailian_payload",
     "inject_deepseek_official_payload",
+    "inject_openai_reasoning_payload",
     "inject_reasoning_params",
 ]

--- a/tests/unit_tests/agents/harness/test_team_config_loader_reasoning.py
+++ b/tests/unit_tests/agents/harness/test_team_config_loader_reasoning.py
@@ -1,0 +1,243 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""``reasoning_level`` must never reach the model request config of a team agent.
+
+It is an internal hint. ``ModelRequestConfig`` is declared with ``extra=allow``,
+so anything left in the request config is forwarded to
+``AsyncCompletions.create()`` and fails the call with
+``TypeError: got an unexpected keyword argument 'reasoning_level'``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jiuwenswarm.agents.harness.team.config_loader import load_team_spec_dict
+
+
+def _config_base(
+    *,
+    reasoning_level: Any = "medium",
+    model_name: str = "deepseek-v4-pro",
+    api_base: str = "https://api.deepseek.com",
+    provider: str = "DeepSeek",
+) -> dict[str, Any]:
+    model_config_obj: dict[str, Any] = {"temperature": 0.95}
+    if reasoning_level is not None:
+        model_config_obj["reasoning_level"] = reasoning_level
+    return {
+        "models": {
+            "defaults": [
+                {
+                    "model_client_config": {
+                        "model_name": model_name,
+                        "api_base": api_base,
+                        "api_key": "sk-test",
+                        "client_provider": provider,
+                    },
+                    "model_config_obj": model_config_obj,
+                }
+            ]
+        },
+        "modes": {
+            "team": {
+                "jiuwen_team": {
+                    "team_name": "jiuwen_team",
+                    "agents": {"leader": {}},
+                }
+            }
+        },
+    }
+
+
+def _request_configs(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        key: (agent.get("model") or {}).get("model_request_config") or {}
+        for key, agent in (spec.get("agents") or {}).items()
+    }
+
+
+def test_reasoning_level_is_not_forwarded_as_a_request_param():
+    spec = load_team_spec_dict(config_base=_config_base())
+
+    request_configs = _request_configs(spec)
+    assert request_configs, "team spec produced no agents"
+    for agent_key, request_config in request_configs.items():
+        assert "reasoning_level" not in request_config, (
+            f"agent '{agent_key}' would send reasoning_level to the OpenAI SDK: "
+            f"{request_config}"
+        )
+
+
+def test_reasoning_level_medium_enables_thinking_without_effort():
+    """medium must not collapse to reasoning_effort=high."""
+    spec = load_team_spec_dict(config_base=_config_base())
+
+    for request_config in _request_configs(spec).values():
+        assert request_config["extra_body"] == {"thinking": {"type": "enabled"}}
+        assert "reasoning_effort" not in request_config
+
+
+def test_reasoning_level_high_still_sends_effort_high():
+    spec = load_team_spec_dict(config_base=_config_base(reasoning_level="high"))
+
+    for request_config in _request_configs(spec).values():
+        assert request_config["extra_body"] == {"thinking": {"type": "enabled"}}
+        assert request_config["reasoning_effort"] == "high"
+
+
+def test_reasoning_level_off_disables_thinking():
+    spec = load_team_spec_dict(config_base=_config_base(reasoning_level="off"))
+
+    for request_config in _request_configs(spec).values():
+        assert "reasoning_level" not in request_config
+        assert request_config["extra_body"] == {"thinking": {"type": "disabled"}}
+        assert "reasoning_effort" not in request_config
+
+
+def test_unsupported_provider_still_drops_the_internal_hint():
+    """No provider mapping exists, but the hint must not leak to the SDK either."""
+    spec = load_team_spec_dict(
+        config_base=_config_base(
+            model_name="nvidia/nemotron-3-ultra-550b-a55b:free",
+            api_base="https://openrouter.ai/api/v1",
+            provider="OpenRouter",
+        )
+    )
+
+    for request_config in _request_configs(spec).values():
+        assert "reasoning_level" not in request_config
+        assert request_config["temperature"] == 0.95
+
+
+def test_model_name_is_still_resolved_into_the_request_config():
+    spec = load_team_spec_dict(config_base=_config_base(reasoning_level=None))
+
+    for request_config in _request_configs(spec).values():
+        assert request_config["model"] == "deepseek-v4-pro"
+        assert request_config["temperature"] == 0.95
+
+
+def test_explicit_model_in_model_config_obj_keeps_precedence():
+    config_base = _config_base(reasoning_level=None)
+    config_base["models"]["defaults"][0]["model_config_obj"]["model"] = "pinned-model"
+
+    spec = load_team_spec_dict(config_base=config_base)
+
+    for request_config in _request_configs(spec).values():
+        assert request_config["model"] == "pinned-model"
+
+
+def test_missing_model_name_adds_no_empty_model_key():
+    config_base = _config_base(reasoning_level=None)
+    config_base["models"]["defaults"][0]["model_client_config"].pop("model_name")
+
+    spec = load_team_spec_dict(config_base=config_base)
+
+    for request_config in _request_configs(spec).values():
+        assert "model" not in request_config
+
+
+def test_per_agent_model_override_is_sanitized():
+    """Explicit per-agent overrides bypass the default model path entirely."""
+    config_base = _config_base()
+    config_base["modes"]["team"]["jiuwen_team"]["agents"] = {
+        "leader": {
+            "model": {
+                "model_client_config": {
+                    "model_name": "deepseek-v4-pro",
+                    "api_base": "https://api.deepseek.com",
+                    "api_key": "sk-test",
+                    "client_provider": "DeepSeek",
+                },
+                "model_request_config": {
+                    "temperature": 0.3,
+                    "reasoning_level": "high",
+                },
+            }
+        }
+    }
+
+    spec = load_team_spec_dict(config_base=config_base)
+
+    leader_request = _request_configs(spec)["leader"]
+    assert "reasoning_level" not in leader_request
+    assert leader_request["extra_body"] == {"thinking": {"type": "enabled"}}
+    assert leader_request["reasoning_effort"] == "high"
+    assert leader_request["temperature"] == 0.3
+
+
+def test_openai_reasoning_level_maps_through_the_config_loader():
+    spec = load_team_spec_dict(
+        config_base=_config_base(
+            reasoning_level="medium",
+            model_name="o3-mini",
+            api_base="https://api.openai.com/v1",
+            provider="OpenAI",
+        )
+    )
+
+    for request_config in _request_configs(spec).values():
+        assert "reasoning_level" not in request_config
+        assert request_config["reasoning_effort"] == "medium"
+        assert "thinking" not in request_config
+
+
+def test_detection_uses_the_request_model_id_not_the_client_name():
+    """A DeepSeek client name must not leak its knob onto a different wire model.
+
+    ``model_config_obj["model"]`` overrides the on-the-wire model id (see
+    ``test_explicit_model_in_model_config_obj_keeps_precedence``). Detection
+    must use that same id, not the client's ``model_name``, or a DeepSeek
+    client config paired with a ``gpt-4o`` override would still get
+    ``extra_body.thinking`` injected onto a request that will actually be
+    sent as ``gpt-4o``.
+    """
+    config_base = _config_base(reasoning_level="high")
+    config_base["models"]["defaults"][0]["model_config_obj"]["model"] = "gpt-4o"
+
+    spec = load_team_spec_dict(config_base=config_base)
+
+    for request_config in _request_configs(spec).values():
+        assert request_config["model"] == "gpt-4o"
+        assert "extra_body" not in request_config
+        assert "reasoning_effort" not in request_config
+        assert "reasoning_level" not in request_config
+
+
+def test_detection_uses_the_request_model_id_inverse_case():
+    """A chat client name overridden to a reasoning request id must get the knob."""
+    config_base = _config_base(
+        reasoning_level="medium",
+        model_name="gpt-4o",
+        api_base="https://api.openai.com/v1",
+        provider="OpenAI",
+    )
+    config_base["models"]["defaults"][0]["model_config_obj"]["model"] = "o3-mini"
+
+    spec = load_team_spec_dict(config_base=config_base)
+
+    for request_config in _request_configs(spec).values():
+        assert request_config["model"] == "o3-mini"
+        assert request_config["reasoning_effort"] == "medium"
+        assert "reasoning_level" not in request_config
+
+
+def test_anthropic_reasoning_level_maps_through_the_config_loader():
+    spec = load_team_spec_dict(
+        config_base=_config_base(
+            reasoning_level="high",
+            model_name="claude-sonnet-4-5",
+            api_base="https://api.anthropic.com",
+            provider="Anthropic",
+        )
+    )
+
+    for request_config in _request_configs(spec).values():
+        assert "reasoning_level" not in request_config
+        assert request_config["thinking"] == {
+            "type": "enabled",
+            "budget_tokens": 16000,
+        }
+        assert request_config["max_tokens"] > 16000
+        assert "temperature" not in request_config

--- a/tests/unit_tests/common/test_reasoning_config.py
+++ b/tests/unit_tests/common/test_reasoning_config.py
@@ -1,0 +1,268 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Provider detection and the level tables behind it.
+
+``reasoning_level`` is the product-facing axis. What each provider wants for it
+is not the same shape -- an effort enum, an integer budget, an on/off switch --
+so detection has to name the provider before anything can be mapped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.reasoning_config import (
+    ANTHROPIC_BUDGET_TOKENS,
+    ANTHROPIC_THINKING_MODEL_PREFIXES,
+    OPENAI_REASONING_MODEL_PREFIXES,
+    is_anthropic_thinking_model,
+    is_openai_reasoning_model,
+    normalize_reasoning_level,
+    resolve_reasoning_target,
+)
+
+
+# ------------------------------------------------------------ existing kinds
+
+
+def test_deepseek_official_still_resolves() -> None:
+    """The two kinds that already worked must keep working."""
+    assert resolve_reasoning_target(
+        client_provider="DeepSeek",
+        api_base="https://api.deepseek.com",
+        model_name="deepseek-v4-pro",
+    ) == ("deepseek_official", "deepseek-v4-pro")
+
+
+def test_dashscope_bailian_still_resolves() -> None:
+    assert resolve_reasoning_target(
+        client_provider="DashScope",
+        api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        model_name="deepseek-v4-flash",
+    ) == ("dashscope_bailian", "deepseek-v4-flash")
+
+
+def test_a_deepseek_host_with_an_unsupported_model_does_not_resolve() -> None:
+    assert resolve_reasoning_target(
+        client_provider="DeepSeek",
+        api_base="https://api.deepseek.com",
+        model_name="deepseek-chat",
+    ) is None
+
+
+# ------------------------------------------------------------------- OpenAI
+
+
+@pytest.mark.parametrize("model", ["o1", "o1-mini", "o3", "o3-mini", "o4-mini", "gpt-5", "gpt-5-mini"])
+def test_openai_reasoning_models_are_recognised(model: str) -> None:
+    assert is_openai_reasoning_model(model) is True
+
+
+@pytest.mark.parametrize("model", ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo", "", "  "])
+def test_plain_chat_models_are_not_reasoning_models(model: str) -> None:
+    """Sending reasoning_effort to these is a 400, not a degraded answer."""
+    assert is_openai_reasoning_model(model) is False
+
+
+@pytest.mark.parametrize("model", ["o1lama", "o3pus", "gpt-50"])
+def test_a_prefix_match_needs_a_boundary(model: str) -> None:
+    """``o1`` must not swallow every model whose name starts with those letters."""
+    assert is_openai_reasoning_model(model) is False
+
+
+@pytest.mark.parametrize("model", ["gpt-5.1", "gpt-5.1-mini", "gpt-5.2"])
+def test_dotted_gpt5_ids_are_reasoning_models(model: str) -> None:
+    """OpenAI ships ``gpt-5.1`` with a dot, not a hyphen after the family."""
+    assert is_openai_reasoning_model(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5-chat-latest", "gpt-5-chat", "gpt-5.1-chat-latest", "gpt-5.1-chat"],
+)
+def test_gpt5_chat_variants_are_not_reasoning_models(model: str) -> None:
+    """ChatGPT-instant gpt-5 ids 400 on reasoning_effort, same as gpt-4o."""
+    assert is_openai_reasoning_model(model) is False
+
+
+def test_gpt5_chat_latest_does_not_resolve_as_reasoning_target() -> None:
+    assert resolve_reasoning_target(
+        client_provider="OpenAI",
+        api_base="https://api.openai.com/v1",
+        model_name="gpt-5-chat-latest",
+    ) is None
+
+
+def test_openai_o3_mini_resolves() -> None:
+    assert resolve_reasoning_target(
+        client_provider="OpenAI",
+        api_base="https://api.openai.com/v1",
+        model_name="o3-mini",
+    ) == ("openai_reasoning", "o3-mini")
+
+
+def test_openai_resolves_by_host_without_the_provider_name() -> None:
+    assert resolve_reasoning_target(
+        client_provider="",
+        api_base="https://api.openai.com/v1",
+        model_name="o3-mini",
+    ) == ("openai_reasoning", "o3-mini")
+
+
+def test_gpt4o_does_not_resolve_as_reasoning_target() -> None:
+    assert resolve_reasoning_target(
+        client_provider="OpenAI",
+        api_base="https://api.openai.com/v1",
+        model_name="gpt-4o",
+    ) is None
+
+
+def test_an_openai_compatible_third_party_host_does_not_resolve() -> None:
+    """A local or reseller endpoint is not the OpenAI reasoning API."""
+    assert resolve_reasoning_target(
+        client_provider="OpenAI",
+        api_base="https://my-gateway.internal/v1",
+        model_name="o3-mini",
+    ) is None
+
+
+# ---------------------------------------------------------------- Anthropic
+
+
+def test_anthropic_resolves_by_provider() -> None:
+    assert resolve_reasoning_target(
+        client_provider="Anthropic",
+        api_base="https://api.anthropic.com",
+        model_name="claude-sonnet-4-5",
+    ) == ("anthropic", "claude-sonnet-4-5")
+
+
+def test_anthropic_resolves_by_host_without_the_provider_name() -> None:
+    assert resolve_reasoning_target(
+        client_provider="",
+        api_base="https://api.anthropic.com",
+        model_name="claude-sonnet-4-5",
+    ) == ("anthropic", "claude-sonnet-4-5")
+
+
+def test_anthropic_needs_a_model_name() -> None:
+    assert resolve_reasoning_target(
+        client_provider="Anthropic",
+        api_base="https://api.anthropic.com",
+        model_name="",
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-3-7-sonnet-20250219",
+        "claude-opus-4-20250514",
+        "claude-sonnet-4-5-20250929",
+        "claude-haiku-4-5",
+    ],
+)
+def test_models_with_extended_thinking_are_recognised(model: str) -> None:
+    assert is_anthropic_thinking_model(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-3-5-sonnet-20241022", "claude-3-haiku-20240307", "claude-2.1", "", "  "],
+)
+def test_models_without_extended_thinking_are_refused(model: str) -> None:
+    """Sending a thinking block to these is an error on every request.
+
+    Before the allowlist they resolved, so a level set on Claude 3.5 turned a
+    knob that did nothing into one that broke the conversation.
+    """
+    assert is_anthropic_thinking_model(model) is False
+
+
+def test_a_model_without_extended_thinking_does_not_resolve() -> None:
+    assert resolve_reasoning_target(
+        client_provider="Anthropic",
+        api_base="https://api.anthropic.com",
+        model_name="claude-3-5-sonnet-20241022",
+    ) is None
+
+
+def test_the_thinking_allowlist_is_bounded_above_too() -> None:
+    """A family newer than 4.x prefers adaptive thinking and may reject a budget.
+
+    Getting no thinking is recoverable; every request failing is not, so an
+    unrecognised newer model falls back to sending nothing.
+    """
+    assert is_anthropic_thinking_model("claude-opus-9") is False
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-7",
+        "claude-opus-4-7",
+        "claude-haiku-4-6-20260401",
+    ],
+)
+def test_claude_4_6_and_newer_do_not_get_a_budget(model: str) -> None:
+    """``claude-sonnet-4`` must not swallow 4.6+ IDs that reject budget_tokens."""
+    assert is_anthropic_thinking_model(model) is False
+    assert resolve_reasoning_target(
+        client_provider="Anthropic",
+        api_base="https://api.anthropic.com",
+        model_name=model,
+    ) is None
+
+
+def test_anthropic_is_not_gated_by_the_openai_sdk_provider_set() -> None:
+    """Regression: the old provider allowlist would have refused Anthropic outright."""
+    kind, _ = resolve_reasoning_target(
+        client_provider="anthropic",
+        api_base="",
+        model_name="claude-opus-4-1",
+    ) or (None, None)
+    assert kind == "anthropic"
+
+
+# ------------------------------------------------------------------- tables
+
+
+def test_budget_table() -> None:
+    assert ANTHROPIC_BUDGET_TOKENS["low"] == 1024
+    assert ANTHROPIC_BUDGET_TOKENS["medium"] == 8000
+    assert ANTHROPIC_BUDGET_TOKENS["high"] == 16000
+
+
+def test_the_minimum_budget_is_the_anthropic_floor() -> None:
+    """Anthropic rejects a budget below 1024."""
+    assert min(ANTHROPIC_BUDGET_TOKENS.values()) >= 1024
+
+
+def test_off_has_no_budget() -> None:
+    """``off`` omits thinking entirely; a budget for it would be meaningless."""
+    assert "off" not in ANTHROPIC_BUDGET_TOKENS
+
+
+def test_prefixes_are_lowercase() -> None:
+    assert all(p == p.lower() for p in OPENAI_REASONING_MODEL_PREFIXES)
+    assert all(p == p.lower() for p in ANTHROPIC_THINKING_MODEL_PREFIXES)
+
+
+# ----------------------------------------------------------- normalisation
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("OFF", "off"),
+        ("disabled", "off"),
+        ("enabled", "low"),
+        ("Medium", "medium"),
+        ("HIGH", "high"),
+        ("nonsense", None),
+        (None, None),
+    ],
+)
+def test_level_normalisation_is_unchanged(raw, expected) -> None:
+    assert normalize_reasoning_level(raw) == expected

--- a/tests/unit_tests/common/test_reasoning_injector.py
+++ b/tests/unit_tests/common/test_reasoning_injector.py
@@ -1,0 +1,316 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""What each provider actually receives for a reasoning level.
+
+The contract these pin down is per provider, because there is no shared shape:
+OpenAI takes an effort enum, Anthropic an integer budget, DeepSeek and DashScope
+an on/off switch. The one rule common to all of them is that ``reasoning_level``
+itself -- an internal hint -- must never reach an SDK.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.reasoning_injector import inject_reasoning_params
+
+
+def _inject(client: dict, config: dict) -> dict:
+    return inject_reasoning_params(model_client_config=client, model_config_obj=config)
+
+
+def _deepseek_client() -> dict:
+    return {
+        "client_provider": "DeepSeek",
+        "api_base": "https://api.deepseek.com",
+        "model_name": "deepseek-v4-pro",
+    }
+
+
+def _dashscope_client() -> dict:
+    return {
+        "client_provider": "DashScope",
+        "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "model_name": "deepseek-v4-flash",
+    }
+
+
+def _openai_client(model: str = "o3-mini") -> dict:
+    return {
+        "client_provider": "OpenAI",
+        "api_base": "https://api.openai.com/v1",
+        "model_name": model,
+    }
+
+
+def _anthropic_client(model: str = "claude-sonnet-4-5") -> dict:
+    return {
+        "client_provider": "Anthropic",
+        "api_base": "https://api.anthropic.com",
+        "model_name": model,
+    }
+
+
+# ----------------------------------------------------- the universal rule
+
+
+@pytest.mark.parametrize("level", ["off", "low", "medium", "high"])
+def test_reasoning_level_never_reaches_the_sdk(level: str) -> None:
+    """ModelRequestConfig allows extras, so a leak here becomes a request field."""
+    for client in (_deepseek_client(), _openai_client(), _anthropic_client()):
+        out = _inject(client, {"reasoning_level": level})
+        assert "reasoning_level" not in out
+
+
+def test_an_unresolved_provider_is_left_alone() -> None:
+    out = _inject(
+        {"client_provider": "Ollama", "api_base": "http://localhost:11434", "model_name": "qwen"},
+        {"reasoning_level": "high", "temperature": 0.5},
+    )
+    assert out == {"temperature": 0.5}
+
+
+# ---------------------------------------------------------------- DeepSeek
+
+
+def test_low_does_not_force_reasoning_effort_high() -> None:
+    """Every non-off level used to collapse to effort=high."""
+    out = _inject(_deepseek_client(), {"temperature": 0.2, "reasoning_level": "low"})
+
+    assert out["extra_body"]["thinking"] == {"type": "enabled"}
+    assert "reasoning_effort" not in out
+    assert out["temperature"] == 0.2
+
+
+def test_medium_does_not_force_reasoning_effort_high() -> None:
+    out = _inject(_deepseek_client(), {"reasoning_level": "medium"})
+
+    assert out["extra_body"]["thinking"] == {"type": "enabled"}
+    assert "reasoning_effort" not in out
+
+
+def test_deepseek_high_still_sends_effort_high() -> None:
+    """The one level that always meant effort=high keeps meaning it."""
+    out = _inject(_deepseek_client(), {"reasoning_level": "high"})
+
+    assert out["extra_body"]["thinking"] == {"type": "enabled"}
+    assert out["reasoning_effort"] == "high"
+
+
+def test_deepseek_off_disables_thinking() -> None:
+    out = _inject(_deepseek_client(), {"reasoning_level": "off"})
+
+    assert out["extra_body"]["thinking"] == {"type": "disabled"}
+    assert "reasoning_effort" not in out
+
+
+def test_deepseek_preserves_unrelated_extra_body_keys() -> None:
+    out = _inject(
+        _deepseek_client(),
+        {"reasoning_level": "low", "extra_body": {"custom_option": {"enabled": True}}},
+    )
+
+    assert out["extra_body"]["custom_option"] == {"enabled": True}
+    assert out["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+# --------------------------------------------------------------- DashScope
+
+
+def test_dashscope_low_enables_thinking_without_effort() -> None:
+    out = _inject(_dashscope_client(), {"reasoning_level": "low"})
+
+    assert out["extra_body"]["enable_thinking"] is True
+    assert "reasoning_effort" not in out
+
+
+def test_dashscope_high_still_sends_effort_high() -> None:
+    out = _inject(_dashscope_client(), {"reasoning_level": "high"})
+
+    assert out["extra_body"]["enable_thinking"] is True
+    assert out["reasoning_effort"] == "high"
+
+
+def test_dashscope_off_disables_thinking() -> None:
+    out = _inject(_dashscope_client(), {"reasoning_level": "off"})
+
+    assert out["extra_body"]["enable_thinking"] is False
+
+
+# ------------------------------------------------------------------ OpenAI
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high"])
+def test_openai_maps_the_level_straight_through(level: str) -> None:
+    out = _inject(_openai_client(), {"reasoning_level": level})
+    assert out["reasoning_effort"] == level
+
+
+def test_openai_off_omits_reasoning_effort() -> None:
+    """``none`` is not sent: omitting is what every model accepts."""
+    out = _inject(_openai_client(), {"reasoning_level": "off"})
+    assert "reasoning_effort" not in out
+
+
+def test_openai_off_clears_a_preconfigured_effort() -> None:
+    out = _inject(_openai_client(), {"reasoning_level": "off", "reasoning_effort": "high"})
+    assert "reasoning_effort" not in out
+
+
+def test_openai_chat_model_does_not_get_reasoning_effort() -> None:
+    """gpt-4o 400s on reasoning_effort; the level must be dropped, not applied."""
+    out = _inject(_openai_client("gpt-4o"), {"reasoning_level": "high", "temperature": 0.5})
+
+    assert "reasoning_effort" not in out
+    assert "reasoning_level" not in out
+    assert out["temperature"] == 0.5
+
+
+def test_openai_gpt5_chat_model_does_not_get_reasoning_effort() -> None:
+    """gpt-5-chat-latest is a ChatGPT-instant id and 400s on reasoning_effort."""
+    out = _inject(_openai_client("gpt-5-chat-latest"), {"reasoning_level": "high", "temperature": 0.5})
+
+    assert "reasoning_effort" not in out
+    assert "reasoning_level" not in out
+    assert out["temperature"] == 0.5
+
+
+def test_openai_does_not_touch_thinking() -> None:
+    out = _inject(_openai_client(), {"reasoning_level": "high"})
+    assert "thinking" not in out
+
+
+# --------------------------------------------------------------- Anthropic
+
+
+def test_anthropic_maps_high_to_budget_tokens() -> None:
+    out = _inject(_anthropic_client(), {"reasoning_level": "high", "max_tokens": 32000})
+
+    assert out["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+    assert out["max_tokens"] == 32000
+
+
+@pytest.mark.parametrize(
+    ("level", "budget"), [("low", 1024), ("medium", 8000), ("high", 16000)],
+)
+def test_anthropic_budget_per_level(level: str, budget: int) -> None:
+    out = _inject(_anthropic_client(), {"reasoning_level": level, "max_tokens": 64000})
+    assert out["thinking"]["budget_tokens"] == budget
+
+
+def test_anthropic_off_omits_thinking() -> None:
+    """Omitted, not ``{type: disabled}``: models without thinking reject the field."""
+    out = _inject(_anthropic_client(), {"reasoning_level": "off"})
+    assert "thinking" not in out
+
+
+def test_anthropic_off_clears_a_preconfigured_thinking_block() -> None:
+    out = _inject(
+        _anthropic_client(),
+        {"reasoning_level": "off", "thinking": {"type": "enabled", "budget_tokens": 4096}},
+    )
+    assert "thinking" not in out
+
+
+def test_anthropic_raises_max_tokens_that_cannot_fit_the_budget() -> None:
+    """Anthropic requires budget_tokens < max_tokens, or the request 400s."""
+    out = _inject(_anthropic_client(), {"reasoning_level": "high", "max_tokens": 8000})
+
+    assert out["thinking"]["budget_tokens"] == 16000
+    assert out["max_tokens"] > 16000
+
+
+def test_anthropic_raises_max_tokens_with_only_one_token_of_answer_room() -> None:
+    """budget+1 is accepted by the API and leaves a near-empty reply."""
+    out = _inject(_anthropic_client(), {"reasoning_level": "medium", "max_tokens": 8001})
+
+    assert out["thinking"]["budget_tokens"] == 8000
+    assert out["max_tokens"] - 8000 >= 4096
+
+
+def test_anthropic_coerces_string_max_tokens_instead_of_shrinking_them() -> None:
+    out = _inject(_anthropic_client(), {"reasoning_level": "high", "max_tokens": "32000"})
+
+    assert out["thinking"]["budget_tokens"] == 16000
+    assert out["max_tokens"] == 32000
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high"])
+def test_anthropic_sets_max_tokens_when_it_is_unset(level: str) -> None:
+    """The unset case is the one that looks safe and is not.
+
+    The client substitutes 8192. Against that default ``high`` (16000) is
+    rejected outright, and ``medium`` (8000) is *accepted* with 192 tokens left
+    for the answer -- a reply that reads like the model had nothing to say.
+    """
+    out = _inject(_anthropic_client(), {"reasoning_level": level})
+
+    budget = out["thinking"]["budget_tokens"]
+    assert out["max_tokens"] > budget
+    assert out["max_tokens"] - budget >= 4096, "the answer needs room, not a sliver"
+
+
+def test_anthropic_off_does_not_invent_a_max_tokens() -> None:
+    """No thinking, no reason to override the caller's ceiling."""
+    out = _inject(_anthropic_client(), {"reasoning_level": "off"})
+
+    assert "max_tokens" not in out
+
+
+def test_anthropic_does_not_send_reasoning_effort() -> None:
+    """An OpenAI-only knob on a Messages request is a hard error."""
+    out = _inject(_anthropic_client(), {"reasoning_level": "high"})
+    assert "reasoning_effort" not in out
+
+
+def test_anthropic_clears_a_stale_reasoning_effort() -> None:
+    out = _inject(
+        _anthropic_client(),
+        {"reasoning_level": "high", "reasoning_effort": "medium"},
+    )
+    assert "reasoning_effort" not in out
+
+
+def test_anthropic_drops_incompatible_sampling_knobs_with_thinking() -> None:
+    """Extended thinking rejects non-default temperature and any top_p/top_k."""
+    out = _inject(
+        _anthropic_client(),
+        {
+            "reasoning_level": "high",
+            "temperature": 0.95,
+            "top_p": 0.9,
+            "top_k": 40,
+            "max_tokens": 32000,
+        },
+    )
+
+    assert out["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+    assert "temperature" not in out
+    assert "top_p" not in out
+    assert "top_k" not in out
+
+
+def test_anthropic_off_preserves_sampling_knobs() -> None:
+    out = _inject(
+        _anthropic_client(),
+        {"reasoning_level": "off", "temperature": 0.95, "top_p": 0.9},
+    )
+
+    assert "thinking" not in out
+    assert out["temperature"] == 0.95
+    assert out["top_p"] == 0.9
+
+
+# ---------------------------------------------------------------- no level
+
+
+def test_without_a_level_nothing_is_injected() -> None:
+    out = _inject(_deepseek_client(), {"temperature": 0.4})
+
+    assert out == {"temperature": 0.4}
+
+
+def test_an_unrecognised_level_is_ignored() -> None:
+    out = _inject(_deepseek_client(), {"reasoning_level": "turbo", "temperature": 0.4})
+
+    assert out == {"temperature": 0.4}


### PR DESCRIPTION
Paired: [GitHub #2711](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2711) ↔ [GitCode !4710](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4710)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind feature


**What does this PR do / why do we need it**:
* Replace `LEVEL_MAPPING`, which collapsed `low` / `medium` / `high` into `high`, with per-provider translators for DeepSeek, DashScope, OpenAI, and Anthropic.
* Sanitize team config load so `reasoning_level` never reaches the SDK.
* DeepSeek / DashScope: `off` disables thinking; `low` / `medium` enable thinking without `reasoning_effort`; `high` enables thinking and sets `reasoning_effort=high`.
* OpenAI: map levels to `reasoning_effort` on first-party hosts and allowlisted models.
* Anthropic: map levels to `thinking.budget_tokens`, size `max_tokens` for answer headroom, and drop sampling knobs that conflict with thinking.
* Anthropic runtime still needs agent-core to forward `thinking`. This PR builds the payload; agent-core must land for end-to-end Anthropic support.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2710


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Unit tests: `105 passed`
  * `tests/unit_tests/common/test_reasoning_config.py`
  * `tests/unit_tests/common/test_reasoning_injector.py`
  * `tests/unit_tests/agents/harness/test_team_config_loader_reasoning.py`
* Manual Web + DeepSeek V4 (`api.deepseek.com`, `deepseek-v4-flash`):
  * `reasoning_level=medium` (or non-high): `extra_body.thinking.type=enabled`, no `reasoning_effort`. Chat returned `reasoning_tokens`.
  * `reasoning_level=high`: `thinking.enabled` and `reasoning_effort=high`. Chat returned `reasoning_tokens`.
* Anthropic payload shape is covered by unit tests. End-to-end Anthropic needs the agent-core forward of `thinking`.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [x] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bug Fix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2710
<!-- /bot1-related-issues -->
