### PR TITLE
fix(pdf): disclose partial reads in read_pdf, and make the whole-document read its default

### DIFF
--- a/jiuwenswarm/agents/harness/common/tools/pdf_tools.py
+++ b/jiuwenswarm/agents/harness/common/tools/pdf_tools.py
@@ -139,21 +139,37 @@ def _read_pdf_sync(req: ReadPdfRequest) -> str:
             selected = list(range(1, total_pages + 1))
             out_of_range = []
 
-        truncated_pages = selected[_MAX_PAGES_PER_CALL:]
         selected = selected[:_MAX_PAGES_PER_CALL]
 
         header = [f"PDF: {path.name} | total pages: {total_pages} | reading pages: "
                   + (_format_page_list(selected) if selected else "none")]
+        # The header line above states the subset, but a passive fact is easy to
+        # summarise past: say plainly what is missing and how to get it. Pages go
+        # unread whenever the selection misses them, whether because `pages` named
+        # a subset or because the per-call page cap truncated it, so the disclosure
+        # keys off the pages actually missing rather than off `pages` being passed.
+        chosen = set(selected)
+        skipped = [p for p in range(1, total_pages + 1) if p not in chosen]
+        if skipped:
+            if total_pages <= _MAX_PAGES_PER_CALL:
+                remedy = "Omit `pages` to read the whole document in one call."
+            else:
+                # Above the cap no single call can cover the document, so pointing
+                # at the default read would send the model back here short again.
+                remedy = (
+                    f"At most {_MAX_PAGES_PER_CALL} pages are read per call, so no single "
+                    "call covers this document — call read_pdf again with `pages` starting "
+                    f"at {skipped[0]}."
+                )
+            header.append(
+                f"[Partial read: {len(skipped)} of {total_pages} pages were NOT read "
+                f"(pages {_format_page_list(skipped)}). {remedy} Any answer based on "
+                "this call must state which pages it covers.]"
+            )
         if out_of_range:
             header.append(
                 f"[Note: requested page(s) {_format_page_list(out_of_range)} exceed "
                 f"total page count {total_pages} and were skipped]"
-            )
-        if truncated_pages:
-            header.append(
-                f"[Note: at most {_MAX_PAGES_PER_CALL} pages per call; "
-                f"pages {_format_page_list(truncated_pages)} were not read — "
-                "call read_pdf again with a narrower `pages` range]"
             )
         blocks.append("\n".join(header))
 
@@ -177,13 +193,19 @@ def _read_pdf_sync(req: ReadPdfRequest) -> str:
                 if not truncated_here:
                     continue
                 unread = selected[idx + 1:]
-            note = f"[Truncated at max_chars={req.max_chars}"
+            note = (
+                f"[Truncated at max_chars={req.max_chars}: the rest of the document "
+                "was NOT read"
+            )
             if unread:
                 note += (
                     f"; unread pages: {_format_page_list(unread)} — "
                     "call read_pdf again with `pages` starting there"
                 )
-            note += "]"
+            note += (
+                ". Raise `max_chars` to read more in one call. Any answer based on "
+                "this call must state that the document was read only in part.]"
+            )
             blocks.append(note)
             break
 
@@ -218,10 +240,16 @@ def _format_page_list(pages: list[int] | tuple[int, ...]) -> str:
     description=(
         "Read the text content of a PDF file, optionally limited to specific pages. "
         "Use this tool when a PDF file path is available and its content is needed. "
-        "For large documents, first read page 1 to learn the structure and total "
-        "page count, then read subsequent chunks with the `pages` parameter. "
+        # Interpolated, not spelled out: the description is the only place the
+        # model learns these bounds, so a changed constant must not leave it
+        # stating the old one.
+        f"Omitting `pages` reads the whole document, up to max_chars and {_MAX_PAGES_PER_CALL} pages, "
+        "which is the right default — most documents fit in one call. Only when the return "
+        "reports that pages were left unread, continue with `pages` from the first "
+        "unread page until the document is covered. Any answer based on part of a "
+        "document must state which pages it used. "
         "Input: pdf_path (local file path), optional pages (e.g. 3, '1-5' or '1,3,8-10'), "
-        "optional max_chars (default 50000). Pages without a text layer are reported "
+        f"optional max_chars (default {DEFAULT_MAX_CHARS}). Pages without a text layer are reported "
         "as likely scanned images."
     ),
 )

--- a/tests/unit_tests/agents/test_pdf_tools.py
+++ b/tests/unit_tests/agents/test_pdf_tools.py
@@ -8,6 +8,7 @@ import pytest
 
 from jiuwenswarm.agents.harness.common.tools.pdf_tools import (
     DEFAULT_MAX_CHARS,
+    _MAX_PAGES_PER_CALL,
     _format_page_list,
     _normalize_request,
     _parse_page_ranges,
@@ -91,6 +92,25 @@ def test_parse_page_ranges_rejects_invalid(bad):
         _parse_page_ranges(bad)
 
 
+def test_read_pdf_description_states_the_whole_document_default():
+    """`pages` has no typed schema, so the description carries every hint."""
+    description = read_pdf.card.description
+
+    # The cheap, complete option has to be named as the default.
+    assert "Omitting `pages` reads the whole document" in description
+    # ... but only within the limits that actually bound it, so the default is
+    # not promised for documents the per-call page cap cuts short. Built from
+    # the constants rather than their current values, so raising either one
+    # cannot leave the description quietly stating the old bound.
+    assert f"up to max_chars and {_MAX_PAGES_PER_CALL} pages" in description
+    assert f"max_chars (default {DEFAULT_MAX_CHARS})" in description
+    # Incremental reading is advice for large documents, not an opening move.
+    assert "first read page 1" not in description
+    assert "when the return reports that pages were left unread" in description.lower()
+    # An answer from a subset has to disclose the subset.
+    assert "must state which pages it used" in description
+
+
 def test_format_page_list_compresses_runs():
     assert _format_page_list([1, 2, 3, 7]) == "1-3,7"
     assert _format_page_list([5]) == "5"
@@ -148,6 +168,77 @@ async def test_read_pdf_respects_page_selection(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_read_pdf_subset_discloses_the_pages_it_skipped(tmp_path: Path):
+    pytest.importorskip("pdfplumber")
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(_build_minimal_pdf([f"Page {i} body" for i in range(1, 6)]))
+
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path), "pages": "1-2"}})
+
+    # The page text a caller passing `pages` already got is unchanged.
+    assert "Page 1 body" in result
+    assert "Page 2 body" in result
+    assert "Page 3 body" not in result
+    # ... but the omission is now stated as an instruction, not a passive fact.
+    assert "Partial read: 3 of 5 pages were NOT read" in result
+    assert "pages 3-5" in result
+    assert "Omit `pages` to read the whole document" in result
+    assert "must state which pages it covers" in result
+
+
+@pytest.mark.asyncio
+async def test_read_pdf_discloses_pages_lost_to_the_page_cap(tmp_path: Path):
+    """Omitting `pages` above the per-call page cap is still a partial read.
+
+    The cap truncates the selection whether or not `pages` was passed, so the
+    document's default read — the one the description recommends — is the call
+    most likely to under-report, not the one least likely to.
+    """
+    pytest.importorskip("pdfplumber")
+    pdf_path = tmp_path / "big.pdf"
+    pdf_path.write_bytes(_build_minimal_pdf([f"Page {i} body" for i in range(1, 102)]))
+
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path)}})
+
+    assert "Partial read: 1 of 101 pages were NOT read" in result
+    assert "pages 101" in result
+    assert "must state which pages it covers" in result
+    # Above the cap the whole document does not fit in one call, so the note must
+    # not send the model back to the default read it has just made.
+    assert "Omit `pages` to read the whole document" not in result
+    assert "call read_pdf again with `pages` starting at 101" in result
+
+
+@pytest.mark.asyncio
+async def test_read_pdf_page_cap_remedy_points_past_a_subset(tmp_path: Path):
+    """A subset of an over-cap document may not advise omitting `pages` either."""
+    pytest.importorskip("pdfplumber")
+    pdf_path = tmp_path / "big.pdf"
+    pdf_path.write_bytes(_build_minimal_pdf([f"Page {i} body" for i in range(1, 102)]))
+
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path), "pages": "1-2"}})
+
+    assert "Partial read: 99 of 101 pages were NOT read" in result
+    assert "Omit `pages` to read the whole document" not in result
+    assert "call read_pdf again with `pages` starting at 3" in result
+
+
+@pytest.mark.asyncio
+async def test_read_pdf_full_read_adds_no_partial_note(tmp_path: Path):
+    pytest.importorskip("pdfplumber")
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(_build_minimal_pdf(["Alpha", "Bravo", "Charlie"]))
+
+    # Default (no `pages`) reads everything, so there is nothing to disclose.
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path)}})
+    assert "Partial read" not in result
+
+    # An explicit range that happens to cover the document is a full read too.
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path), "pages": "1-3"}})
+    assert "Partial read" not in result
+
+
+@pytest.mark.asyncio
 async def test_read_pdf_truncates_at_max_chars(tmp_path: Path):
     pytest.importorskip("pdfplumber")
     long_text = "word " * 500  # ~2500 chars on one page
@@ -161,6 +252,25 @@ async def test_read_pdf_truncates_at_max_chars(tmp_path: Path):
     assert "Tail page" not in result
     # Truncation must list the unread pages so the model can continue in chunks
     assert "unread pages: 2" in result
+    # ... and say the read was partial, the same blind spot as a page subset.
+    assert "the rest of the document was NOT read" in result
+    assert "Raise `max_chars` to read more in one call" in result
+    assert "read only in part" in result
+
+
+@pytest.mark.asyncio
+async def test_read_pdf_discloses_truncation_of_a_single_page(tmp_path: Path):
+    pytest.importorskip("pdfplumber")
+    pdf_path = tmp_path / "one.pdf"
+    pdf_path.write_bytes(_build_minimal_pdf([("word " * 500).strip()]))
+
+    # No page is left unread here, so only the max_chars cut-off is disclosed.
+    result = await read_pdf.invoke(
+        {"inputs": {"pdf_path": str(pdf_path), "max_chars": 1000}}
+    )
+    assert "the rest of the document was NOT read" in result
+    assert "unread pages" not in result
+    assert "read only in part" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Paired: [GitHub #2720](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2720) ↔ [GitCode !4715](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4715)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

`read_pdf` supports a `pages` subset so large documents can be read in chunks. Two properties of its contract combine so that a model reads a fraction of a document and then answers as though it had read all of it: the description prescribes a partial first read unconditionally and never mentions that omitting `pages` reads the whole document, and the return states the subset only as a passive metadata line.

Neither is an extraction defect. Both are contract defects, and together they produce a confidently incomplete answer in which no individual statement is false. Seen in production: a document was read as a three-page subset and summarised as "the paper", with no mention of coverage. Its full extracted text fitted well inside the default `max_chars` of 50,000 — the whole document would have been returned in one call, untruncated, had `pages` simply been omitted. `max_chars` was never passed, so the model never chose a budget; it chose a page subset, which is what the description told it to do first.

The two halves are fixed together, because either alone leaves the contract inconsistent: a return that discloses unread pages is only actionable if the description says a whole-document read was available, and a description that recommends the whole-document read is only safe if the return says when that read fell short.

---

### The return: state the pages that were not read

The return already disclosed the subset — `PDF: <name> | total pages: N | reading pages: 1-3`. That is accurate, and it is why this is a disclosure problem rather than silent data loss. But it reads as metadata about the call rather than as a limit on any answer drawn from it: it never says how many pages went unread, that a complete read was available in one call, or that an answer must state its coverage.

A read that leaves pages unread now appends, directly under that line:

```
[Partial read: 12 of 15 pages were NOT read (pages 4-15). Omit `pages` to read
the whole document in one call. Any answer based on this call must state which
pages it covers.]
```

The note is emitted whenever the selection actually leaves pages unread, whatever caused it. That is deliberately **not** the same as "`pages` was passed". Pages go unread by two mechanisms:

- a `pages` argument naming a subset, and
- the per-call cap of 100 pages, which truncates the selection **whether or not `pages` was given**.

Keying the note off the argument would leave the default whole-document call on a document above the cap — the very call the description below recommends — reporting no partial read at all. It is emitted only when pages are genuinely missing, so a full read, whether by omitting `pages` or by passing a range that covers the document, still adds no noise.

The remedy sentence is likewise conditioned on the document rather than the argument. Advising that `pages` be omitted to read everything in one call is only true at or below the cap; above it, no single call covers the document, so the note names the cap and points at the first unread page instead:

```
PDF: big.pdf | total pages: 101 | reading pages: 1-100
[Partial read: 1 of 101 pages were NOT read (pages 101). At most 100 pages are
read per call, so no single call covers this document — call read_pdf again with
`pages` starting at 101. Any answer based on this call must state which pages it
covers.]
```

This subsumes the previous standalone per-call-cap note, which listed a subset of the same missing pages and offered "a narrower `pages` range" as the remedy. The two are merged into the single partial-read block above: one statement of what went unread and one way to obtain it, rather than two overlapping notes leaving the reader to reconcile them. The out-of-range note (pages requested beyond the end of the document) is a different concern — invalid input rather than incomplete coverage — and stays separate.

The `max_chars` cut-off had the same blind spot: it announced the truncation and listed the unread pages, but never said the answer would be partial, and said nothing about coverage at all when the cut-off fell inside the last selected page, leaving no unread pages to list. Its note becomes:

```
[Truncated at max_chars=1000: the rest of the document was NOT read; unread
pages: 2 — call read_pdf again with `pages` starting there. Raise `max_chars` to
read more in one call. Any answer based on this call must state that the
document was read only in part.]
```

The `unread pages:` clause and its wording are unchanged, so anything keying on it still matches.

The set of pages actually read is built once before the scan that computes what is missing, rather than inside its filter. Rebuilding it per candidate page makes the scan cost proportional to the document length times the per-call cap instead of to the document length; on a 20,000-page document that measured 22.1 ms against 0.5 ms, a factor of about 41. The two forms are equivalent, and the emitted notes are byte-identical for subset, full, over-cap and out-of-range reads.

### The description: name the whole-document read as the default

The schema `read_pdf` exposes to the model is an opaque `inputs` object with `additionalProperties` and no typed members, so `pages` and `max_chars` never appear as parameters with defaults. Every hint about them comes from the prose description, which said:

> For large documents, first read page 1 to learn the structure and total page count, then read subsequent chunks with the `pages` parameter.

That prescribes a partial first read unconditionally — "for large documents" is not a condition the model can evaluate before the first call, since page count is precisely what it does not yet know. It never prescribes reading the subsequent chunks, so the sequence has no defined end and stopping after the first is consistent with it. And it never mentions that omitting `pages` reads the whole document, so the cheapest and most complete call is the one option the description does not offer.

Replaced by:

> Omitting `pages` reads the whole document, up to max_chars and 100 pages, which is the right default — most documents fit in one call. Only when the return reports that pages were left unread, continue with `pages` from the first unread page until the document is covered. Any answer based on part of a document must state which pages it used.

The incremental-read advice is now conditioned on an observable signal — the return reporting unread pages, which the change above makes explicit — rather than on an unknowable size judgement, and it names a terminating condition.

The default is qualified by **both** limits that bound it, not just `max_chars`. Omitting `pages` reads at most 100 pages, so above the cap it is not a whole-document read; promising one unqualified would overpromise on precisely the documents whose return has to report a partial read.

Both bounds are interpolated from the constants that enforce them rather than written out as literals. The description is the only place the model learns either limit, so a raised cap or default would otherwise leave it confidently stating a bound the code no longer applies — a silent lie of exactly the kind this PR is about. The test asserts them the same way, built from the constants, so it cannot pass while the description has drifted and needs no edit when either constant changes.

---

### Behaviour changes

- None for extraction. The text returned for any given `pages` argument is byte-identical; only the header and note blocks differ.
- None from the unread-page scan being hoisted out of its filter; it is a cost change only, verified by diffing the full returns for subset, full, over-cap and out-of-range reads before and after.
- A read that leaves pages unread receives one additional header line, and loses the separate per-call-cap line that is now folded into it.
- The `max_chars` note is longer, and is now also informative when no pages were left entirely unread.

**Which issue(s) this PR fixes**:

Fixes #2719

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Six tests added to `tests/unit_tests/agents/test_pdf_tools.py`, alongside the existing PDF fixtures:

- A subset read of a 5-page document discloses that 3 of 5 pages went unread, names them, and carries both the "omit `pages`" and the state-your-coverage instructions — while the page text for pages 1-2 is unchanged and page 3 is still absent, confirming extraction is untouched.
- A 101-page document read with `pages` **omitted** discloses that page 101 went unread and must state its coverage. This is the regression test for the gating defect: it fails if the note is keyed off `pages` having been passed.
- A 101-page document read as `pages: "1-2"` gets a remedy pointing at page 3 rather than the "omit `pages`" advice, which above the cap would send the model back to a call that is still short.
- A full read adds no partial-read note, both by omitting `pages` and by passing a range that covers the document, so the common path gains no noise.

**Five of these six fail against the unfixed tree; one does not, by design.** The subset disclosure, the two page-cap cases and both `max_chars` cases fail before the change, on the assertion rather than at setup, so each is a genuine regression test for a behaviour that was absent. The full-read case passes both before and after: it exists to catch the note firing when nothing is missing, which is a failure mode the fix could introduce but the unfixed tree never had. It is a guard against over-firing, not evidence that the fix works, and it is the test that would fail if a later change keyed the note off `pages` having been passed instead of off the pages actually missing. Counting it among the proofs would overstate the verification by one.
- The existing `max_chars` truncation test is extended to assert the new coverage wording, and still asserts the unchanged `unread pages: 2` clause.
- A single-page document truncated at `max_chars` discloses the cut-off with no unread pages to list — the case that previously said nothing about coverage.

The description is asserted directly against `read_pdf.card.description`: it must state the whole-document default, must qualify that default by both the `max_chars` default and the per-call page cap — asserted by interpolating those constants, so the test tracks them instead of pinning their present values — must no longer instruct an unconditional "first read page 1", and must require an answer from a subset to name its pages.

The production scenario was reproduced against a synthetic 15-page document, whose first block is now:

```
PDF: demo15.pdf | total pages: 15 | reading pages: 1-3
[Partial read: 12 of 15 pages were NOT read (pages 4-15). Omit `pages` to read the whole document in one call. Any answer based on this call must state which pages it covers.]
```

Full unit suite: **5574 passed, 5 failed, 16 skipped**. The same 5 fail on `develop` before this branch — compared test-by-test rather than by count — so there is no regression. The delta of 6 passing tests is exactly the 6 added here. Four desktop test modules skip at import in both runs, on a missing `webview` dependency unrelated to this change.

The failure mode itself is a model behaviour and cannot be asserted in a unit test. The tests therefore pin the contract the model is given — what the return says and what the description instructs — rather than the summary it produces.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

**Special notes for your reviewers**:

#2529 (`bug: Improve PDF and XSLX files handling`) also touches `pdf_tools.py`, on rendering quality — embedded images, table and multi-column formatting, and an XLSX double-extraction bug. It does not change partial-read or `max_chars` disclosure, and it adds a typed `input_params` schema for `read_pdf`, which is a complementary improvement to the same opaque-schema weakness described above.

**The two PRs do conflict, and the conflict cannot be resolved mechanically.** #2529 preserves the *"For large documents, first read page 1 to learn the structure and total page count, then read subsequent chunks with the `pages` parameter"* sentence verbatim, while this PR deliberately deletes it. Both therefore edit the same `description=` hunk, in opposing directions. Whoever merges second must resolve it **semantically**, not by taking either side wholesale: a naive resolution — in particular "keep both" or "accept incoming" — silently reinstates the sentence this PR removes and reintroduces the reported behaviour, with the rest of the fix still in place and appearing to have landed. The correct resolution keeps #2529's typed `input_params` schema **and** this PR's replacement description text.

This branch is rebased onto the current develop tip (2cc2048b7) and merges into it cleanly. No commit on develop has touched either file here since the work began, so the two files are byte-identical to the tip apart from this change.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2719
<!-- /bot1-related-issues -->

