### PR TITLE
fix(channel): support wildcard patterns in allow_from

### DIFF
--- a/jiuwenswarm/gateway/channel_manager/base.py
+++ b/jiuwenswarm/gateway/channel_manager/base.py
@@ -2,6 +2,7 @@
 
 import logging
 import asyncio
+import fnmatch
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -177,14 +178,13 @@ class BaseChannel(ABC):
         if not allow_list:
             return True
 
-        sender_str = str(sender_id)
-        if sender_str in allow_list:
-            return True
-        if "|" in sender_str:
-            for part in sender_str.split("|"):
-                if part and part in allow_list:
-                    return True
-        return False
+        sender_parts = [part for part in str(sender_id).split("|") if part]
+        patterns = [str(pattern) for pattern in allow_list if pattern is not None]
+        return any(
+            fnmatch.fnmatchcase(sender_part, pattern)
+            for sender_part in sender_parts
+            for pattern in patterns
+        )
 
     async def _handle_message(
             self,

--- a/tests/unit_tests/channel/test_base_channel.py
+++ b/tests/unit_tests/channel/test_base_channel.py
@@ -1,0 +1,50 @@
+"""Unit tests for shared channel behavior."""
+
+from dataclasses import dataclass, field
+
+from jiuwenswarm.gateway.channel_manager.base import BaseChannel, RobotMessageRouter
+
+
+@dataclass
+class _Config:
+    allow_from: list[str] = field(default_factory=list)
+
+
+class _Channel(BaseChannel):
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+
+def _channel(patterns: list[str]) -> _Channel:
+    return _Channel(_Config(patterns), RobotMessageRouter())
+
+
+def test_empty_allow_list_allows_everyone() -> None:
+    assert _channel([]).is_allowed("any-user")
+
+
+def test_exact_match_is_preserved() -> None:
+    channel = _channel(["user-123"])
+
+    assert channel.is_allowed("user-123")
+    assert not channel.is_allowed("user-1234")
+
+
+def test_shell_style_wildcards_match_complete_sender_id() -> None:
+    channel = _channel(["team-*-admin", "user-??", "bot-[ab]"])
+
+    assert channel.is_allowed("team-east-admin")
+    assert channel.is_allowed("user-42")
+    assert channel.is_allowed("bot-a")
+    assert not channel.is_allowed("prefix-team-east-admin")
+    assert not channel.is_allowed("bot-c")
+
+
+def test_composite_sender_matches_each_part() -> None:
+    channel = _channel(["staff-*"])
+
+    assert channel.is_allowed("chat-1|staff-007")
+    assert not channel.is_allowed("chat-1|guest-007")


### PR DESCRIPTION
/kind bug

**What does this PR do / why do we need it**:

Support shell-style wildcard patterns in channel `allow_from` while preserving exact matching and pipe-delimited composite sender IDs. Add shared `BaseChannel` regression tests for empty allow lists, exact matching, `*` / `?` / character-class patterns, full-string behavior, and composite senders.

**Which issue(s) this PR fixes**:

Fixes #2922

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- `python -m py_compile jiuwenswarm/gateway/channel_manager/base.py tests/unit_tests/channel/test_base_channel.py` — passed.
- The targeted pytest suite could not be executed in the local bundled Python runtime because pytest is not installed; regression tests are included for CI.

**Self-checklist**:

- [ ] **Design**: Maintainer review pending.
- [x] **Test**: Regression test cases are included in this PR.
- [x] **Verification**: Expected behavior and local verification are documented above.
- [x] **Interface**: No external API change.
- [x] **Document**: No documentation change required.
