### PR TITLE
fix(swarm): honor runtime memory and browser gates

### DIFF
--- a/jiuwenswarm/agents/swarm/config_specs.py
+++ b/jiuwenswarm/agents/swarm/config_specs.py
@@ -42,6 +42,7 @@ from openjiuwen.harness.rails import SkillUseRail
 from jiuwenswarm.agents.harness.common.browser_defaults import (
     DEFAULT_BROWSER_AGENT_MAX_ITERATIONS,
 )
+from jiuwenswarm.agents.harness.common.memory.config import is_memory_enabled
 from jiuwenswarm.common.config import (
     ASCEND_AFFINITY_PROVIDER,
     get_default_model_provider,
@@ -424,7 +425,7 @@ def _team_common_rail_names(role: str) -> tuple[str, ...]:
     return _COMMON_RAIL_NAMES
 
 
-def _code_base_rail_names(role: str) -> tuple[str, ...]:
+def _code_base_rail_names(config: dict[str, Any], role: str) -> tuple[str, ...]:
     """Code-profile rails minus permission interrupt; leaders omit code todo planning.
 
     ``PERMISSION_INTERRUPT`` is excluded for all team members: it relies on a
@@ -435,6 +436,9 @@ def _code_base_rail_names(role: str) -> tuple[str, ...]:
         name for name in _CODE_RAIL_NAMES
         if name != registry.PERMISSION_INTERRUPT
     )
+    if not is_memory_enabled("code", config):
+        memory_rails = {registry.CODE_PROJECT_MEMORY, registry.CODE_CODING_MEMORY}
+        names = tuple(name for name in names if name not in memory_rails)
     if role == "leader":
         return tuple(name for name in names if name != registry.CODE_TASK_PLANNING)
     return names
@@ -549,7 +553,7 @@ def _build_code_capability_specs(
 
     rails_specs: list[RailSpec] = [
         RailSpec(type=name, params=_rail_params(name, config))
-        for name in _code_base_rail_names(role)
+        for name in _code_base_rail_names(config, role)
     ]
 
     if is_team_plan_leader:
@@ -703,6 +707,22 @@ def _is_explore_subagent(spec: Any) -> bool:
     )
 
 
+def _is_browser_subagent(spec: Any) -> bool:
+    """Return whether *spec* declares any browser sub-agent shape.
+
+    Base specs and provider-backed specs do not share one identity field.  In
+    particular, the code adapter's base spec can carry a legacy browser entry
+    even when ``react.subagents.browser_agent.enabled`` is false.  Treat the
+    config-derived list as authoritative by recognizing all supported shapes
+    before merging.
+    """
+    return (
+        getattr(spec, "subagent_type", None) == "browser_agent"
+        or getattr(spec, "factory_name", None) == registry.SWARM_BROWSER_AGENT
+        or getattr(getattr(spec, "agent_card", None), "name", None) == "browser_agent"
+    )
+
+
 def build_member_subagent_specs(
     config: dict[str, Any],
     mode: str,
@@ -832,14 +852,14 @@ def build_member_deep_agent_spec(
                 spec for spec in merged_subagents
                 if not _is_explore_subagent(spec)
             ]
-        # Remove any browser_agent from base_spec to prevent the shared
-        # playwright_official_stdio entry from co-existing with our isolated one.
-        if team_browser_spec or any(
-            getattr(s, "subagent_type", None) == "browser_agent" for s in subagent_specs
-        ):
+        # Code-team config is authoritative for browser availability.  Strip
+        # the adapter's hard-coded base browser even when the configured gate
+        # is false; otherwise disabling it only omits the replacement while the
+        # legacy shared browser silently survives the merge.
+        if _is_code_mode(mode) or team_browser_spec:
             merged_subagents = [
                 s for s in merged_subagents
-                if getattr(s, "subagent_type", None) != "browser_agent"
+                if not _is_browser_subagent(s)
             ]
         if team_browser_spec:
             merged_subagents.append(team_browser_spec)

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_code.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_code.py
@@ -552,12 +552,13 @@ class JiuwenSwarmCodeAdapter(JiuWenSwarmDeepAdapter):
             root_path=self._workspace_dir or "./",
             language=self._resolve_runtime_language(),
         )
-        _set_workspace_coding_memory_directory(
-            workspace,
-            project_dir=self._project_dir or self._workspace_dir,
-            agent_workspace_dir=self._agent_workspace_dir,
-            description="Coding Agent 记忆模块",
-        )
+        if is_memory_enabled("code", config_base):
+            _set_workspace_coding_memory_directory(
+                workspace,
+                project_dir=self._project_dir or self._workspace_dir,
+                agent_workspace_dir=self._agent_workspace_dir,
+                description="Coding Agent 记忆模块",
+            )
 
         self._instance = create_deep_agent(
             model=model,
@@ -1571,11 +1572,12 @@ class JiuwenSwarmCodeAdapter(JiuWenSwarmDeepAdapter):
         tool_cards = self.build_code_tool_cards(agent_id)
         added_tools = _merge_tool_cards(agent, tool_cards)
 
-        _set_coding_memory_directory(
-            agent,
-            initial_workspace,
-            self._agent_workspace_dir,
-        )
+        if is_memory_enabled("code", config_base):
+            _set_coding_memory_directory(
+                agent,
+                initial_workspace,
+                self._agent_workspace_dir,
+            )
 
         rails = self._build_agent_rails(react_config, config_base, mode="code")
         added_rails = sum(1 for rail in rails if _queue_rail_if_missing(agent, rail))

--- a/tests/agents/swarm/test_swarm_assembly.py
+++ b/tests/agents/swarm/test_swarm_assembly.py
@@ -2580,6 +2580,32 @@ def test_browser_subagent_spec_excluded_when_disabled() -> None:
         assert all(s.factory_name != SWARM_BROWSER_AGENT for s in subs)
 
 
+def test_code_team_browser_gate_removes_legacy_base_spec_when_disabled() -> None:
+    """A false browser gate must not retain the adapter's base browser."""
+    from openjiuwen.agent_teams.schema.deep_agent_spec import SubAgentSpec
+    from openjiuwen.core.single_agent import AgentCard
+
+    shared_browser = SubAgentSpec(
+        agent_card=AgentCard(name="browser_agent"),
+        system_prompt="",
+        subagent_type="browser_agent",
+    )
+    base = DeepAgentSpec(
+        subagents=[shared_browser],
+        workspace=WorkspaceSpec(root_path="/tmp/ws"),
+    )
+    config = {"react": {"subagents": {"browser_agent": {"enabled": False}}}}
+
+    spec = build_member_deep_agent_spec(config, "code.team", "leader", base)
+
+    assert all(
+        getattr(item, "subagent_type", None) != "browser_agent"
+        and getattr(item, "factory_name", None) != SWARM_BROWSER_AGENT
+        and getattr(getattr(item, "agent_card", None), "name", None) != "browser_agent"
+        for item in (spec.subagents or [])
+    )
+
+
 def test_browser_subagent_provider_skips_without_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem
A cold/recovered `code.team` member could retain browser subagent specs even when runtime config disabled them, and the team assembly path did not consistently honor the memory gate. Scheduled reviewers could therefore inherit unintended delegation state and be cancelled before persisting their vote.

## Change
- gate memory assembly through the consumed runtime setting;
- recognize and remove both current and legacy browser subagent specs when disabled;
- keep enabled browser behavior unchanged;
- add assembly coverage for the legacy-spec removal path.

## Validation
- browser/subagent gate tests: 7 passed;
- live isolated JiuwenSwarm run completed the full reward-guided task graph;
- complementary fail-closed vote lifecycle is proposed in openJiuwen-ai/agent-core#724.

The changes are runtime-boundary fixes and do not add game-domain behavior to JiuwenSwarm.