### PR TITLE
fix(web_fetch): 区分访问失败与无结果, GitHub 仓库搜索改走 JSON API

### DIFF
--- a/jiuwenswarm/agents/harness/common/tools/web_fetch_tools.py
+++ b/jiuwenswarm/agents/harness/common/tools/web_fetch_tools.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 import re
 from html import unescape
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlparse
 
 import requests
 import urllib3
@@ -188,6 +188,35 @@ def _normalize_url(url: str) -> str:
     return f"https://{decoded}"
 
 
+def _github_search_api_url(url: str) -> str | None:
+    """Rewrite GitHub repository-search HTML pages to the public JSON API.
+
+    github.com/search is a client-rendered (JS) page: a plain HTTP fetch only
+    receives the SPA shell, so agents cannot see any results. The public search
+    API (api.github.com/search/repositories) returns plain JSON and works
+    without a browser. Only ``type=repositories`` (or no type) is rewritten;
+    other tabs (issues, pull requests, ...) keep their original URL.
+    """
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    host = parsed.netloc.lower()
+    if host not in {"github.com", "www.github.com"} or parsed.path != "/search":
+        return None
+    query = parse_qs(parsed.query)
+    q = (query.get("q") or [""])[0]
+    if not q:
+        return None
+    search_type = (query.get("type") or [""])[0].lower()
+    if search_type and search_type != "repositories":
+        return None
+    try:
+        per_page = min(max(int((query.get("per_page") or ["10"])[0]), 1), 30)
+    except (TypeError, ValueError):
+        per_page = 10
+    return f"https://api.github.com/search/repositories?q={quote(q)}&per_page={per_page}"
+
+
 def _fetch_via_jina_reader_sync(url: str, timeout_seconds: int) -> dict[str, str | int]:
     reader_url = f"https://r.jina.ai/{url}"
     response = _http_get(reader_url, headers=_REQUEST_HEADERS, timeout=timeout_seconds)
@@ -201,7 +230,19 @@ def _fetch_via_jina_reader_sync(url: str, timeout_seconds: int) -> dict[str, str
 
 
 def _fetch_webpage_sync(url: str, timeout_seconds: int) -> dict[str, str | int]:
-    response = _http_get(url, headers=_REQUEST_HEADERS, timeout=timeout_seconds)
+    api_url = _github_search_api_url(url)
+    if api_url:
+        url = api_url
+    try:
+        response = _http_get(url, headers=_REQUEST_HEADERS, timeout=timeout_seconds)
+    except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as exc:
+        # Network-level failures: try the reader fallback before giving up.
+        try:
+            return _fetch_via_jina_reader_sync(url, timeout_seconds)
+        except Exception:
+            # Preserve the original network error; suppress the Jina fallback
+            # failure from the traceback (it is a best-effort retry only).
+            raise exc from None
     if response.status_code in {401, 403, 429}:
         return _fetch_via_jina_reader_sync(url, timeout_seconds)
     response.raise_for_status()
@@ -226,12 +267,28 @@ def _fetch_webpage_sync(url: str, timeout_seconds: int) -> dict[str, str | int]:
     }
 
 
+def _classify_fetch_error(exc: Exception) -> str:
+    """Classify fetch failures so agents can tell access errors from empty results."""
+    if isinstance(exc, requests.exceptions.Timeout):
+        return "timeout"
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        return "connection"
+    if isinstance(exc, requests.exceptions.HTTPError):
+        return "http_error"
+    if isinstance(exc, requests.exceptions.RequestException):
+        return "request"
+    return "unknown"
+
+
 @tool(
     name="mcp_fetch_webpage",
     description=(
         "Fetch webpage text content from URL. Returns status/title/plain text content. "
         "Set max_chars=0 to disable output clipping. "
-        "Use a larger timeout_seconds for slow websites."
+        "Use a larger timeout_seconds for slow websites. "
+        "A result starting with [FETCH_ERROR: <category>] means the page could NOT be "
+        "ACCESSED (network/HTTP failure), not that the content does not exist — try an "
+        "alternative source (API endpoint, search engine) before concluding absence."
     ),
 )
 async def mcp_fetch_webpage(url: str, max_chars: int = 0, timeout_seconds: int = 30) -> str:
@@ -259,6 +316,14 @@ async def mcp_fetch_webpage(url: str, max_chars: int = 0, timeout_seconds: int =
 
     try:
         data = await asyncio.to_thread(_fetch_webpage_sync, url, timeout_seconds)
+    except requests.exceptions.RequestException as exc:
+        category = _classify_fetch_error(exc)
+        return (
+            f"[FETCH_ERROR: {category}] failed to fetch webpage: {exc}\n"
+            "This is an ACCESS failure (network/HTTP), not an empty result. "
+            "Retry with an alternative source (API endpoint, search engine) "
+            "before concluding the content does not exist."
+        )
     except Exception as exc:
         return f"[ERROR]: failed to fetch webpage: {exc}"
 

--- a/tests/unit_tests/agents/test_web_fetch_tools.py
+++ b/tests/unit_tests/agents/test_web_fetch_tools.py
@@ -1,0 +1,241 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+from jiuwenswarm.agents.harness.common.tools.web_fetch_tools import (
+    _classify_fetch_error,
+    _fetch_via_jina_reader_sync,
+    _github_search_api_url,
+    mcp_fetch_webpage,
+)
+
+
+def _run(coro) -> str:
+    return asyncio.run(coro)
+
+
+def _call(url: str, max_chars: int = 0, timeout_seconds: int = 30) -> str:
+    """调用 @tool 包装后的底层 async 函数(mcp_fetch_webpage._func)。"""
+    return _run(mcp_fetch_webpage._func(url, max_chars=max_chars, timeout_seconds=timeout_seconds))
+
+
+def _fake_response(
+    body: bytes,
+    *,
+    status_code: int = 200,
+    content_type: str = "text/html",
+    url: str = "https://example.com/",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        status_code=status_code,
+        headers={"Content-Type": content_type},
+        content=body,
+        encoding="utf-8",
+        apparent_encoding="utf-8",
+        url=url,
+        raise_for_status=lambda: None,
+    )
+
+
+# ── _github_search_api_url ─────────────────────────────────────────
+
+
+class TestGithubSearchApiUrl:
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            (
+                "https://github.com/search?q=deepseek+harness&type=repositories",
+                "https://api.github.com/search/repositories?q=deepseek%20harness&per_page=10",
+            ),
+            (
+                "https://github.com/search?q=deepseek+harness",
+                "https://api.github.com/search/repositories?q=deepseek%20harness&per_page=10",
+            ),
+            (
+                "https://www.github.com/search?q=foo&type=repositories&per_page=5",
+                "https://api.github.com/search/repositories?q=foo&per_page=5",
+            ),
+            # 中文/特殊字符必须 URL 编码
+            (
+                "https://github.com/search?q=量化+因子&type=repositories",
+                "https://api.github.com/search/repositories?q=%E9%87%8F%E5%8C%96%20%E5%9B%A0%E5%AD%90&per_page=10",
+            ),
+        ],
+    )
+    def test_rewrites_repository_search(self, url: str, expected: str) -> None:
+        assert _github_search_api_url(url) == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com/search?q=foo&type=issues",
+            "https://github.com/search?q=foo&type=pullrequests",
+            "https://github.com/search",  # 缺 q
+            "https://example.com/search?q=foo&type=repositories",
+            "https://github.com/notsearch?q=foo",
+            "https://api.github.com/search/repositories?q=foo",
+        ],
+    )
+    def test_does_not_rewrite_other_urls(self, url: str) -> None:
+        assert _github_search_api_url(url) is None
+
+    def test_per_page_clamped_to_30(self) -> None:
+        url = "https://github.com/search?q=foo&type=repositories&per_page=999"
+        assert _github_search_api_url(url) == (
+            "https://api.github.com/search/repositories?q=foo&per_page=30"
+        )
+
+
+# ── mcp_fetch_webpage: GitHub search 重写生效 ─────────────────────
+
+
+class TestFetchWebpageGithubRewrite:
+    def test_github_search_goes_to_api(self, monkeypatch) -> None:
+        captured: list[str] = []
+
+        def fake_get(url, **kwargs) -> SimpleNamespace:
+            captured.append(url)
+            return _fake_response(
+                b'{"total_count": 1, "items": [{"full_name": "a/b"}]}',
+                content_type="application/json",
+            )
+
+        monkeypatch.setattr("jiuwenswarm.agents.harness.common.tools.web_fetch_tools._http_get", fake_get)
+        result = _call("https://github.com/search?q=deepseek+harness&type=repositories")
+        assert captured == ["https://api.github.com/search/repositories?q=deepseek%20harness&per_page=10"]
+        assert "a/b" in result
+
+
+# ── mcp_fetch_webpage: 错误分类 ────────────────────────────────────
+
+
+class TestFetchErrorClassification:
+    def test_timeout_returns_fetch_error_category(self, monkeypatch) -> None:
+        def fail_get(url, **kwargs):
+            raise requests.exceptions.Timeout("timed out")
+
+        def fail_jina(url, timeout_seconds):
+            raise requests.exceptions.Timeout("jina also timed out")
+
+        monkeypatch.setattr("jiuwenswarm.agents.harness.common.tools.web_fetch_tools._http_get", fail_get)
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.web_fetch_tools._fetch_via_jina_reader_sync",
+            fail_jina,
+        )
+        result = _call("https://example.com/page")
+        assert result.startswith("[FETCH_ERROR: timeout]")
+
+    def test_connection_error_category(self, monkeypatch) -> None:
+        def fail_get(url, **kwargs):
+            raise requests.exceptions.ConnectionError("connection refused")
+
+        monkeypatch.setattr("jiuwenswarm.agents.harness.common.tools.web_fetch_tools._http_get", fail_get)
+        result = _call("https://example.com/page")
+        assert result.startswith("[FETCH_ERROR: connection]")
+
+    def test_http_error_category(self, monkeypatch) -> None:
+        def bad_response(url, **kwargs) -> SimpleNamespace:
+            response = _fake_response(b"nope", status_code=500)
+
+            def raise_for_status():
+                raise requests.exceptions.HTTPError("500 Server Error")
+
+            response.raise_for_status = raise_for_status
+            return response
+
+        monkeypatch.setattr("jiuwenswarm.agents.harness.common.tools.web_fetch_tools._http_get", bad_response)
+        result = _call("https://example.com/page")
+        assert result.startswith("[FETCH_ERROR: http_error]")
+
+    def test_classify_fetch_error_unknown(self) -> None:
+        assert _classify_fetch_error(ValueError("boom")) == "unknown"
+
+
+# ── mcp_fetch_webpage: 降级链 ──────────────────────────────────────
+
+
+class TestFetchFallbackChain:
+    def test_timeout_falls_back_to_jina_reader(self, monkeypatch) -> None:
+        def fail_get(url, **kwargs):
+            raise requests.exceptions.Timeout("timed out")
+
+        monkeypatch.setattr("jiuwenswarm.agents.harness.common.tools.web_fetch_tools._http_get", fail_get)
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.web_fetch_tools._fetch_via_jina_reader_sync",
+            lambda url, timeout_seconds: {
+                "url": url,
+                "status_code": 200,
+                "title": "",
+                "content": "fallback content from jina",
+            },
+        )
+        result = _call("https://example.com/page")
+        assert "fallback content from jina" in result
+
+    def test_http_403_falls_back_to_jina_reader(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.web_fetch_tools._http_get",
+            lambda url, **kwargs: _fake_response(b"forbidden", status_code=403),
+        )
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.web_fetch_tools._fetch_via_jina_reader_sync",
+            lambda url, timeout_seconds: {
+                "url": url,
+                "status_code": 200,
+                "title": "",
+                "content": "jina rendered it",
+            },
+        )
+        result = _call("https://example.com/page")
+        assert "jina rendered it" in result
+
+
+# ── mcp_fetch_webpage: 内容解析 ────────────────────────────────────
+
+
+class TestFetchContentParsing:
+    def test_html_strips_scripts_and_styles(self, monkeypatch) -> None:
+        html = (
+            b"<html><head><title>Page Title</title>"
+            b"<script>var x = 1;</script><style>.a { color: red; }</style></head>"
+            b"<body><h1>Hello</h1><p>World</p></body></html>"
+        )
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.web_fetch_tools._http_get",
+            lambda url, **kwargs: _fake_response(html),
+        )
+        result = _call("https://example.com/page")
+        assert "Page Title" in result
+        assert "Hello" in result
+        assert "World" in result
+        assert "var x" not in result
+        assert "color: red" not in result
+
+    def test_empty_page_returns_empty_marker(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.web_fetch_tools._http_get",
+            lambda url, **kwargs: _fake_response(b""),
+        )
+        result = _call("https://example.com/empty")
+        assert "[empty]" in result
+
+    def test_empty_url_rejected(self) -> None:
+        result = _call("")
+        assert "url cannot be empty" in result
+
+    def test_jina_reader_sync_passes_through(self, monkeypatch) -> None:
+        def fake_get(url, **kwargs) -> SimpleNamespace:
+            assert url == "https://r.jina.ai/https://example.com/page"
+            return _fake_response(b"reader output", content_type="text/plain")
+
+        monkeypatch.setattr("jiuwenswarm.agents.harness.common.tools.web_fetch_tools._http_get", fake_get)
+        data = _fetch_via_jina_reader_sync("https://example.com/page", timeout_seconds=5)
+        assert isinstance(data["content"], str)
+        assert "reader output" in data["content"]


### PR DESCRIPTION
Paired: [GitHub #3405](https://github.com/openJiuwen-ai/jiuwenswarm/pull/3405) ↔ [GitCode !5086](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5086)

# fix(web_fetch): distinguish access failures from empty results and route GitHub repo search to the JSON API

## Problem

`mcp_fetch_webpage` reports *every* failure as a single opaque `[ERROR]` string and cannot retrieve
anything from client-rendered (JS) pages. In practice this makes agents conclude
"no such project found" when the real cause is one of:

1. **Network/HTTP access failure misread as absence.** A timeout or connection error returns
   `[ERROR]: failed to fetch webpage: HTTPSConnectionPool(...)`. The model treats that as
   "the content does not exist" instead of "the page could not be reached", and stops searching.
2. **`github.com/search` pages are JS-rendered.** A plain HTTP fetch only receives the SPA shell,
   so agents can never see repository search results — even though the public JSON API
   (`api.github.com/search/repositories`) works fine and returns results in seconds.

Observed end-to-end: an agent asked "deepseek harness 会成为新的 Agent 内核吗？" fetched
Bing + `github.com/search?q=deepseek+harness&type=repositories`, received an empty/error payload
from the GitHub page, and answered "没有找到相关项目" — while `deepseek-ai/deepseek-harness`
is the #1 hit on both Bing and the GitHub API.

## Changes

`jiuwenswarm/agents/harness/common/tools/web_fetch_tools.py`:

- **Structured fetch-error categories.** New `_classify_fetch_error()` maps exceptions to
  `timeout` / `connection` / `http_error` / `request` / `unknown`. `mcp_fetch_webpage` now
  returns `[FETCH_ERROR: <category>] ...` for network/HTTP failures, with an explicit hint that
  this is an *access* failure and the agent should try an alternative source (API endpoint,
  search engine) before concluding the content does not exist.
- **GitHub repository search → public JSON API.** New `_github_search_api_url()` rewrites
  `https://github.com/search?q=<query>[&type=repositories]` to
  `https://api.github.com/search/repositories?q=<query>&per_page=N` (URL-encoded, per_page
  clamped to 1–30). Only repository search is rewritten; other tabs (`type=issues`,
  `type=pullrequests`, ...) keep their original URL.
- **Complete the fallback chain.** Network-level failures (timeout / connection error) now also
  attempt the existing Jina Reader fallback (`r.jina.ai`) before surfacing the original error,
  instead of only 401/403/429 responses.
- **Tool description updated** so the model knows `[FETCH_ERROR: ...]` means the page could not
  be accessed, not that it does not exist.

`tests/unit_tests/agents/test_web_fetch_tools.py` (new):

- `_github_search_api_url` rewrite table (incl. URL-encoding of CJK queries, per_page clamp,
  non-repository tabs and non-GitHub hosts rejected).
- `mcp_fetch_webpage` GitHub rewrite actually hits `api.github.com` (URL captured via stub).
- Error classification: timeout / connection / HTTP error → correct `[FETCH_ERROR: ...]`
  category.
- Fallback chain: timeout and 403 both route to Jina Reader.
- Content parsing: script/style stripped, empty page → `[empty]`, empty URL rejected.

## Verification

- New test file: `pytest tests/unit_tests/agents/test_web_fetch_tools.py` — 22 passed.
- Full suite (excluding 5 pre-existing collection errors, see Notes):
  **5345 passed, 28 skipped, 0 errors** in 7:57.
- Live sanity check (GFW-restricted WSL, same network the bug was observed on):
  - `github.com/search?q=deepseek+harness&type=repositories` → rewritten to
    `api.github.com/search/repositories?q=deepseek%20harness&per_page=10` → HTTP 200,
    8661 results, `deepseek-ai/deepseek-harness` first.
  - Direct `github.com/search` HTML fetch → connect timeout (the environment that triggered
    the bug); the rewritten API call succeeds in <1s.

## Notes

- The Jina Reader fallback is not reachable from some networks (e.g. GFW-restricted WSL);
  when the fallback itself fails the original error is preserved and surfaced with its
  `[FETCH_ERROR]` category, so agents still get actionable signal.
- Pre-existing, unrelated to this change (already broken on `develop` @ `1693210`):
  4 desktop tests fail to collect on Python 3.12 because
  `jiuwenswarm/channels/desktop/desktop_app.py:28` has a module-level `import webview`
  while `pywebview` is only in the `desktop` extra; `test_mcp_cli_driver.py` has an
  invalid escape `\s` in a docstring that Python 3.12 rejects during assertion rewrite.
- No change to routing, schema, or other tools.
