### PR TITLE
Two governance rails, and five silent-failure fixes found by running the framework

### DIFF
--- a/jiuwenswarm/agents/harness/team/rails/__init__.py
+++ b/jiuwenswarm/agents/harness/team/rails/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Team-harness rails — prompt injection and governance layers."""
+
+from jiuwenswarm.agents.harness.team.rails.governance_review_rail import GovernanceReviewRail
+from jiuwenswarm.agents.harness.team.rails.team_member_skill_toolkit_rail import MemberSkillToolkitRail
+from jiuwenswarm.agents.harness.team.rails.team_permission_policy_rail import TeamPermissionPolicyRail
+from jiuwenswarm.agents.harness.team.rails.team_shared_skill_link_refresh_rail import TeamSharedSkillLinkRefreshRail
+from jiuwenswarm.agents.harness.team.rails.team_skill_storage_policy_rail import TeamSkillStoragePolicyRail
+from jiuwenswarm.agents.harness.team.rails.team_workspace_report_path_rail import TeamWorkspaceReportPathRail
+
+__all__ = [
+    "GovernanceReviewRail",
+    "MemberSkillToolkitRail",
+    "TeamPermissionPolicyRail",
+    "TeamSharedSkillLinkRefreshRail",
+    "TeamSkillStoragePolicyRail",
+    "TeamWorkspaceReportPathRail",
+]

--- a/jiuwenswarm/agents/harness/team/rails/__init__.py
+++ b/jiuwenswarm/agents/harness/team/rails/__init__.py
@@ -3,6 +3,7 @@
 """Team-harness rails — prompt injection and governance layers."""
 
 from jiuwenswarm.agents.harness.team.rails.governance_review_rail import GovernanceReviewRail
+from jiuwenswarm.agents.harness.team.rails.rigor_audit_rail import RigorAuditRail
 from jiuwenswarm.agents.harness.team.rails.team_member_skill_toolkit_rail import MemberSkillToolkitRail
 from jiuwenswarm.agents.harness.team.rails.team_permission_policy_rail import TeamPermissionPolicyRail
 from jiuwenswarm.agents.harness.team.rails.team_shared_skill_link_refresh_rail import TeamSharedSkillLinkRefreshRail
@@ -11,6 +12,7 @@ from jiuwenswarm.agents.harness.team.rails.team_workspace_report_path_rail impor
 
 __all__ = [
     "GovernanceReviewRail",
+    "RigorAuditRail",
     "MemberSkillToolkitRail",
     "TeamPermissionPolicyRail",
     "TeamSharedSkillLinkRefreshRail",

--- a/jiuwenswarm/agents/harness/team/rails/governance_review_rail.py
+++ b/jiuwenswarm/agents/harness/team/rails/governance_review_rail.py
@@ -1,0 +1,183 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Process-governance rail for research-agent workflows.
+
+Implements the B5 process-governance layer described in ResearchFlowBench:
+each research agent is instructed to emit typed scholarly objects with
+explicit support states before advancing to the next workflow stage.
+Unsupported claims, missing baselines, and stale evidence markers are
+surfaced as gate decisions rather than silently passed through.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+from openjiuwen.harness.prompts import PromptSection
+from openjiuwen.harness.rails.base import DeepAgentRail
+
+if TYPE_CHECKING:
+    from openjiuwen.harness.deep_agent import DeepAgent
+
+logger = logging.getLogger(__name__)
+
+_UNSUPPORTED_SIGNAL_RE = re.compile(
+    r"\b(novel|first|only|unique|state.of.the.art|outperform|significantly better)\b",
+    re.IGNORECASE,
+)
+_CITATION_RE = re.compile(r"\[[\w\s,]+\]|\\\(\\cite|\\citep|\\citet", re.IGNORECASE)
+_STALE_SIGNAL_RE = re.compile(
+    r"\b(previous(ly)?|earlier|above|as noted|as mentioned)\b", re.IGNORECASE
+)
+
+_GOVERNANCE_PROMPT_CN = """\
+# 过程治理规则（Process-Governance Rules）
+
+在每次生成研究内容时，你必须遵守以下学术对象治理规则：
+
+1. **引用支撑（Citation Support）**：每条断言性claim必须附带文献引用。
+   存在引用 ≠ 引用支撑claim。请标注支撑程度：完全支撑 / 部分支撑 / 不支撑。
+2. **新颖性基线（Novelty Baseline）**：声称"首创"或"优于现有方法"时，必须列出
+   最相关的对比基线，并说明差异。缺少基线 = 虚假新颖性（false novelty）。
+3. **证据新鲜度（Evidence Freshness）**：引用上游信息时，若该信息已被修订或
+   撤回，必须标注证据失效（stale），并触发下游对象的连锁检查。
+4. **门控决策（Gate Decision）**：每个研究阶段结束时，输出一个明确的门控结论：
+   ADVANCE（可推进）/ BLOCK（需阻断）/ REVIEW（需人工审阅）。
+
+违反上述规则的输出将被治理审阅者标记为流程异常。
+"""
+
+_GOVERNANCE_PROMPT_EN = """\
+# Process-Governance Rules
+
+When producing research content, you must follow these scholarly-object governance rules:
+
+1. **Citation Support**: Every assertive claim must be backed by a reference.
+   A citation existing is not the same as that citation supporting the claim.
+   Label support level: FULL / PARTIAL / UNSUPPORTED.
+2. **Novelty Baseline**: When claiming "first" or "outperforms prior work",
+   list the most directly competing baselines and explain the delta.
+   Missing baseline = false novelty.
+3. **Evidence Freshness**: When referencing upstream information, if that
+   information has been revised or retracted, mark it STALE and trigger
+   a downstream propagation check.
+4. **Gate Decision**: At the end of each research phase, emit an explicit gate:
+   ADVANCE / BLOCK / REVIEW.
+
+Outputs that violate these rules will be flagged as process anomalies by the
+governance reviewer.
+"""
+
+
+class GovernanceReviewRail(DeepAgentRail):
+    """Inject process-governance constraints into research-agent prompts.
+
+    This rail implements the B5 process-governance condition from
+    ResearchFlowBench. It:
+    - Injects scholarly-object governance rules before each model call.
+    - After each call, scans for potential governance violations (novelty
+      claims without citations, stale-evidence signals) and logs them.
+
+    The rail is designed to surface process-reliability failures that
+    outcome-only evaluation would miss, as defined in ResearchFlowBench's
+    five task families (T01--T05): citation support, open-world attribution,
+    partial-support classification, stale propagation, and false novelty.
+    """
+
+    priority = 90
+    SECTION_NAME = "process_governance"
+    SECTION_PRIORITY = 45
+
+    def __init__(
+        self,
+        *,
+        language: str = "cn",
+        emit_gate_decisions: bool = True,
+        log_violations: bool = True,
+    ) -> None:
+        super().__init__()
+        self._language = language
+        self._emit_gate_decisions = emit_gate_decisions
+        self._log_violations = log_violations
+        self.system_prompt_builder = None
+        self._agent_id: str = ""
+        self._violation_count: int = 0
+
+    def init(self, agent: "DeepAgent") -> None:
+        self.system_prompt_builder = getattr(agent, "system_prompt_builder", None)
+        self._agent_id = str(getattr(agent.card, "id", None) or getattr(agent.card, "name", "unknown"))
+        logger.info("[GovernanceReviewRail] Initialized for agent_id=%s", self._agent_id)
+
+    def uninit(self, agent: "DeepAgent") -> None:
+        _ = agent
+        if self.system_prompt_builder is not None:
+            self.system_prompt_builder.remove_section(self.SECTION_NAME)
+        self.system_prompt_builder = None
+        if self._violation_count > 0:
+            logger.info(
+                "[GovernanceReviewRail] agent_id=%s accumulated %d governance signals",
+                self._agent_id,
+                self._violation_count,
+            )
+
+    async def before_model_call(self, ctx: AgentCallbackContext) -> None:
+        _ = ctx
+        if self.system_prompt_builder is None:
+            return
+        content_text = (
+            _GOVERNANCE_PROMPT_CN if self._language == "cn" else _GOVERNANCE_PROMPT_EN
+        )
+        self.system_prompt_builder.add_section(
+            PromptSection(
+                name=self.SECTION_NAME,
+                content={self._language: content_text},
+                priority=self.SECTION_PRIORITY,
+            )
+        )
+
+    async def after_model_call(self, ctx: AgentCallbackContext) -> None:
+        if not self._log_violations:
+            return
+
+        response_text = ""
+        if ctx and hasattr(ctx, "response") and ctx.response:
+            r = ctx.response
+            if hasattr(r, "content") and isinstance(r.content, str):
+                response_text = r.content
+            elif hasattr(r, "text"):
+                response_text = str(r.text or "")
+
+        if not response_text:
+            return
+
+        violations: list[str] = []
+
+        # Check for novelty/superiority claims without citations
+        novelty_hits = _UNSUPPORTED_SIGNAL_RE.findall(response_text)
+        citation_hits = _CITATION_RE.findall(response_text)
+        if novelty_hits and not citation_hits:
+            violations.append(
+                f"novelty/superiority claim(s) {novelty_hits[:3]} detected without citation support"
+            )
+
+        # Check for stale-evidence signals
+        stale_hits = _STALE_SIGNAL_RE.findall(response_text)
+        if stale_hits and "stale" not in response_text.lower() and "freshen" not in response_text.lower():
+            violations.append(
+                f"possible stale-reference signal(s) ({stale_hits[:2]}) without explicit freshness check"
+            )
+
+        if violations:
+            self._violation_count += len(violations)
+            for v in violations:
+                logger.warning(
+                    "[GovernanceReviewRail] GOVERNANCE SIGNAL agent_id=%s: %s",
+                    self._agent_id,
+                    v,
+                )
+
+
+__all__ = ["GovernanceReviewRail"]

--- a/jiuwenswarm/agents/harness/team/rails/governance_review_rail.py
+++ b/jiuwenswarm/agents/harness/team/rails/governance_review_rail.py
@@ -19,6 +19,8 @@ from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
 from openjiuwen.harness.prompts import PromptSection
 from openjiuwen.harness.rails.base import DeepAgentRail
 
+from jiuwenswarm.agents.harness.team.rails.response_text import response_text
+
 if TYPE_CHECKING:
     from openjiuwen.harness.deep_agent import DeepAgent
 
@@ -142,30 +144,26 @@ class GovernanceReviewRail(DeepAgentRail):
         if not self._log_violations:
             return
 
-        response_text = ""
-        if ctx and hasattr(ctx, "response") and ctx.response:
-            r = ctx.response
-            if hasattr(r, "content") and isinstance(r.content, str):
-                response_text = r.content
-            elif hasattr(r, "text"):
-                response_text = str(r.text or "")
-
-        if not response_text:
+        # The model response is on ctx.inputs.response (the ModelCallInputs for
+        # this event), not on ctx itself; reading ctx.response scanned an empty
+        # string on every call, which is indistinguishable from a clean draft.
+        text = response_text(ctx)
+        if not text:
             return
 
         violations: list[str] = []
 
         # Check for novelty/superiority claims without citations
-        novelty_hits = _UNSUPPORTED_SIGNAL_RE.findall(response_text)
-        citation_hits = _CITATION_RE.findall(response_text)
+        novelty_hits = _UNSUPPORTED_SIGNAL_RE.findall(text)
+        citation_hits = _CITATION_RE.findall(text)
         if novelty_hits and not citation_hits:
             violations.append(
                 f"novelty/superiority claim(s) {novelty_hits[:3]} detected without citation support"
             )
 
         # Check for stale-evidence signals
-        stale_hits = _STALE_SIGNAL_RE.findall(response_text)
-        if stale_hits and "stale" not in response_text.lower() and "freshen" not in response_text.lower():
+        stale_hits = _STALE_SIGNAL_RE.findall(text)
+        if stale_hits and "stale" not in text.lower() and "freshen" not in text.lower():
             violations.append(
                 f"possible stale-reference signal(s) ({stale_hits[:2]}) without explicit freshness check"
             )

--- a/jiuwenswarm/agents/harness/team/rails/response_text.py
+++ b/jiuwenswarm/agents/harness/team/rails/response_text.py
@@ -1,0 +1,51 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Read the model's text out of an AFTER_MODEL_CALL context.
+
+Shared by the rails that inspect what an agent just wrote. It exists as its own
+module because getting this wrong is silent: the response lives on
+``ctx.inputs.response`` -- ``inputs`` is the ``ModelCallInputs`` for the event --
+and a rail reading ``ctx.response`` instead receives ``None``, scans an empty
+string, finds nothing, and is indistinguishable at the log from a rail that
+looked at a clean draft.
+"""
+
+from __future__ import annotations
+
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+
+
+def response_text(ctx: AgentCallbackContext | None) -> str:
+    """Return the assistant text for this call, or "" when there is none.
+
+    ``ctx.response`` is still consulted as a fallback so the helper keeps
+    working if a host ever populates it.
+    """
+    if ctx is None:
+        return ""
+    response = getattr(getattr(ctx, "inputs", None), "response", None)
+    if response is None:
+        response = getattr(ctx, "response", None)
+    if response is None:
+        return ""
+    if isinstance(response, str):
+        return response
+
+    content = getattr(response, "content", None)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        # Multimodal content blocks: keep the text parts, drop images and the rest.
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                parts.append(str(block.get("text") or ""))
+            else:
+                parts.append(str(getattr(block, "text", "") or ""))
+        return "".join(p for p in parts if p)
+
+    text = getattr(response, "text", None)
+    return str(text or "") if text is not None else ""
+
+
+__all__ = ["response_text"]

--- a/jiuwenswarm/agents/harness/team/rails/rigor_audit_rail.py
+++ b/jiuwenswarm/agents/harness/team/rails/rigor_audit_rail.py
@@ -1,0 +1,286 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Rigor-audit rail: deterministic fabrication forensics on agent-written research text.
+
+Ships the deterministic layer of SciRigorBench as an in-harness guardrail. Where
+GovernanceReviewRail governs how scholarly objects are *produced*, this rail audits what was
+actually written: numeric feasibility, cross-surface agreement, and construction residue.
+
+Design constraints taken from the benchmark:
+
+* Zero additional model calls. Every check is pure Python over the emitted text, so the rail
+  costs nothing on the token budget and cannot itself hallucinate a finding.
+* Report, never block. The benchmark's own result is that deterministic surface forensics
+  saturate near zero on final-draft-quality agent papers: what they catch is a floor, not a
+  certificate. Findings are logged for the writing loop; acceptance is not this rail's call.
+* Every finding carries the fragment that triggered it, so a downstream reviewer can confirm
+  or dismiss it without rerunning the agent.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+from openjiuwen.harness.prompts import PromptSection
+from openjiuwen.harness.rails.base import DeepAgentRail
+
+if TYPE_CHECKING:
+    from openjiuwen.harness.deep_agent import DeepAgent
+
+logger = logging.getLogger(__name__)
+
+# --- numeric feasibility -------------------------------------------------------------------
+_MEAN_N_RE = re.compile(
+    r"(?:mean|average|M)\s*[=:]?\s*(\d+\.\d+).{0,60}?\bn\s*[=:]\s*(\d{1,4})\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_PVALUE_RE = re.compile(r"\bp\s*[=<]\s*(0?\.\d+|\d\.\d+e-\d+|0\.0+)\b", re.IGNORECASE)
+_PERCENT_RE = re.compile(r"(\d{1,3}(?:\.\d+)?)\s*%")
+_SD_ZERO_RE = re.compile(r"(?:SD|std|s\.d\.)\s*[=:]?\s*0\.0+\b", re.IGNORECASE)
+_CI_RE = re.compile(r"\[\s*(-?\d+\.\d+)\s*,\s*(-?\d+\.\d+)\s*\]")
+
+# --- construction residue ------------------------------------------------------------------
+_PLACEHOLDER_RE = re.compile(
+    r"\b(TODO|FIXME|TBD|XXX|placeholder|lorem ipsum|Author [A-E]\b|\[dream[^\]]*\])",
+    re.IGNORECASE,
+)
+_INTERNAL_MARKER_RE = re.compile(
+    r"\b(writing_mode\s*[:=]\s*dream|hypothetical_until_validated|target_result|idealized_claim|"
+    r"claim boundary note|white-?box release)\b",
+    re.IGNORECASE,
+)
+_ROUND_NUMBER_RE = re.compile(r"\b\d+\.(?:00|000|0000)\b")
+
+
+@dataclass(frozen=True)
+class RigorFinding:
+    """One deterministic finding, bound to the fragment that produced it."""
+
+    code: str
+    message: str
+    evidence: str
+
+    def render(self) -> str:
+        return f"{self.code}: {self.message} | evidence: {self.evidence[:120]}"
+
+
+def _grim_infeasible(mean_str: str, n: int) -> bool:
+    """GRIM: a mean of n integer responses must be a multiple of 1/n at its stated precision."""
+    if not (0 < n <= 1000):
+        return False
+    decimals = len(mean_str.split(".")[1])
+    if decimals == 0 or decimals > 4:
+        return False
+    mean = float(mean_str)
+    scale = 10**decimals
+    nearest = round(mean * n) / n
+    return round(abs(nearest - mean) * scale) >= 1
+
+
+def audit_text(text: str) -> list[RigorFinding]:
+    """Run every deterministic check over one block of generated text.
+
+    Pure function: no I/O, no model calls, no global state. Exposed at module level so the
+    checks can be unit-tested and reused outside the harness.
+    """
+    findings: list[RigorFinding] = []
+
+    for match in _MEAN_N_RE.finditer(text):
+        mean_str, n_str = match.group(1), match.group(2)
+        if _grim_infeasible(mean_str, int(n_str)):
+            findings.append(RigorFinding(
+                "D10_stat_feasibility",
+                f"mean {mean_str} is not attainable from n={n_str} integer responses (GRIM)",
+                match.group(0),
+            ))
+
+    for match in _PVALUE_RE.finditer(text):
+        raw = match.group(1)
+        if float(raw) == 0.0:
+            findings.append(RigorFinding(
+                "D11_pvalue_exact_zero",
+                "p-value reported as exactly zero; report a bound such as p < 0.001 instead",
+                match.group(0),
+            ))
+
+    percents = [float(p) for p in _PERCENT_RE.findall(text)]
+    impossible = [p for p in percents if p > 100.0]
+    if impossible:
+        findings.append(RigorFinding(
+            "D9_percent_out_of_range",
+            f"percentage(s) above 100 reported: {impossible[:3]}",
+            ", ".join(f"{p}%" for p in impossible[:3]),
+        ))
+
+    sd_zeros = _SD_ZERO_RE.findall(text)
+    if len(sd_zeros) >= 2:
+        findings.append(RigorFinding(
+            "D2_missing_variance",
+            f"{len(sd_zeros)} cells report exactly zero dispersion; collapsed variance is a "
+            "construction signature unless the quantity is deterministic",
+            sd_zeros[0],
+        ))
+
+    for match in _CI_RE.finditer(text):
+        lo, hi = float(match.group(1)), float(match.group(2))
+        if lo > hi:
+            findings.append(RigorFinding(
+                "D20_ci_inverted",
+                f"confidence interval has lower bound {lo} above upper bound {hi}",
+                match.group(0),
+            ))
+        elif lo == hi:
+            findings.append(RigorFinding(
+                "D27_ci_zero_width",
+                "confidence interval collapses to a point at the printed precision",
+                match.group(0),
+            ))
+
+    for match in _PLACEHOLDER_RE.finditer(text):
+        findings.append(RigorFinding(
+            "D34_submission_completeness",
+            "placeholder text left in submission-facing content",
+            match.group(0),
+        ))
+
+    for match in _INTERNAL_MARKER_RE.finditer(text):
+        findings.append(RigorFinding(
+            "D28_internal_marker_leak",
+            "internal generation marker present on the public surface",
+            match.group(0),
+        ))
+
+    round_numbers = _ROUND_NUMBER_RE.findall(text)
+    if len(round_numbers) >= 4:
+        findings.append(RigorFinding(
+            "D1_result_number_grid",
+            f"{len(round_numbers)} values sit on an exact rounding grid; check they were "
+            "measured rather than filled in",
+            ", ".join(round_numbers[:4]),
+        ))
+
+    return findings
+
+
+class RigorAuditRail(DeepAgentRail):
+    """Audit agent-written research text with the deterministic SciRigorBench detector layer."""
+
+    SECTION_NAME = "rigor_audit"
+    SECTION_PRIORITY = 44
+
+    _PROMPT_CN = """\
+# 严谨性自检规则（Rigor Self-Check）
+
+在写出任何数值结果前，逐条自检：
+
+1. **数值可行性**：均值必须能由样本量产生（如 n 个整数打分的均值必是 1/n 的倍数）；
+   百分比不得超过 100；p 值不写成精确的 0，改写为 p < 0.001 之类的界。
+2. **不确定度**：不要输出恒为零的标准差或宽度为零的置信区间；若量本身是确定性的，明说。
+3. **跨表一致**：正文、表格、图注中同一个量必须一致；改动一处就同步另外两处。
+4. **不留痕迹**：交付面不得出现 TODO/占位符/作者代号/内部生成标记。
+5. **避免整齐**：不要把结果凑到整齐的小数网格上；报告实际计算出的位数。
+"""
+
+    _PROMPT_EN = """\
+# Rigor Self-Check
+
+Before writing any numeric result, verify each of the following:
+
+1. **Numeric feasibility.** A mean must be attainable from the stated sample size (the mean of
+   n integer responses is a multiple of 1/n); percentages must not exceed 100; never report a
+   p-value as exactly zero -- report a bound such as p < 0.001.
+2. **Uncertainty.** Do not emit standard deviations that are identically zero or intervals of
+   zero width; if a quantity really is deterministic, say so explicitly.
+3. **Cross-surface agreement.** The same quantity must match across prose, tables, and captions;
+   changing one requires changing the others.
+4. **No residue.** Submission-facing text must contain no TODO markers, placeholders, author
+   codenames, or internal generation markers.
+5. **No tidy grids.** Do not round results onto an even decimal grid; report the precision you
+   actually computed.
+"""
+
+    def __init__(
+        self,
+        *,
+        language: str = "cn",
+        inject_prompt: bool = True,
+        log_findings: bool = True,
+    ) -> None:
+        super().__init__()
+        self._language = language
+        self._inject_prompt = inject_prompt
+        self._log_findings = log_findings
+        self.system_prompt_builder = None
+        self._agent_id: str = ""
+        self._findings: list[RigorFinding] = []
+
+    @property
+    def findings(self) -> list[RigorFinding]:
+        """Findings accumulated over this agent's lifetime, for downstream reporting."""
+        return list(self._findings)
+
+    def init(self, agent: "DeepAgent") -> None:
+        self.system_prompt_builder = getattr(agent, "system_prompt_builder", None)
+        self._agent_id = str(
+            getattr(agent.card, "id", None) or getattr(agent.card, "name", "unknown")
+        )
+        logger.info("[RigorAuditRail] Initialized for agent_id=%s", self._agent_id)
+
+    def uninit(self, agent: "DeepAgent") -> None:
+        _ = agent
+        if self.system_prompt_builder is not None:
+            self.system_prompt_builder.remove_section(self.SECTION_NAME)
+        self.system_prompt_builder = None
+        if self._findings:
+            codes = sorted({f.code for f in self._findings})
+            logger.info(
+                "[RigorAuditRail] agent_id=%s emitted %d rigor finding(s) across %s",
+                self._agent_id,
+                len(self._findings),
+                ", ".join(codes),
+            )
+
+    async def before_model_call(self, ctx: AgentCallbackContext) -> None:
+        _ = ctx
+        if not self._inject_prompt or self.system_prompt_builder is None:
+            return
+        self.system_prompt_builder.add_section(
+            PromptSection(
+                name=self.SECTION_NAME,
+                content={
+                    self._language: (
+                        self._PROMPT_CN if self._language == "cn" else self._PROMPT_EN
+                    )
+                },
+                priority=self.SECTION_PRIORITY,
+            )
+        )
+
+    async def after_model_call(self, ctx: AgentCallbackContext) -> None:
+        if not self._log_findings:
+            return
+
+        response_text = ""
+        if ctx and getattr(ctx, "response", None):
+            response = ctx.response
+            if isinstance(getattr(response, "content", None), str):
+                response_text = response.content
+            elif hasattr(response, "text"):
+                response_text = str(response.text or "")
+        if not response_text:
+            return
+
+        for finding in audit_text(response_text):
+            self._findings.append(finding)
+            logger.warning(
+                "[RigorAuditRail] RIGOR FINDING agent_id=%s %s",
+                self._agent_id,
+                finding.render(),
+            )
+
+
+__all__ = ["RigorAuditRail", "RigorFinding", "audit_text"]

--- a/jiuwenswarm/agents/harness/team/rails/rigor_audit_rail.py
+++ b/jiuwenswarm/agents/harness/team/rails/rigor_audit_rail.py
@@ -28,6 +28,8 @@ from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
 from openjiuwen.harness.prompts import PromptSection
 from openjiuwen.harness.rails.base import DeepAgentRail
 
+from jiuwenswarm.agents.harness.team.rails.response_text import response_text
+
 if TYPE_CHECKING:
     from openjiuwen.harness.deep_agent import DeepAgent
 
@@ -264,17 +266,11 @@ Before writing any numeric result, verify each of the following:
         if not self._log_findings:
             return
 
-        response_text = ""
-        if ctx and getattr(ctx, "response", None):
-            response = ctx.response
-            if isinstance(getattr(response, "content", None), str):
-                response_text = response.content
-            elif hasattr(response, "text"):
-                response_text = str(response.text or "")
-        if not response_text:
+        text = response_text(ctx)
+        if not text:
             return
 
-        for finding in audit_text(response_text):
+        for finding in audit_text(text):
             self._findings.append(finding)
             logger.warning(
                 "[RigorAuditRail] RIGOR FINDING agent_id=%s %s",

--- a/jiuwenswarm/agents/harness/team/rails/self_eval_gate.py
+++ b/jiuwenswarm/agents/harness/team/rails/self_eval_gate.py
@@ -1,0 +1,184 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Correlation-aware acceptance gate for self-graded verdicts.
+
+An agent framework that evolves its own skills has to decide, repeatedly,
+whether to keep a change. The cheap way is to ask a model: *did this work?* The
+problem is that the model answering shares a blind spot with the model that
+produced the thing being judged -- same training data, same failure modes, same
+sense of what a good answer looks like. A "pass" from that arrangement is not
+worth its face value, and using a *different* model only partly helps: family
+effects and a shared familiarity bias leave residual correlation behind.
+
+This gate prices that in. Given how correlated the judge is with the generator
+(``contamination_rho``) and how much residual error is tolerable (``alpha``), it
+returns the number of *independent external checks* the verdict still needs
+before it may be accepted.
+
+The risk model is one line: each independent anchor is a fresh look that
+multiplies the residual risk by rho again, so with k anchors plus the
+(contaminated) self-grade the residual is ``rho**(k+1)``. Bringing that under
+alpha requires ``k+1 >= log(alpha)/log(rho)`` checks.
+
+**This is a conservative routing policy for verification effort, not a proven
+statistical bound.** It is stated that way here because a gate that overstates
+its own guarantee is the exact failure it exists to prevent.
+
+Two asymmetries do the real work:
+
+* **Negative verdicts pass straight through.** Contamination inflates a model's
+  acceptance of its *own* favoured outputs; it does not manufacture rejections.
+  Keeping a change out is the safe direction and needs no anchor.
+* **Unknown provenance is treated as self-graded.** If the generator or judge is
+  not identified, the gate assumes the worst case rather than the convenient one.
+
+Deterministic: no model call, so the gate cannot inherit the bias it is measuring.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+# Model families that share a lineage closely enough for a cross-checkpoint
+# judgement to stay substantially correlated.
+_FAMILIES = (
+    "gpt", "claude", "gemini", "llama", "qwen", "mistral", "deepseek", "gemma",
+)
+
+# How much of the contamination survives when the judge differs from the
+# generator. Same family means different checkpoints of shared lineage; a
+# genuinely different model still shares a familiarity bias, so neither
+# decorrelates fully. Both are judgement calls, deliberately conservative.
+_RHO_SAME_FAMILY = 0.7
+_RHO_CROSS_FAMILY = 0.5
+
+_POSITIVE_VERDICTS = frozenset(
+    {"", "open", "accept", "pass", "novel", "supported", "true", "yes", "approve"}
+)
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """What the gate decided, and every input that produced it."""
+
+    action: str                       # accept | require_external | abstain | accept_verdict
+    self_graded: bool
+    regime: str                       # self_graded | cross_model
+    effective_rho: float
+    residual_risk: float
+    required_external: int
+    external_anchors: int
+    alpha: float
+    trust_adjusted_confidence: float
+    rationale: str
+
+    def render(self) -> str:
+        return (
+            f"{self.action} [{self.regime}] rho_eff={self.effective_rho:.3f} "
+            f"residual={self.residual_risk:.4f} vs alpha={self.alpha:.3f} "
+            f"anchors={self.external_anchors} need={self.required_external} "
+            f"-- {self.rationale}"
+        )
+
+
+def _family(model: str) -> str:
+    m = (model or "").strip().lower()
+    for fam in _FAMILIES:
+        if fam in m:
+            return fam
+    return m
+
+
+def _regime(generator_model: str, judge_model: str, rho: float,
+            same_lineage: bool | None) -> tuple[bool, str, float]:
+    gen, jud = (generator_model or "").strip().lower(), (judge_model or "").strip().lower()
+    if same_lineage is True or (gen and jud and gen == jud):
+        return True, "self_graded", rho
+    if not (gen and jud):
+        # Unknown provenance: assume the worst case, never the convenient one.
+        return True, "self_graded", rho
+    if _family(gen) == _family(jud):
+        return False, "cross_model", rho * _RHO_SAME_FAMILY
+    return False, "cross_model", rho * _RHO_CROSS_FAMILY
+
+
+def evaluate(
+    *,
+    verdict: str = "",
+    judge_confidence: float = 0.5,
+    generator_model: str = "",
+    judge_model: str = "",
+    external_anchors: int = 0,
+    contamination_rho: float = 0.7,
+    alpha: float = 0.1,
+    same_lineage: bool | None = None,
+) -> GateDecision:
+    """Decide whether a self-graded verdict may be accepted as it stands.
+
+    Args:
+        verdict: the judgement being gated; anything outside the positive set is
+            treated as a rejection and passes through.
+        judge_confidence: the judge's own confidence, in [0, 1]. Used only to
+            report a trust-adjusted figure; it never relaxes the anchor
+            requirement, because a contaminated judge is confident for the same
+            reason it is wrong.
+        generator_model / judge_model: model identifiers, used to detect whether
+            the judgement is genuinely independent.
+        external_anchors: independent checks already performed (a corpus lookup,
+            a deterministic validator, a human spot-check).
+        contamination_rho: measured or assumed generator/judge correlation.
+        alpha: residual error budget.
+        same_lineage: force the self-graded regime when provenance is known but
+            the model strings do not match.
+    """
+    rho = min(max(float(contamination_rho), 0.0), 0.999)
+    conf = min(max(float(judge_confidence), 0.0), 1.0)
+    anchors = max(int(external_anchors), 0)
+    a = min(max(float(alpha), 1e-6), 0.999)
+
+    self_graded, regime, eff_rho = _regime(generator_model, judge_model, rho, same_lineage)
+
+    if (verdict or "").strip().lower() not in _POSITIVE_VERDICTS:
+        return GateDecision(
+            action="accept_verdict", self_graded=self_graded, regime=regime,
+            effective_rho=round(eff_rho, 4), residual_risk=0.0,
+            required_external=0, external_anchors=anchors, alpha=round(a, 4),
+            trust_adjusted_confidence=round(conf, 3),
+            rationale="negative verdict is in the safe direction; contamination "
+                      "inflates self-favoured accepts, not rejects",
+        )
+
+    if eff_rho <= 0.0:
+        residual, needed_total = 0.0, 0
+    else:
+        residual = eff_rho ** (anchors + 1)
+        needed_total = max(0, math.ceil(math.log(a) / math.log(eff_rho)) - 1)
+    required = max(0, needed_total - anchors)
+
+    if required <= 0:
+        action = "accept"
+        why = (f"{anchors} external anchor(s) bring residual risk {residual:.4f} "
+               f"within the budget {a:.3f}")
+    elif anchors == 0 and self_graded:
+        # Nothing but the contaminated judgement itself. There is no confidence
+        # level at which that becomes evidence, so the gate declines to rule.
+        action = "abstain"
+        why = (f"self-graded with no external anchor: residual risk {residual:.4f} "
+               f"exceeds {a:.3f} and no amount of judge confidence substitutes "
+               f"for an independent check")
+    else:
+        action = "require_external"
+        why = (f"{required} more independent check(s) needed: residual risk "
+               f"{residual:.4f} exceeds the budget {a:.3f}")
+
+    return GateDecision(
+        action=action, self_graded=self_graded, regime=regime,
+        effective_rho=round(eff_rho, 4), residual_risk=round(residual, 6),
+        required_external=required, external_anchors=anchors, alpha=round(a, 4),
+        trust_adjusted_confidence=round(conf * (1.0 - residual), 3),
+        rationale=why,
+    )
+
+
+__all__ = ["GateDecision", "evaluate"]

--- a/jiuwenswarm/agents/harness/team/team_runtime_inheritance.py
+++ b/jiuwenswarm/agents/harness/team/team_runtime_inheritance.py
@@ -32,10 +32,12 @@ from jiuwenswarm.agents.harness.common.rails.response_prompt_rail import Respons
 from jiuwenswarm.agents.harness.common.rails.runtime_prompt_rail import RuntimePromptRail
 from jiuwenswarm.agents.harness.common.rails.stream_event_rail import JiuSwarmStreamEventRail
 from jiuwenswarm.agents.harness.team.rails.team_workspace_report_path_rail import TeamWorkspaceReportPathRail
+from jiuwenswarm.agents.harness.team.rails.rigor_audit_rail import RigorAuditRail
 from jiuwenswarm.common.config import (
     get_config,
     get_evolution_auto_save_enabled,
     get_evolution_auto_scan_enabled,
+    get_rigor_audit_enabled,
     get_skill_create_enabled,
 )
 from jiuwenswarm.common.reasoning_injector import build_reasoning_model_request_kwargs
@@ -237,6 +239,18 @@ def build_member_rails(
         logger.info("[TeamRuntime] AvatarPromptRail created")
     except Exception as exc:
         logger.warning("[TeamRuntime] AvatarPromptRail failed: %s", exc)
+
+    # Mounted for every member, not just the reviewer: the arithmetic errors this
+    # rail catches are made by whoever writes the number, so the floor has to sit
+    # under the writer as well as the reviewer. It issues no model call, so
+    # mounting it everywhere costs nothing.
+    if get_rigor_audit_enabled(config):
+        try:
+            rail = RigorAuditRail(language=language)
+            rails_list.append(rail)
+            logger.info("[TeamRuntime] RigorAuditRail created: role=%s", role)
+        except Exception as exc:
+            logger.warning("[TeamRuntime] RigorAuditRail failed: %s", exc)
 
     if team_ws_root:
         try:

--- a/jiuwenswarm/cli/chat.py
+++ b/jiuwenswarm/cli/chat.py
@@ -371,6 +371,16 @@ def _build_request(args: argparse.Namespace, prompt: str) -> dict:
     }
 
 
+def _emit_usage(renderer: HumanRenderer) -> None:
+    """Print what the run cost, if the server reported it."""
+    summary = getattr(renderer, "usage_summary", None)
+    if summary is None:
+        return
+    line = summary()
+    if line:
+        logger.info("[usage] %s", line)
+
+
 async def _spinner_loop(renderer: HumanRenderer) -> None:
     while renderer.loading:
         renderer.tick_spinner()
@@ -629,6 +639,8 @@ async def _run_interactive_loop(
                 renderer.handle_tool_call(payload)
             elif kind == "tool_result":
                 renderer.handle_tool_result(payload)
+            elif kind == "usage":
+                renderer.handle_usage(payload)
             elif kind == "final":
                 # team.error is broadcast through the chat.final envelope
                 # (gateway default for unknown EventType). Route it to the
@@ -966,10 +978,15 @@ async def _run_chat(
                 show_reasoning=args.show_reasoning,
                 show_tools=args.show_tools,
             )
-            return await _run_interactive_loop(
-                client, renderer, request,
-                timeout=args.timeout,
-            )
+            try:
+                return await _run_interactive_loop(
+                    client, renderer, request,
+                    timeout=args.timeout,
+                )
+            finally:
+                # Report on every exit path, including interrupts and errors:
+                # a run that cost tokens and then failed still cost them.
+                _emit_usage(renderer)
     finally:
         await client.close()
 

--- a/jiuwenswarm/cli/events.py
+++ b/jiuwenswarm/cli/events.py
@@ -50,6 +50,11 @@ def event_kind(event_type: str) -> str:
         return "interactive"
     if event_type in ("chat.processing_status",):
         return "processing_status"
+    # Token accounting is already on the wire; without a kind of its own it
+    # falls into the generic "chat" bucket and is discarded, so a CLI run
+    # reports no cost even though the server measured it.
+    if event_type in ("chat.usage_metadata", "context.usage"):
+        return "usage"
     if event_type.startswith("chat.") or event_type.startswith("plan."):
         return "chat"
     return "other"

--- a/jiuwenswarm/cli/render.py
+++ b/jiuwenswarm/cli/render.py
@@ -42,6 +42,7 @@ class HumanRenderer:
         self._show_tools = show_tools
         self._streamed_text = ""
         self._printed_final = False
+        self._usage: dict[str, Any] = {}
         self._loading = False
         self._spinner_idx = 0
         self._start_time = 0.0
@@ -149,8 +150,15 @@ class HumanRenderer:
         if not self._show_tools:
             return
         self._last_token_time = time.monotonic()
-        name = payload.get("tool_name") or payload.get("name", "?")
-        args = payload.get("arguments") or payload.get("input", {})
+        # chat.tool_call nests the name under "tool_call"; chat.tool_update and
+        # chat.tool_result put "tool_name" at the top level. Same event family,
+        # two shapes -- reading only the flat one renders every call as "?".
+        nested = payload.get("tool_call")
+        nested = nested if isinstance(nested, dict) else {}
+        name = (payload.get("tool_name") or payload.get("name")
+                or nested.get("tool_name") or nested.get("name") or "?")
+        args = (payload.get("arguments") or payload.get("input")
+                or nested.get("arguments") or nested.get("input") or {})
         arg_str = json.dumps(args, ensure_ascii=False, default=str)
         if len(arg_str) > 120:
             arg_str = arg_str[:117] + "..."
@@ -163,6 +171,45 @@ class HumanRenderer:
         name = payload.get("tool_name") or payload.get("name", "?")
         status = payload.get("status", "done")
         _logger.info("[tool] %s -> %s", name, status)
+
+    def handle_usage(self, payload: dict[str, Any]) -> None:
+        """Accumulate token accounting the server already reports.
+
+        chat.usage_metadata carries per-call input/output/total/cache counts;
+        context.usage carries the running context window occupancy. Both were
+        arriving and being dropped, so a command-line run could not say what it
+        cost.
+        """
+        meta = payload.get("metadata")
+        um = (meta or {}).get("usage_metadata") if isinstance(meta, dict) else None
+        if isinstance(um, dict):
+            for key in ("input_tokens", "output_tokens", "total_tokens", "cache_tokens"):
+                self._usage[key] = self._usage.get(key, 0) + int(um.get(key) or 0)
+            self._usage["calls"] = self._usage.get("calls", 0) + 1
+            cost = float(um.get("total_cost") or 0.0)
+            if cost:
+                self._usage["cost"] = self._usage.get("cost", 0.0) + cost
+        used = payload.get("tokens_used")
+        if isinstance(used, (int, float)):
+            self._usage["context_tokens"] = int(used)
+            self._usage["context_max"] = int(payload.get("context_max") or 0)
+
+    def usage_summary(self) -> str:
+        """One line of resource accounting, or empty when nothing was reported."""
+        u = self._usage
+        if not u.get("calls"):
+            return ""
+        parts = [f"{u['calls']} model call(s)",
+                 f"in {u.get('input_tokens', 0):,}",
+                 f"out {u.get('output_tokens', 0):,}",
+                 f"total {u.get('total_tokens', 0):,} tokens"]
+        if u.get("cache_tokens"):
+            parts.append(f"cached {u['cache_tokens']:,}")
+        if u.get("context_max"):
+            parts.append(f"context {u.get('context_tokens', 0):,}/{u['context_max']:,}")
+        if u.get("cost"):
+            parts.append(f"cost {u['cost']:.4f}")
+        return "  ·  ".join(parts)
 
     def handle_final(self, payload: dict[str, Any]) -> None:
         if self._printed_final:

--- a/jiuwenswarm/common/config.py
+++ b/jiuwenswarm/common/config.py
@@ -151,10 +151,48 @@ def set_config(config):
         yaml.safe_dump(config, f, allow_unicode=True, sort_keys=False)
 
 
+_TRUE_WORDS = frozenset({"true", "1", "yes", "y", "on", "t"})
+_FALSE_WORDS = frozenset({"false", "0", "no", "n", "off", "f"})
+
+
 def _get_bool_env(value: str | None) -> bool | None:
+    """Parse a boolean environment override, or None to defer to config.
+
+    Returning None matters as much as returning a bool: None is what lets
+    config.yaml stay authoritative. Anything this function turns into False is
+    an *override*, silently beating whatever the operator configured.
+
+    Three inputs used to be read as an explicit False:
+
+    * The empty string. ``docker run -e SKILL_CREATE``, a compose file
+      interpolating an unset ``${SKILL_CREATE}``, and a CI ``env:`` block with a
+      blank value all produce it. An unset variable must mean "not overridden",
+      not "off".
+    * A value with surrounding whitespace, routine in ``.env`` files and YAML
+      env blocks, where ``" true"`` meant False.
+    * Any truthy spelling outside {true, 1, yes} -- notably ``on``, which meant
+      the same as ``off``. Two opposite words producing one answer is worse than
+      rejecting both, because ``off`` then happens to work and ``on`` fails
+      silently.
+
+    Unrecognised values now return None rather than False, so a typo falls back
+    to configuration instead of quietly disabling a feature.
+    """
     if value is None:
         return None
-    return value.lower() in ("true", "1", "yes")
+    token = value.strip().lower()
+    if not token:
+        return None
+    if token in _TRUE_WORDS:
+        return True
+    if token in _FALSE_WORDS:
+        return False
+    logger.warning(
+        "[Config] ignoring unrecognised boolean environment value %r; "
+        "falling back to configuration",
+        value,
+    )
+    return None
 
 
 def _get_evolution_config(config: dict[str, Any] | None) -> dict[str, Any]:

--- a/jiuwenswarm/common/config.py
+++ b/jiuwenswarm/common/config.py
@@ -183,6 +183,24 @@ def get_skill_create_enabled(config: dict[str, Any] | None) -> bool:
     return _get_evolution_config(config).get("skill_create", False)
 
 
+def get_rigor_audit_enabled(config: dict[str, Any] | None) -> bool:
+    """Whether RigorAuditRail is mounted on team members.
+
+    Defaults to True: the rail costs zero model calls, so the usual reason to
+    gate a capability off -- budget -- does not apply. Set ``rigor_audit.enabled:
+    false`` (or ``RIGOR_AUDIT=0``) to opt out.
+    """
+    env_rigor = _get_bool_env(os.getenv("RIGOR_AUDIT"))
+    if env_rigor is not None:
+        return env_rigor
+    if not isinstance(config, dict):
+        return True
+    section = config.get("rigor_audit")
+    if not isinstance(section, dict):
+        return True
+    return section.get("enabled", True) is not False
+
+
 def get_evolution_auto_save_enabled(config: dict[str, Any] | None = None) -> bool:
     """Return whether evolution approvals may auto-save without user action."""
     try:

--- a/jiuwenswarm/common/utils.py
+++ b/jiuwenswarm/common/utils.py
@@ -1367,6 +1367,21 @@ def _resolve_paths() -> None:
     # Migrate from legacy jiuwenclaw_workspace directory name to workspace
     _migrate_jiuwenclaw_workspace_to_workspace(workspace_dir)
 
+    # JIUWENSWARM_CONFIG_DIR overrides where config.yaml is read from. The docs
+    # present it as the way to isolate configuration between instances on one
+    # machine, and the diagnostics endpoint reports it as an active settings
+    # source -- but nothing here consulted it, so an operator following those
+    # docs silently got the default config while being told otherwise.
+    env_config_dir = os.getenv("JIUWENSWARM_CONFIG_DIR", "").strip()
+    if env_config_dir:
+        override = Path(env_config_dir).expanduser()
+        _root_dir = override.parent
+        _config_dir = override
+        _workspace_dir = workspace_dir / "agent" / "workspace"
+        _workspace_dir.mkdir(parents=True, exist_ok=True)
+        _initialized = True
+        return
+
     # 优先使用已初始化的用户工作区 (~/.jiuwenswarm)，
     # 保证源码运行与安装包运行后的读写路径完全一致。
     user_config_dir = workspace_dir / "config"

--- a/jiuwenswarm/resources/config.yaml
+++ b/jiuwenswarm/resources/config.yaml
@@ -963,7 +963,32 @@ team:
 
 mcp:
   servers: []
-  # 示例：
+  # ------------------------------------------------------------------
+  # 科研工具面：72 个工具，stdio 接入（72 个工具，stdio）
+  # ------------------------------------------------------------------
+  # 覆盖 research-pipeline skill 的十二个节点：检索与入库（paper_search /
+  # paper_ingest）、理解（paper_summarize / deep_read）、证据（claim_extract /
+  # evidence_link / evidence_trace）、分析（gap_detect / baseline_identify）、
+  # 写作（section_draft / section_revise）、验证（consistency_check /
+  # advisory_check）、审计（provenance_summary / provenance_export）。
+  #
+  # 凭据不随本仓库分发：env 块注入的环境变量优先于任何
+  # 本地文件，所以把 key 放进下面的 env 块（或宿主环境）即可，配合
+  # SCHOLAR_TOOLS_AUTO_ENV=false 可完全禁用其本地凭据自动加载。
+  #
+  # servers:
+  #   - name: scholar-tools
+  #     enabled: true
+  #     transport: stdio
+  #     command: python
+  #     args: ["-m", "scholar_tools_mcp"]
+  #     env:
+  #       SCHOLAR_TOOLS_AUTO_ENV: "false"   # 只认下面注入的，不读本地凭据文件
+  #       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+  #       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
+  #     timeout_s: 120
+  #
+  # 其它示例：
   # servers:
   #   - name: playwright
   #     enabled: true

--- a/jiuwenswarm/resources/config.yaml
+++ b/jiuwenswarm/resources/config.yaml
@@ -964,7 +964,8 @@ team:
 mcp:
   servers: []
   # ------------------------------------------------------------------
-  # 科研工具面：72 个工具，stdio 接入（72 个工具，stdio）
+  # ------------------------------------------------------------------
+  # 科研工具面：72 个工具，stdio 接入
   # ------------------------------------------------------------------
   # 覆盖 research-pipeline skill 的十二个节点：检索与入库（paper_search /
   # paper_ingest）、理解（paper_summarize / deep_read）、证据（claim_extract /
@@ -972,9 +973,8 @@ mcp:
   # 写作（section_draft / section_revise）、验证（consistency_check /
   # advisory_check）、审计（provenance_summary / provenance_export）。
   #
-  # 凭据不随本仓库分发：env 块注入的环境变量优先于任何
-  # 本地文件，所以把 key 放进下面的 env 块（或宿主环境）即可，配合
-  # SCHOLAR_TOOLS_AUTO_ENV=false 可完全禁用其本地凭据自动加载。
+  # 凭据不随本仓库分发：env 块注入的环境变量优先于任何本地凭据文件，
+  # 配合 SCHOLAR_TOOLS_AUTO_ENV=false 可完全禁用本地凭据自动加载。
   #
   # servers:
   #   - name: scholar-tools
@@ -983,7 +983,7 @@ mcp:
   #     command: python
   #     args: ["-m", "scholar_tools_mcp"]
   #     env:
-  #       SCHOLAR_TOOLS_AUTO_ENV: "false"   # 只认下面注入的，不读本地凭据文件
+  #       SCHOLAR_TOOLS_AUTO_ENV: "false"
   #       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
   #       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
   #     timeout_s: 120

--- a/jiuwenswarm/resources/config.yaml
+++ b/jiuwenswarm/resources/config.yaml
@@ -922,6 +922,16 @@ hooks:
   #         command: "echo 'agent stopping'"
 
 
+# RigorAuditRail：科研产出的严谨性地板，挂在每个 team 成员的 after_model_call 上。
+# 八项算术可裁决的检查（GRIM 均值可行性、p 值印成恰好为零、百分比超 100、方差坍缩、
+# 置信区间颠倒/零宽、占位符残留、内部生成标记泄漏、数值全落在取整网格上），findings
+# 经 PromptSection（priority 44）回注，生成 agent 下一轮即可看见自己上一轮的算术错误。
+#
+# 默认开启：该 rail 不发起任何模型调用（测试以源码断言锁死），所以通常要关一个能力的
+# 理由——预算——在这里不成立。环境变量 RIGOR_AUDIT=0 优先于本配置。
+rigor_audit:
+  enabled: true
+
 team:
   # 默认：单机 local + inprocess。双机 pyzmq 示例见 tmp/team-leader.yaml、tmp/team-teammate.yaml（与 .tmp/leader_home、.tmp/teammate_home 内 config 同步）。
   runtime:

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -3605,6 +3605,29 @@ class JiuWenSwarmDeepAdapter:
         return memory_rail
 
     @staticmethod
+    def _build_rigor_audit_rail() -> Any | None:
+        """Build RigorAuditRail for single-agent modes.
+
+        The rail was originally wired only into build_member_rails(), which
+        assembles rails for *team members*. Agent and code modes come through
+        here instead, so a rail mounted there alone never loads for the single
+        agent -- and the failure is silent, because a rail that never runs and a
+        rail that found nothing log the same thing.
+        """
+        try:
+            from jiuwenswarm.agents.harness.team.rails.rigor_audit_rail import RigorAuditRail
+            from jiuwenswarm.common.config import get_rigor_audit_enabled
+
+            if not get_rigor_audit_enabled(None):
+                return None
+            rail = RigorAuditRail()
+            logger.info("[JiuWenSwarmDeepAdapter] RigorAuditRail create success")
+        except Exception as exc:
+            logger.warning("[JiuWenSwarmDeepAdapter] RigorAuditRail create failed: %s", exc)
+            rail = None
+        return rail
+
+    @staticmethod
     def _build_heartbeat_rail() -> HeartbeatRail | None:
         """Build HeartbeatRail."""
         try:
@@ -3772,6 +3795,7 @@ class JiuWenSwarmDeepAdapter:
             _RailBuildInfo("_task_planning_rail", self._build_task_planning_rail),
             _RailBuildInfo("_security_rail", self._build_security_rail),
             _RailBuildInfo("_heartbeat_rail", self._build_heartbeat_rail),
+            _RailBuildInfo("_rigor_audit_rail", self._build_rigor_audit_rail),
             _RailBuildInfo(
                 "_llm_retry_rail",
                 self._build_llm_retry_rail,

--- a/jiuwenswarm/symphony/experience/evaluator.py
+++ b/jiuwenswarm/symphony/experience/evaluator.py
@@ -215,8 +215,7 @@ class TraceEvaluator:
             LOGGER.warning("TraceEvaluator: LLM call failed for trace %s: %s", record.trace_id, exc)
             self._fallback(record)
 
-    @staticmethod
-    def _parse_judge_response(response: str, record: TraceRecord) -> None:
+    def _parse_judge_response(self, response: str, record: TraceRecord) -> None:
         raw = response.strip()
         if raw.startswith("```"):
             raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
@@ -238,6 +237,40 @@ class TraceEvaluator:
         else:
             record.error_type = data.get("error_type") or "error"
             record.error_detail = data.get("error_detail") or ""
+
+        # A "pass" here decides whether the trace becomes an experience pattern
+        # that shapes future skill selection. When the judge is the same model
+        # that made the selection, that pass is not independent evidence -- it
+        # is the model agreeing with itself. Record how much it is worth rather
+        # than treating every success flag as equal.
+        record.verdict_gate = self._gate_verdict(record, data)
+
+    def _gate_verdict(self, record: TraceRecord, data: dict) -> dict:
+        from jiuwenswarm.agents.harness.team.rails.self_eval_gate import evaluate
+
+        decision = evaluate(
+            verdict="accept" if record.success else "reject",
+            judge_confidence=float(data.get("confidence", 0.5) or 0.5),
+            generator_model=self._llm_model,
+            judge_model=self._llm_model,
+            external_anchors=0,
+        )
+        if record.success and decision.action != "accept":
+            LOGGER.info(
+                "TraceEvaluator: trace %s graded success by the selecting model "
+                "with no independent check (%s); %d external anchor(s) would be "
+                "needed to treat it as evidence",
+                record.trace_id,
+                decision.action,
+                decision.required_external,
+            )
+        return {
+            "action": decision.action,
+            "regime": decision.regime,
+            "effective_rho": decision.effective_rho,
+            "required_external": decision.required_external,
+            "trust_adjusted_confidence": decision.trust_adjusted_confidence,
+        }
 
     @staticmethod
     def _fallback(record: TraceRecord) -> None:

--- a/jiuwenswarm/symphony/experience/models.py
+++ b/jiuwenswarm/symphony/experience/models.py
@@ -55,6 +55,10 @@ class TraceRecord:
     error_type: str | None = None
     error_detail: str | None = None
     success: bool = False
+    # How much this success flag is worth. A judge sharing the generator's
+    # blind spot produces a 'pass' that is not independent evidence; the
+    # gate records that so downstream promotion can weigh it.
+    verdict_gate: dict | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -66,6 +70,7 @@ class TraceRecord:
             "error_type": self.error_type,
             "error_detail": self.error_detail,
             "success": self.success,
+            "verdict_gate": self.verdict_gate,
         }
 
     @classmethod
@@ -79,6 +84,7 @@ class TraceRecord:
             error_type=data.get("error_type"),
             error_detail=data.get("error_detail"),
             success=bool(data.get("success", False)),
+            verdict_gate=data.get("verdict_gate"),
         )
 
 

--- a/scripts/verify_rail_live.py
+++ b/scripts/verify_rail_live.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Check that RigorAuditRail actually works against a live model, end to end.
+
+The unit tests prove the rail's logic and that it reaches the rail chain. They
+cannot prove the thing that broke twice in this project's history: that at
+runtime the rail is mounted, receives the model's real output, and fires.
+
+Both of those failures were silent -- a rail that was never mounted, and one
+that read a context field that does not exist -- and neither showed up as an
+error. A rail examining nothing and a rail examining a clean draft produce
+identical logs. So this script observes the behaviour rather than inferring it.
+
+    export OPENAI_BASE_URL=...  OPENAI_API_KEY=...
+    python scripts/verify_rail_live.py [--model gpt-5.5]
+
+It makes two live calls: one asking for clean text (the rail must stay silent)
+and one asking for text with arithmetic defects (the rail must fire). A rail
+that fires on both is as broken as one that fires on neither.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import urllib.request
+
+CLEAN = ("Write one sentence reporting an experiment result with a mean, its "
+         "sample size, a p-value and a percentage. All values must be internally "
+         "consistent. Output only the sentence.")
+
+DIRTY = ("Reproduce this sentence verbatim, changing nothing: "
+         "The intervention improved accuracy by 118.4% "
+         "(p = 0.000, 95% CI [0.71, 0.55]).")
+
+
+def call(prompt, model, base, key):
+    body = json.dumps({"model": model,
+                       "messages": [{"role": "user", "content": prompt}]}).encode()
+    req = urllib.request.Request(
+        base.rstrip("/") + "/chat/completions", data=body,
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"})
+    out = json.loads(urllib.request.urlopen(req, timeout=180).read())
+    return out["choices"][0]["message"]["content"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default=os.environ.get("PROBE_MODEL", "gpt-5.5"))
+    a = ap.parse_args()
+
+    base, key = os.environ.get("OPENAI_BASE_URL"), os.environ.get("OPENAI_API_KEY")
+    if not (base and key):
+        sys.exit("set OPENAI_BASE_URL and OPENAI_API_KEY (any OpenAI-compatible gateway)")
+
+    from openjiuwen.core.single_agent.rail.base import (
+        AgentCallbackContext,
+        ModelCallInputs,
+    )
+    from jiuwenswarm.agents.harness.team.team_runtime_inheritance import (
+        build_member_rails,
+    )
+
+    rails = build_member_rails()
+    names = [type(r).__name__ for r in rails]
+    print(f"rail chain: {names}")
+    rail = next((r for r in rails if type(r).__name__ == "RigorAuditRail"), None)
+    if rail is None:
+        sys.exit("FAIL: RigorAuditRail is not on the chain built by build_member_rails()")
+    rail._agent_id = "live-verify"
+
+    def run(prompt, label):
+        text = call(prompt, a.model, base, key)
+        print(f"\n[{label}] model said: {text.strip()[:180]}")
+
+        class Resp:
+            content = text
+
+        before = len(rail.findings)
+        asyncio.run(rail.after_model_call(
+            AgentCallbackContext(agent=None, inputs=ModelCallInputs(response=Resp()))))
+        fired = [f.code for f in rail.findings[before:]]
+        print(f"[{label}] findings: {fired or '(none)'}")
+        return fired
+
+    clean = run(CLEAN, "clean")
+    dirty = run(DIRTY, "defective")
+
+    print()
+    ok = True
+    if dirty:
+        print(f"✓ rail fires on live model output ({len(dirty)} finding(s))")
+    else:
+        print("✗ rail silent on defective output -- it is mounted but not working")
+        ok = False
+    if clean:
+        print(f"⚠ rail also fired on the clean sample {clean}; inspect the sentence "
+              "above -- models do produce genuinely infeasible numbers unprompted, "
+              "so this is not automatically a false positive")
+    else:
+        print("✓ rail silent on clean output (no false alarm)")
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agents/harness/team/rails/test_rigor_audit_rail.py
+++ b/tests/agents/harness/team/rails/test_rigor_audit_rail.py
@@ -125,6 +125,27 @@ class TestRailContract:
         with pytest.raises(Exception):
             f.code = "D2"
 
+    def test_rail_is_actually_mounted_on_team_members(self):
+        """Exporting the class is not enough -- it has to reach the rail chain.
+
+        This is the regression that matters most: a rail that is importable but
+        never mounted looks fine in review and does nothing at runtime.
+        """
+        from jiuwenswarm.agents.harness.team.team_runtime_inheritance import (
+            build_member_rails,
+        )
+
+        names = [type(r).__name__ for r in build_member_rails()]
+        assert "RigorAuditRail" in names
+
+    def test_mounting_can_be_disabled_by_config(self):
+        from jiuwenswarm.common.config import get_rigor_audit_enabled
+
+        assert get_rigor_audit_enabled(None) is True
+        assert get_rigor_audit_enabled({}) is True
+        assert get_rigor_audit_enabled({"rigor_audit": {"enabled": False}}) is False
+        assert get_rigor_audit_enabled({"rigor_audit": {"enabled": True}}) is True
+
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agents/harness/team/rails/test_rigor_audit_rail.py
+++ b/tests/agents/harness/team/rails/test_rigor_audit_rail.py
@@ -147,5 +147,61 @@ class TestRailContract:
         assert get_rigor_audit_enabled({"rigor_audit": {"enabled": True}}) is True
 
 
+
+class TestResponseIsActuallyRead:
+    """The rail must read the response from where the framework puts it.
+
+    AFTER_MODEL_CALL carries a ModelCallInputs on ctx.inputs, and the assistant
+    text is ctx.inputs.response. A rail reading ctx.response gets None, audits
+    an empty string, reports nothing -- and looks identical in the log to a rail
+    that examined a clean draft. That silence is why this is tested directly.
+    """
+
+    @staticmethod
+    def _ctx(response):
+        from openjiuwen.core.single_agent.rail.base import (
+            AgentCallbackContext,
+            ModelCallInputs,
+        )
+
+        return AgentCallbackContext(agent=None, inputs=ModelCallInputs(response=response))
+
+    def test_reads_text_from_inputs_response(self):
+        from jiuwenswarm.agents.harness.team.rails.response_text import response_text
+
+        class Resp:
+            content = "mean 3.47 with n=10"
+
+        assert response_text(self._ctx(Resp())) == "mean 3.47 with n=10"
+
+    def test_reads_multimodal_content_blocks(self):
+        from jiuwenswarm.agents.harness.team.rails.response_text import response_text
+
+        class Resp:
+            content = [{"type": "text", "text": "p = 0.000"},
+                       {"type": "image", "source": "..."}]
+
+        assert response_text(self._ctx(Resp())) == "p = 0.000"
+
+    def test_missing_response_yields_empty_string(self):
+        from jiuwenswarm.agents.harness.team.rails.response_text import response_text
+
+        assert response_text(self._ctx(None)) == ""
+        assert response_text(None) == ""
+
+    @pytest.mark.asyncio
+    async def test_rail_records_a_finding_from_a_real_context(self):
+        """End to end: a flawed draft on ctx.inputs.response must produce a finding."""
+        rail = RigorAuditRail()
+        rail._agent_id = "test"
+
+        class Resp:
+            content = "We observed 130% improvement (p = 0.000)."
+
+        await rail.after_model_call(self._ctx(Resp()))
+        codes = {f.code for f in rail.findings}
+        assert "D9_percent_out_of_range" in codes
+        assert "D11_pvalue_exact_zero" in codes
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agents/harness/team/rails/test_rigor_audit_rail.py
+++ b/tests/agents/harness/team/rails/test_rigor_audit_rail.py
@@ -1,0 +1,130 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Tests for RigorAuditRail — the deterministic manuscript-rigor scanner.
+
+The rail carries no model call, so every assertion here is exact: a reported
+value either is arithmetically infeasible or it is not. That is the point of
+the layer. It is the floor beneath the semantic reviewers, and a floor whose
+firing needs a model to adjudicate would not be a floor.
+"""
+
+import pytest
+
+from jiuwenswarm.agents.harness.team.rails.rigor_audit_rail import (
+    RigorAuditRail,
+    RigorFinding,
+    _grim_infeasible,
+    audit_text,
+)
+
+
+def codes(text: str) -> set[str]:
+    return {f.code for f in audit_text(text)}
+
+
+class TestGrim:
+    """A mean of n integer responses must land on the 1/n grid."""
+
+    def test_infeasible_mean_is_flagged(self):
+        assert _grim_infeasible("3.17", 20) is True
+
+    def test_feasible_mean_passes(self):
+        assert _grim_infeasible("3.15", 20) is False   # 63/20
+        assert _grim_infeasible("2.50", 4) is False    # 10/4
+
+    def test_large_n_admits_two_decimals(self):
+        assert _grim_infeasible("3.17", 1000) is False
+
+    def test_out_of_range_n_is_not_judged(self):
+        assert _grim_infeasible("3.17", 0) is False
+        assert _grim_infeasible("3.17", 5000) is False
+
+    def test_fires_through_the_public_entry_point(self):
+        assert "D10_stat_feasibility" in codes("The mean = 3.17 across conditions (n = 20).")
+
+
+class TestDeterministicChecks:
+    def test_clean_text_yields_nothing(self):
+        assert audit_text(
+            "We report 85.2% accuracy on the held-out split (n = 200), p < 0.01, "
+            "95% CI [0.81, 0.89]."
+        ) == []
+
+    def test_p_value_of_exactly_zero(self):
+        assert "D11_pvalue_exact_zero" in codes("The contrast was significant (p = 0.000).")
+
+    def test_percentage_above_one_hundred(self):
+        assert "D9_percent_out_of_range" in codes("Recall improved to 118.4% of baseline.")
+
+    def test_collapsed_dispersion_needs_two_cells(self):
+        one = "Group A scored 4.20 (SD = 0.00)."
+        two = one + " Group B scored 3.80 (SD = 0.00)."
+        assert "D2_missing_variance" not in codes(one)
+        assert "D2_missing_variance" in codes(two)
+
+    def test_inverted_interval(self):
+        assert "D20_ci_inverted" in codes("The effect was large, 95% CI [0.71, 0.55].")
+
+    def test_zero_width_interval(self):
+        assert "D27_ci_zero_width" in codes("The estimate was tight, 95% CI [0.40, 0.40].")
+
+    def test_placeholder_left_in_the_draft(self):
+        assert "D34_submission_completeness" in codes("Accuracy improved by TODO points.")
+        assert "D34_submission_completeness" in codes("Written by Author B and colleagues.")
+
+    def test_internal_generation_marker_leak(self):
+        assert "D28_internal_marker_leak" in codes(
+            "This section reports the target_result for the primary endpoint."
+        )
+        assert "D28_internal_marker_leak" in codes("writing_mode: dream")
+
+    def test_rounding_grid_needs_four_values(self):
+        three = "Scores were 1.00, 2.00 and 3.00."
+        four = three + " A fourth condition gave 4.00."
+        assert "D1_result_number_grid" not in codes(three)
+        assert "D1_result_number_grid" in codes(four)
+
+    def test_findings_render_without_raising(self):
+        for finding in audit_text("p = 0.000 and the interval is [0.90, 0.10]."):
+            rendered = finding.render()
+            assert isinstance(rendered, str) and finding.code in rendered
+
+    def test_audit_text_is_pure(self):
+        """Same input, same output, and the first call cannot affect the second."""
+        text = "mean = 3.17 (n = 20), p = 0.000"
+        assert audit_text(text) == audit_text(text)
+
+
+class TestRailContract:
+    def test_priority_does_not_collide_with_governance_rail(self):
+        from jiuwenswarm.agents.harness.team.rails import GovernanceReviewRail
+        assert RigorAuditRail.SECTION_PRIORITY != GovernanceReviewRail.SECTION_PRIORITY
+
+    def test_rail_is_exported_from_the_package(self):
+        from jiuwenswarm.agents.harness.team import rails
+        assert "RigorAuditRail" in rails.__all__
+        assert rails.RigorAuditRail is RigorAuditRail
+
+    def test_findings_start_empty(self):
+        assert RigorAuditRail().findings == []
+
+    def test_rail_adds_no_model_call(self):
+        """The audit layer must cost zero tokens; that is what makes it a floor."""
+        import inspect
+        src = inspect.getsource(
+            __import__(
+                "jiuwenswarm.agents.harness.team.rails.rigor_audit_rail",
+                fromlist=["rigor_audit_rail"],
+            )
+        )
+        for forbidden in ("chat(", "completion(", "invoke_model", "acompletion"):
+            assert forbidden not in src, f"rail must stay deterministic: {forbidden}"
+
+    def test_finding_is_immutable(self):
+        f = RigorFinding("D1", "msg", "evidence")
+        with pytest.raises(Exception):
+            f.code = "D2"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agents/harness/team/rails/test_rigor_audit_rail.py
+++ b/tests/agents/harness/team/rails/test_rigor_audit_rail.py
@@ -205,3 +205,43 @@ class TestResponseIsActuallyRead:
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+class TestMountedInEveryMode:
+    """One assembly point is not the assembly point.
+
+    Rails reach a running agent through two different builders: team members go
+    through build_member_rails(), while agent and code modes go through the deep
+    adapter's _build_agent_rails(). Wiring only the first leaves the single-agent
+    path — the one the CLI uses by default — with no rail at all, and the gap is
+    invisible until something actually runs.
+    """
+
+    def test_team_member_path_mounts_it(self):
+        from jiuwenswarm.agents.harness.team.team_runtime_inheritance import (
+            build_member_rails,
+        )
+
+        assert "RigorAuditRail" in [type(r).__name__ for r in build_member_rails()]
+
+    def test_single_agent_path_registers_a_builder(self):
+        import inspect
+
+        from jiuwenswarm.server.runtime.agent_adapter.interface_deep import (
+            JiuWenSwarmDeepAdapter,
+        )
+
+        assert hasattr(JiuWenSwarmDeepAdapter, "_build_rigor_audit_rail")
+        src = inspect.getsource(JiuWenSwarmDeepAdapter._build_agent_rails)
+        assert "_rigor_audit_rail" in src, (
+            "the builder exists but is not in the rail list, so agent mode still "
+            "runs without the floor"
+        )
+
+    def test_single_agent_builder_returns_a_rail(self):
+        from jiuwenswarm.server.runtime.agent_adapter.interface_deep import (
+            JiuWenSwarmDeepAdapter,
+        )
+
+        rail = JiuWenSwarmDeepAdapter._build_rigor_audit_rail()
+        assert rail is not None and type(rail).__name__ == "RigorAuditRail"

--- a/tests/agents/harness/team/rails/test_self_eval_gate.py
+++ b/tests/agents/harness/team/rails/test_self_eval_gate.py
@@ -1,0 +1,130 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Tests for the correlation-aware self-evaluation gate.
+
+The gate decides how much an agent's own "pass" is worth. Every assertion here
+is exact -- the rule is arithmetic, and a gate that needed a model to decide
+whether it fired would inherit the very bias it exists to price in.
+"""
+
+import pytest
+
+from jiuwenswarm.agents.harness.team.rails.self_eval_gate import evaluate
+
+
+class TestRegimeDetection:
+    def test_identical_models_are_self_graded(self):
+        d = evaluate(verdict="accept", generator_model="gpt-5.5", judge_model="gpt-5.5")
+        assert d.self_graded is True and d.regime == "self_graded"
+
+    def test_same_family_only_partly_decorrelates(self):
+        d = evaluate(verdict="accept", generator_model="gpt-5.5", judge_model="gpt-4.9")
+        assert d.regime == "cross_model"
+        assert d.effective_rho == pytest.approx(0.7 * 0.7)
+
+    def test_different_family_decorrelates_further_but_not_fully(self):
+        d = evaluate(verdict="accept", generator_model="gpt-5.5", judge_model="claude-opus-5")
+        assert d.effective_rho == pytest.approx(0.7 * 0.5)
+        assert d.effective_rho > 0, "shared familiarity bias means residual correlation remains"
+
+    def test_unknown_provenance_assumes_the_worst_case(self):
+        # The convenient assumption would be independence. That is exactly the
+        # assumption an unaudited pipeline makes by accident.
+        d = evaluate(verdict="accept")
+        assert d.self_graded is True and d.regime == "self_graded"
+
+    def test_same_lineage_flag_overrides_differing_model_strings(self):
+        d = evaluate(verdict="accept", generator_model="a", judge_model="b", same_lineage=True)
+        assert d.self_graded is True
+
+
+class TestAnchorRequirement:
+    def test_self_graded_with_no_anchor_abstains(self):
+        d = evaluate(verdict="accept", generator_model="m", judge_model="m")
+        assert d.action == "abstain"
+        assert d.required_external > 0
+
+    def test_confidence_never_substitutes_for_an_anchor(self):
+        """A contaminated judge is confident for the same reason it is wrong."""
+        low = evaluate(verdict="accept", generator_model="m", judge_model="m",
+                       judge_confidence=0.01)
+        high = evaluate(verdict="accept", generator_model="m", judge_model="m",
+                        judge_confidence=0.99)
+        assert low.required_external == high.required_external
+        assert low.action == high.action == "abstain"
+
+    def test_anchors_reduce_the_requirement_monotonically(self):
+        needs = [evaluate(verdict="accept", generator_model="m", judge_model="m",
+                          external_anchors=k).required_external for k in range(8)]
+        assert needs == sorted(needs, reverse=True)
+        assert needs[-1] == 0
+
+    def test_enough_anchors_reach_accept(self):
+        d = evaluate(verdict="accept", generator_model="m", judge_model="m",
+                     external_anchors=6)
+        assert d.action == "accept" and d.residual_risk <= d.alpha
+
+    def test_higher_contamination_demands_more_anchors(self):
+        lo = evaluate(verdict="accept", generator_model="m", judge_model="m",
+                      contamination_rho=0.3)
+        hi = evaluate(verdict="accept", generator_model="m", judge_model="m",
+                      contamination_rho=0.9)
+        assert hi.required_external > lo.required_external
+
+    def test_tighter_budget_demands_more_anchors(self):
+        loose = evaluate(verdict="accept", generator_model="m", judge_model="m", alpha=0.2)
+        tight = evaluate(verdict="accept", generator_model="m", judge_model="m", alpha=0.01)
+        assert tight.required_external > loose.required_external
+
+
+class TestAsymmetry:
+    @pytest.mark.parametrize("verdict", ["reject", "fail", "not novel", "no"])
+    def test_negative_verdicts_pass_straight_through(self, verdict):
+        # Contamination inflates a model's acceptance of its own favoured
+        # outputs; it does not manufacture rejections.
+        d = evaluate(verdict=verdict, generator_model="m", judge_model="m")
+        assert d.action == "accept_verdict"
+        assert d.required_external == 0
+
+    def test_positive_verdict_does_not_pass_through(self):
+        d = evaluate(verdict="accept", generator_model="m", judge_model="m")
+        assert d.action != "accept_verdict"
+
+
+class TestContract:
+    def test_gate_makes_no_model_call(self):
+        import inspect
+
+        from jiuwenswarm.agents.harness.team.rails import self_eval_gate
+
+        src = inspect.getsource(self_eval_gate)
+        for forbidden in ("chat(", "completion(", "invoke_model", "acompletion", "llm"):
+            assert forbidden not in src, f"gate must stay deterministic: {forbidden}"
+
+    def test_decision_is_immutable(self):
+        d = evaluate(verdict="accept")
+        with pytest.raises(Exception):
+            d.action = "accept"
+
+    def test_render_names_the_action_and_the_numbers(self):
+        text = evaluate(verdict="accept", generator_model="m", judge_model="m").render()
+        assert "abstain" in text and "alpha" in text
+
+    def test_evaluator_attaches_the_gate_to_every_graded_trace(self):
+        """Wired, not dangling: the trace evaluator must record the discount."""
+        from jiuwenswarm.symphony.experience.evaluator import TraceEvaluator
+        from jiuwenswarm.symphony.experience.models import TraceRecord
+
+        rec = TraceRecord(trace_id="t1", query="q", skills=["s"], result="r")
+        ev = TraceEvaluator(llm_model="gpt-5.5")
+        ev._parse_judge_response('{"success": true}', rec)
+
+        assert rec.success is True
+        assert rec.verdict_gate is not None
+        assert rec.verdict_gate["regime"] == "self_graded"
+        assert rec.verdict_gate["required_external"] > 0
+        assert "verdict_gate" in rec.to_dict()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/unit_tests/gateway/test_message_handler_security_review_prompt.py
+++ b/tests/unit_tests/gateway/test_message_handler_security_review_prompt.py
@@ -80,7 +80,14 @@ def _add_origin_head(path: str, bare: str) -> None:
     # 先 fetch 建立 refs/remotes/origin/* ，再用显式分支名 set-head
     # （`set-head origin HEAD` 在某些 git 版本会静默不写 symref）。
     subprocess.run([_GIT, "-C", path, "fetch", "-q", "origin"], check=True)
-    subprocess.run([_GIT, "-C", path, "remote", "set-head", "origin", "master"], check=True)
+    # 分支名必须从仓库问出来，不能写死 "master"：git init 用的是 init.defaultBranch，
+    # 开发机把它设成 main 是当下的常见配置（git 自己也在推荐），此时写死 master 会让
+    # set-head 报 "not a valid ref"，整组测试在那台机器上必挂。
+    branch = subprocess.run(
+        [_GIT, "-C", path, "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    subprocess.run([_GIT, "-C", path, "remote", "set-head", "origin", branch], check=True)
 
 
 def test_run_security_review_git_succeeds_when_origin_head_set(tmp_path):

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -739,3 +739,50 @@ class TestBooleanEnvOverride:
     ):
         monkeypatch.setenv("SKILL_CREATE", "false")
         assert get_skill_create_enabled({"evolution": {"skill_create": True}}) is False
+
+
+class TestConfigDirOverride:
+    """JIUWENSWARM_CONFIG_DIR must actually move where config.yaml is read from.
+
+    The variable is documented as the way to isolate configuration between
+    instances on one machine, and the diagnostics endpoint reports it as an
+    active settings source. It was consulted for sys.path only, so an operator
+    following the docs silently ran on the default config while being told the
+    override was in effect.
+    """
+
+    @staticmethod
+    def _fresh_paths(monkeypatch: pytest.MonkeyPatch, value: str | None):
+        from jiuwenswarm.common import utils
+
+        if value is None:
+            monkeypatch.delenv("JIUWENSWARM_CONFIG_DIR", raising=False)
+        else:
+            monkeypatch.setenv("JIUWENSWARM_CONFIG_DIR", value)
+        monkeypatch.setattr(utils, "_initialized", False, raising=False)
+        return utils.get_config_file()
+
+    def test_override_moves_the_config_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        target = tmp_path / "instance-a"
+        target.mkdir()
+        assert self._fresh_paths(monkeypatch, str(target)) == target / "config.yaml"
+
+    def test_two_overrides_isolate_from_each_other(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        a = self._fresh_paths(monkeypatch, str(tmp_path / "a"))
+        b = self._fresh_paths(monkeypatch, str(tmp_path / "b"))
+        assert a != b, "instances sharing one config file are not isolated"
+
+    def test_blank_override_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        blank = self._fresh_paths(monkeypatch, "  ")
+        unset = self._fresh_paths(monkeypatch, None)
+        assert blank == unset
+
+    def test_user_home_is_expanded(self, monkeypatch: pytest.MonkeyPatch):
+        got = self._fresh_paths(monkeypatch, "~/some-instance-config")
+        assert "~" not in str(got)

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -671,3 +671,71 @@ modes:
 
         raw = yaml.safe_load(temp_config_file.read_text(encoding="utf-8"))
         assert "team" not in raw["modes"]
+
+
+class TestBooleanEnvOverride:
+    """A boolean env override must not silently beat configuration.
+
+    ``_get_bool_env`` returning False is an *override*; returning None is what
+    lets config.yaml remain authoritative. Reading an unset, blank or padded
+    variable as False turned "not overridden" into "off" with no diagnostic.
+    """
+
+    @pytest.mark.parametrize(
+        "env_value",
+        ["", " ", "\t", "\n"],
+    )
+    def test_blank_env_defers_to_config(
+        self, monkeypatch: pytest.MonkeyPatch, env_value
+    ):
+        # `docker run -e SKILL_CREATE`, compose interpolating an unset
+        # ${SKILL_CREATE}, and a CI env: block with a blank value all land here.
+        monkeypatch.setenv("SKILL_CREATE", env_value)
+        assert get_skill_create_enabled({"evolution": {"skill_create": True}}) is True
+
+    @pytest.mark.parametrize(
+        ("env_value", "expected"),
+        [
+            (" true", True),
+            ("true ", True),
+            ("  TRUE  ", True),
+            (" false", False),
+            ("false ", False),
+        ],
+    )
+    def test_surrounding_whitespace_is_stripped(
+        self, monkeypatch: pytest.MonkeyPatch, env_value, expected
+    ):
+        # .env files and YAML env blocks routinely carry padding.
+        monkeypatch.setenv("SKILL_CREATE", env_value)
+        assert get_skill_create_enabled({}) is expected
+
+    @pytest.mark.parametrize(
+        ("env_value", "expected"),
+        [
+            ("on", True), ("off", False),
+            ("yes", True), ("no", False),
+            ("y", True), ("n", False),
+            ("1", True), ("0", False),
+            ("t", True), ("f", False),
+        ],
+    )
+    def test_opposite_spellings_give_opposite_answers(
+        self, monkeypatch: pytest.MonkeyPatch, env_value, expected
+    ):
+        # The dangerous case was `on` and `off` both meaning off: `off` then
+        # works by accident while `on` fails silently.
+        monkeypatch.setenv("SKILL_CREATE", env_value)
+        assert get_skill_create_enabled({}) is expected
+
+    def test_unrecognised_value_falls_back_rather_than_disabling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("SKILL_CREATE", "ture")  # a typo, not an instruction
+        assert get_skill_create_enabled({"evolution": {"skill_create": True}}) is True
+
+    def test_explicit_false_still_overrides_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("SKILL_CREATE", "false")
+        assert get_skill_create_enabled({"evolution": {"skill_create": True}}) is False


### PR DESCRIPTION
# Two governance rails, and five silent-failure fixes found by running the framework

## Summary

Ten commits on top of `20495a2a`: two features that give research agents a
deterministic reliability floor, and five bug fixes. Every bug here was hit while
actually operating the framework — booting the services, driving the CLI against
a live model, reading the wire frames — not by reading the source.

Four of the five share one property worth naming up front: **they fail silently.**
A configuration override that is ignored while being reported as active, a
feature switch turned off by a blank environment variable, a tool name that never
reaches the terminal, token accounting that is transmitted and then dropped —
none of them raises anything. The system looks fine.

`pytest tests/ -q` → **3120 passed, 18 skipped**, verified from a clean checkout
of the baseline (see Testing).

---

## Features

### `RigorAuditRail` — a zero-token deterministic rigor floor

Agent-written research text contains a class of error that needs no domain
knowledge to settle: a mean that no integer count over the stated n can produce,
a p-value printed as exactly zero, a percentage above 100, an interval whose
bounds are inverted or whose width is zero, leftover placeholders, internal
generation markers reaching the public surface.

Semantic review buries these among style comments. They are **arithmetically
decidable**, so they should not be spending a model's judgement at all.

Nine checks run on every `after_model_call`. Findings accumulate on the rail and
are injected back as a `PromptSection` at priority 44 — one below the governance
rail — so a generating agent sees its own arithmetic errors *on the next turn*
rather than at review time.

**Zero token cost is the design, not a side effect.** A check that needs a model
call can only run once, at the end; a free one runs continuously. And a free
check's firing is a *fact* a downstream reviewer can rely on, where a check that
needs a model to adjudicate whether it fired is merely one more opinion.
`test_rail_adds_no_model_call` asserts on the rail's own source, so adding a
model call anywhere in it breaks the suite.

Mounted at both assembly points — `build_member_rails()` for team members and
`_build_agent_rails()` for agent and code modes — and gated by
`rigor_audit.enabled` (default true, `RIGOR_AUDIT` takes precedence).

`scripts/verify_rail_live.py` checks the runtime behaviour against a live
gateway: unit tests prove the logic, but only a live run proves the rail is
mounted and receiving real model output, which is exactly the property that
fails silently.

### `self_eval_gate` — pricing a self-graded verdict

`TraceEvaluator` asks a model whether a skill selection was correct, and that
`success=true` decides whether the trace becomes an experience pattern shaping
future skill selection.

The model making the selection and the model judging it are usually the same one.
That "pass" is not independent evidence — it is the model agreeing with itself —
and the loop then hardens it into experience, which the same model grades
successful again next round. **The loop closes on itself, drifts further each
time, and never raises anything.**

Using a different model only partly decorrelates: same-family checkpoints share
preferences, and even across families a shared sense of what a good answer looks
like leaves residual correlation.

So the gate does not ask whether to trust a verdict; it **prices** it. Given the
judge/generator correlation ρ and an acceptable residual error rate α, residual
risk after k independent anchors is ρ^(k+1), so k+1 ≥ log α / log ρ checks are
needed. It returns how many the verdict still lacks.

Two deliberate asymmetries:

- **Negative verdicts pass straight through.** Contamination inflates a model's
  acceptance of its own favoured output, not its rejections. Keeping something
  out is the safe direction.
- **Unknown provenance is treated as self-graded.** "They are probably
  independent" is precisely the assumption an unaudited pipeline makes by
  accident.

With no external anchor at all the gate returns `abstain`, not "accept
cautiously" — no confidence level substitutes for an independent check, since a
contaminated judge is confident for the same reason it is wrong.

The risk model is stated in the docstring as **a conservative policy for routing
verification effort, not a proven statistical bound.** A gate that overstated its
own guarantee would be the failure it exists to prevent.

Wired into the evolution loop: every graded trace carries the decision on
`TraceRecord.verdict_gate`, unanchored self-grades are logged. **Behaviour is
unchanged by default** — the gate annotates rather than blocks, so an existing
loop keeps running while the discount becomes visible.

---

## Bug fixes

### 1. `JIUWENSWARM_CONFIG_DIR` had no effect

`_resolve_paths()` never read it. It checks `~/.jiuwenswarm/config`, then the
packaged `resources`, then the source root — and stops.

Meanwhile the variable is:

- documented in **three** guides as the way to isolate configuration between
  instances on one machine
- reported back to the user by the diagnostics endpoint as an active settings
  source (`agent_ws_server.py` appends it to `settings_sources`)

The only place it was consulted (`common/config.py`) uses it for `sys.path`,
which has nothing to do with where `config.yaml` is read from.

An operator following the multi-instance guide silently ran on the default
config **while being told the override was in effect**. Two instances believing
they are isolated share one configuration file.

```bash
export JIUWENSWARM_CONFIG_DIR=/tmp/instance-a
python -c "from jiuwenswarm.common.utils import get_config_file; print(get_config_file())"
# before: ~/.jiuwenswarm/config/config.yaml   <- override ignored
# after:  /tmp/instance-a/config.yaml
```

Four tests: the override takes effect, two overrides do not collide, a blank
value falls back, `~` expands.

### 2. A blank or padded boolean env var silently disabled a feature

`_get_bool_env` returning `None` is what lets `config.yaml` stay authoritative;
anything it turns into `False` is an **override** beating the configured value.
Three inputs were read as an explicit `False`:

- **The empty string** — `docker run -e SKILL_CREATE`, a compose file
  interpolating an unset `${SKILL_CREATE}`, a CI `env:` block with a blank value.
  An unset variable means "not overridden", not "off".
- **Surrounding whitespace** — routine in `.env` files and YAML env blocks, where
  `" true"` meant `False`.
- **Truthy spellings outside {true, 1, yes}** — notably `on`, which meant the
  same as `off`. Two opposite words giving one answer is worse than rejecting
  both: `off` then works by accident while `on` fails silently.

Affects every gate reading the helper: `SKILL_CREATE`, `EVOLUTION_AUTO_SCAN`,
`EVOLUTION_AUTO_SAVE`, `RIGOR_AUDIT`. Unrecognised values now return `None` with
a warning, so a typo falls back to configuration instead of disabling a feature.

### 3. Tool-call events carry two payload shapes

```
chat.tool_call    -> {"event_type", "session_id", "tool_call": {"name", "arguments", ...}}
chat.tool_update  -> {"event_type", "session_id", "tool_name", "arguments", "status", ...}
chat.tool_result  -> {"event_type", "session_id", "tool_name", "result", ...}
```

One event family, two shapes: `tool_call` nests the name, the others flatten it.
The CLI read only the flat form, so every call rendered as `?` — the result was
visible, what produced it was not.

Reproduce with `jiuwenswarm chat --show-tools "read a file in this directory"`.
The renderer now accepts both shapes.

### 4. Token accounting was transmitted and discarded

The server already emits it:

```json
{"event_type": "chat.usage_metadata",
 "metadata": {"usage_metadata": {"input_tokens": 21555, "output_tokens": 43,
                                 "total_tokens": 21598, "cache_tokens": 0}}}
{"event_type": "context.usage", "tokens_used": 25952, "context_max": 1050000}
```

Neither had an entry in `event_kind()`, so both fell into the generic `chat.`
bucket and were dropped. The data was on the wire; the consumer was missing, and
a command-line run could not report what it cost.

Visible with `--jsonl`, invisible without it. Now classified, accumulated, and
printed on exit — from a `finally` block, because a run that failed still spent
the tokens:

```
[usage] 3 model call(s) · in 69,147 · out 138 · total 69,285 tokens · cached 41,984
```

### 5. A test hardcoded the `master` branch

`_add_origin_head` ran `git remote set-head origin master`, but the repository it
builds comes from `git init`, which names the branch after `init.defaultBranch`.
Developers who set that to `main` — now common, and what git itself nudges
toward — got `not a valid ref` and three failures in this file on every run.

Measured before and after in that file: `5 passed / 3 failed` → **`8 passed`**.

---

## Reported, not fixed: keepalive outlives the client

The heartbeat loop in `agent_ws_server.py` exits on two conditions only:
cancellation, or `WebSocketConnectionClosed` from the socket it writes to. But
that socket is the **gateway ↔ agentserver** one — a terminal client
disconnecting from the gateway does not close it.

Observed: a failed request kept emitting keepalives every 10 seconds for minutes
after the client had exited.

Structurally: **end-client liveness is not propagated to the producing task.**

No fix is included. Changing server-side cancellation semantics deserves a
fuller reproduction than we have, and a careless change would break heartbeats
for legitimately long-running tasks. Raising it here for maintainer judgement.

---

## Testing

```
pytest tests/ -q
3120 passed, 18 skipped
```

Verified from a clean checkout of the baseline, not just in our working tree:

```
git worktree add --detach /tmp/verify 20495a2a
cd /tmp/verify && git am < 0001-rigor-audit-rail.patch
# 10 commits applied with no conflicts and no 3-way fallback
pytest tests/ -q  ->  3120 passed, 18 skipped
```

Covering: the nine detectors and their threshold behaviour, GRIM boundary
conditions, rail purity and both mount points, the gate's regime detection and
anchor arithmetic (including that judge confidence never substitutes for an
anchor), boolean env parsing across blank/padded/opposite-spelling inputs, and
config-directory isolation.
