### PR TITLE
fix(team): honor named member model bindings

### DIFF
--- a/jiuwenswarm/agents/harness/team/team_manager.py
+++ b/jiuwenswarm/agents/harness/team/team_manager.py
@@ -92,6 +92,117 @@ TEAM_EVENT_QUEUE_MAXSIZE = 64
 _WAITER_PUT_RECHECK_TIMEOUT_SEC = 0.1
 
 
+def _agent_model_name(agent_spec: Any) -> str:
+    """Return the explicit model name carried by one DeepAgent spec mapping."""
+    if not isinstance(agent_spec, dict):
+        return ""
+    model = agent_spec.get("model")
+    if not isinstance(model, dict):
+        return ""
+    client = model.get("model_client_config")
+    if not isinstance(client, dict):
+        return ""
+    return str(client.get("model_name") or "").strip()
+
+
+def _bind_named_member_models(
+    spec_dict: dict[str, Any],
+    config_base: dict[str, Any],
+) -> None:
+    """Bind member-named model configs to predefined team members.
+
+    Team members share the semantic ``teammate`` role, while JiuwenSwarm also
+    permits named ``agents.<member_name>`` model configs. Project those names
+    onto ``TeamMemberSpec.model_name`` and expose their endpoints through the
+    model pool so a specialist does not silently use the generic teammate
+    model.
+    """
+    agents = spec_dict.get("agents")
+    if not isinstance(agents, dict):
+        return
+    named_model_names = {
+        str(agent_key): model_name
+        for agent_key, agent_spec in agents.items()
+        if (model_name := _agent_model_name(agent_spec))
+    }
+
+    predefined = spec_dict.get("predefined_members")
+    if isinstance(predefined, list):
+        for member in predefined:
+            if not isinstance(member, dict):
+                continue
+            member_name = str(member.get("member_name") or "").strip()
+            model_name = named_model_names.get(member_name, "")
+            if model_name:
+                member["model_name"] = model_name
+
+    leader = spec_dict.get("leader")
+    if isinstance(leader, dict) and named_model_names.get("leader"):
+        leader["model_name"] = named_model_names["leader"]
+
+    model_sources: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for entry in get_default_models(config_base):
+        if not isinstance(entry, dict):
+            continue
+        client = entry.get("model_client_config")
+        request = entry.get("model_config_obj")
+        if isinstance(client, dict):
+            model_sources.append((client, request if isinstance(request, dict) else {}))
+    for agent_spec in agents.values():
+        if not isinstance(agent_spec, dict):
+            continue
+        model = agent_spec.get("model")
+        if not isinstance(model, dict):
+            continue
+        client = model.get("model_client_config")
+        request = model.get("model_request_config")
+        if isinstance(client, dict):
+            model_sources.append((client, request if isinstance(request, dict) else {}))
+
+    from openjiuwen.agent_teams.schema.team import ModelPoolEntry
+
+    pool_entries: list[dict[str, Any]] = []
+    seen_endpoints: set[tuple[str, str, str]] = set()
+    for client, request_source in model_sources:
+        model_name = str(client.get("model_name") or "").strip()
+        if not model_name:
+            continue
+        endpoint_key = (
+            model_name,
+            str(client.get("api_base") or "").strip(),
+            str(client.get("client_provider") or "").strip(),
+        )
+        if endpoint_key in seen_endpoints:
+            continue
+        seen_endpoints.add(endpoint_key)
+        request_config = build_reasoning_model_request_kwargs(
+            model_client_config=client,
+            model_config_obj=request_source,
+            model_name=model_name,
+        )
+        request_config.pop("model", None)
+        pool_entry = ModelPoolEntry(
+            model_name=model_name,
+            api_key=client.get("api_key", ""),
+            api_base_url=client.get("api_base", ""),
+            api_provider=client.get("client_provider", ""),
+            metadata={
+                "client": {
+                    key: value
+                    for key, value in client.items()
+                    if key not in ("model_name", "api_key", "api_base", "client_provider")
+                    and value is not None
+                },
+                "request": request_config,
+            },
+        )
+        pool_entries.append(pool_entry.model_dump())
+
+    if len({entry["model_name"] for entry in pool_entries}) > 1:
+        spec_dict["model_pool"] = pool_entries
+        spec_dict["model_pool_strategy"] = "by_model_name"
+
+
 def _safe_payload_preview(payload: Any) -> str:
     """Render an interact payload as a bounded single-line log fragment.
 
@@ -629,6 +740,7 @@ class TeamManager:
             strict_template=strict_template,
         )
         spec_dict = TeamManager._normalize_team_identity_fields(spec_dict)
+        _bind_named_member_models(spec_dict, config_base)
         if TeamManager._is_distributed_mode(config_base):
             spec_dict = TeamManager._normalize_distributed_transport_fields(config_base, spec_dict)
 
@@ -636,7 +748,7 @@ class TeamManager:
         # and set model_pool_strategy to by_model_name so team members
         # can be assigned different model endpoints from the pool.
         default_models = get_default_models(config_base)
-        if len(default_models) > 1:
+        if len(default_models) > 1 and not spec_dict.get("model_pool"):
             from openjiuwen.agent_teams.schema.team import ModelPoolEntry
 
             pool_entries: list[dict] = []

--- a/tests/unit_tests/agentserver/test_team_manager_registry.py
+++ b/tests/unit_tests/agentserver/test_team_manager_registry.py
@@ -12,6 +12,7 @@ import pytest
 from openjiuwen.agent_teams.runtime.pool import RuntimeState
 
 from jiuwenswarm.agents.harness.team.team_manager import (
+    _bind_named_member_models,
     TeamManager,
     TeamRailMountContext,
     MemberInfo,
@@ -94,6 +95,62 @@ def setup_function() -> None:
 
 def teardown_function() -> None:
     reset_team_manager()
+
+
+def test_named_predefined_member_gets_its_declared_model_pool_binding() -> None:
+    """A specialist must not silently fall back to the generic teammate model."""
+    deepseek_model = {
+        "model_client_config": {
+            "api_base": "https://deepseek.example/v1",
+            "api_key": "sk-deepseek",
+            "model_name": "deepseek-v4-flash",
+            "client_provider": "OpenAI",
+        },
+        "model_request_config": {"model": "deepseek-v4-flash", "temperature": 0.8},
+    }
+    qwen_model = {
+        "model_client_config": {
+            "api_base": "https://dashscope.example/v1",
+            "api_key": "sk-qwen",
+            "model_name": "qwen3.7-max",
+            "client_provider": "OpenAI",
+        },
+        "model_request_config": {"model": "qwen3.7-max", "temperature": 0.7},
+    }
+    spec_dict = {
+        "agents": {
+            "leader": {"model": deepseek_model},
+            "teammate": {"model": deepseek_model},
+            "visual_engineer": {"model": qwen_model},
+        },
+        "leader": {"member_name": "team_leader"},
+        "predefined_members": [
+            {"member_name": "gameplay_engineer", "role_type": "teammate"},
+            {"member_name": "visual_engineer", "role_type": "teammate"},
+        ],
+    }
+    config = {
+        "models": {
+            "defaults": [
+                {
+                    "model_client_config": deepseek_model["model_client_config"],
+                    "model_config_obj": {"temperature": 0.8},
+                }
+            ]
+        }
+    }
+
+    _bind_named_member_models(spec_dict, config)
+
+    members = {member["member_name"]: member for member in spec_dict["predefined_members"]}
+    assert members["visual_engineer"]["model_name"] == "qwen3.7-max"
+    assert "model_name" not in members["gameplay_engineer"]
+    assert spec_dict["leader"]["model_name"] == "deepseek-v4-flash"
+    assert spec_dict["model_pool_strategy"] == "by_model_name"
+    assert {entry["model_name"] for entry in spec_dict["model_pool"]} == {
+        "deepseek-v4-flash",
+        "qwen3.7-max",
+    }
 
 
 def test_get_team_manager_is_singleton() -> None:


### PR DESCRIPTION
## Summary

- project agents.<member_name>.model onto predefined member model_name
- add named specialist endpoints to the team model pool
- preserve the existing homogeneous-team fallback
- avoid logging or persisting credentials outside the in-memory team spec

## Why

Predefined members share the semantic teammate role. A config can declare a specialist model under a member name, but without this projection the specialist silently uses the generic teammate model. This is especially visible for multimodal reviewers configured on a visual member.

## Tests

- 60 passed: tests/unit_tests/agentserver/test_team_manager_registry.py
- ruff passed for changed files (excluding the repository-existing E402 import layout)