### PR TITLE
fix(code-team): omit memory rails when disabled

### DIFF
--- a/jiuwenswarm/agents/swarm/config_specs.py
+++ b/jiuwenswarm/agents/swarm/config_specs.py
@@ -42,6 +42,7 @@ from openjiuwen.harness.rails import SkillUseRail
 from jiuwenswarm.agents.harness.common.browser_defaults import (
     DEFAULT_BROWSER_AGENT_MAX_ITERATIONS,
 )
+from jiuwenswarm.agents.harness.common.memory.config import is_memory_enabled
 from jiuwenswarm.common.config import (
     get_default_model_provider,
     get_evolution_auto_save_enabled,
@@ -477,7 +478,7 @@ def _team_common_rail_names(role: str) -> tuple[str, ...]:
     return _COMMON_RAIL_NAMES
 
 
-def _code_base_rail_names(role: str) -> tuple[str, ...]:
+def _code_base_rail_names(config: dict[str, Any], role: str) -> tuple[str, ...]:
     """Code-profile rails minus permission interrupt; leaders omit code todo planning.
 
     ``PERMISSION_INTERRUPT`` is excluded for all team members: it relies on a
@@ -488,6 +489,9 @@ def _code_base_rail_names(role: str) -> tuple[str, ...]:
         name for name in _CODE_RAIL_NAMES
         if name != registry.PERMISSION_INTERRUPT
     )
+    if not is_memory_enabled("code", config):
+        memory_rails = {registry.CODE_PROJECT_MEMORY, registry.CODE_CODING_MEMORY}
+        names = tuple(name for name in names if name not in memory_rails)
     if role == "leader":
         return tuple(name for name in names if name != registry.CODE_TASK_PLANNING)
     return names
@@ -592,7 +596,7 @@ def _build_code_capability_specs(
 
     rails_specs: list[RailSpec] = [
         RailSpec(type=name, params=_rail_params(name, config))
-        for name in _code_base_rail_names(role)
+        for name in _code_base_rail_names(config, role)
     ]
 
     if is_team_plan_leader:

--- a/tests/agents/swarm/test_swarm_assembly.py
+++ b/tests/agents/swarm/test_swarm_assembly.py
@@ -1932,6 +1932,19 @@ def test_code_team_plan_approval_only_mounts_on_leader() -> None:
     assert registry.CODE_CONFIRM_INTERRUPT in {spec.type for spec in teammate_rails}
 
 
+@pytest.mark.parametrize("role", ["leader", "teammate"])
+def test_code_team_memory_disabled_omits_both_memory_rails(role: str) -> None:
+    """A disabled code memory config must not leak an external memory path."""
+    register_swarm_providers()
+    config = {"modes": {"code": {"memory": {"enabled": False}}}}
+
+    rails, _ = build_member_capability_specs(config, "code.team", role)
+    rail_types = {spec.type for spec in rails}
+
+    assert registry.CODE_PROJECT_MEMORY not in rail_types
+    assert registry.CODE_CODING_MEMORY not in rail_types
+
+
 def test_normal_team_plan_leader_uses_deepagent_plan_profile() -> None:
     """Normal Team Plan adds Work plan rails without mounting Code profile rails."""
     register_swarm_providers()


### PR DESCRIPTION
## Summary

- honor modes.code.memory.enabled=false during code-team rail assembly
- omit both project-memory and coding-memory rails for leaders and teammates
- preserve the existing code-mode default of memory enabled

## Why

A disabled code-memory configuration still mounted the two memory rails, which could leak an external memory path into an otherwise memory-free team run.

## Tests

- 2 passed: test_code_team_memory_disabled_omits_both_memory_rails (leader and teammate)
- ruff passed for changed files
- git diff --check passed