### PR TITLE
[Bug] 修复 GitHub 版贡献指南错误指向 GitCode

### DIFF
--- a/docs/en/Contributing.md
+++ b/docs/en/Contributing.md
@@ -33,7 +33,7 @@ Thank you for your interest in JiuwenSwarm! Whether it's filing bugs, developing
 
 ### Filing Issues
 
-Submit on [GitCode Issues](https://gitcode.com/openJiuwen/jiuwenswarm/issues) with the appropriate type:
+Submit on [GitHub Issues](https://github.com/openJiuwen-ai/jiuwenswarm/issues) with the appropriate type:
 
 | Type | Template | Description |
 |------|----------|-------------|
@@ -51,7 +51,7 @@ Submit on [GitCode Issues](https://gitcode.com/openJiuwen/jiuwenswarm/issues) wi
 
 ### Submitting Pull Requests
 
-1. **Fork the repo**: Fork [openJiuwen/jiuwenswarm](https://gitcode.com/openJiuwen/jiuwenswarm) on GitCode
+1. **Fork the repo**: Fork [openJiuwen/jiuwenswarm](https://github.com/openJiuwen-ai/jiuwenswarm) on GitHub
 
 2. **Create a branch**:
 
@@ -80,7 +80,7 @@ git commit -m "feat: add XXX feature"
 git push origin feature/your-feature-name
 ```
 
-Create a Pull Request on GitCode targeting the `develop` branch.
+Create a Pull Request on GitHub targeting the `develop` branch.
 
 **PR description should include:**
 
@@ -101,7 +101,7 @@ For detailed setup instructions, see the [Developer Guide](developer_guide.md). 
 
 ```bash
 # Clone the repository
-git clone https://gitcode.com/openJiuwen/jiuwenswarm.git
+git clone https://github.com/openJiuwen-ai/jiuwenswarm.git
 cd jiuwenswarm
 
 # Create virtual environment
@@ -184,12 +184,12 @@ docs: update Python version requirement in install guide
 - Development branch: `develop`
 - Release branches: created from `develop` as `release/vX.Y.Z`
 - Version numbers follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`
-- After release, create Release Notes on [GitCode Releases](https://gitcode.com/openJiuwen/jiuwenswarm/releases)
+- After release, create Release Notes on [GitHub Releases](https://github.com/openJiuwen-ai/jiuwenswarm/releases)
 
 ---
 
 ## Contact
 
-- **Issues**: [GitCode Issues](https://gitcode.com/openJiuwen/jiuwenswarm/issues)
-- **Pull Requests**: [GitCode Pull Requests](https://gitcode.com/openJiuwen/jiuwenswarm/pulls)
+- **Issues**: [GitHub Issues](https://github.com/openJiuwen-ai/jiuwenswarm/issues)
+- **Pull Requests**: [GitHub Pull Requests](https://github.com/openJiuwen-ai/jiuwenswarm/pulls)
 - **Community**: Follow openJiuwen community events


### PR DESCRIPTION
## 问题类型
/kind bug

## 问题说明
GitHub 版贡献指南仍将贡献入口指向 GitCode，导致用户无法在目标 GitHub 项目中直接提交 Issue、Fork、Pull Request 或获取发布信息。

## 修复内容
- 将 Issue、Fork、Pull Request、源码克隆、Releases 和联系方式中的 GitCode 链接统一更新为 GitHub 链接。
- 保留原有贡献流程和 develop 目标分支说明，不改变其他行为。

## 关联 Issue
Fixes #4023

## 验证结果
- 检查 `docs/en/Contributing.md` 中相关链接均指向 `github.com/openJiuwen-ai/jiuwenswarm`。
- 本次仅修改文档，无需额外运行测试。

## 自检清单
- [x] 设计：变更范围与贡献流程保持一致。
- [x] 测试：已完成文档链接检查。
- [x] 验证：已确认 GitHub 入口均可用于目标仓库。
- [x] 接口：未修改外部接口。
- [x] 文档：已更新贡献指南。