### PR TITLE
fix(command): decode Windows CLI output as UTF-8 first

### DIFF
--- a/jiuwenswarm/agents/harness/common/tools/command_tools.py
+++ b/jiuwenswarm/agents/harness/common/tools/command_tools.py
@@ -658,17 +658,15 @@ def _resolve_execution_plan(command: str, shell_type: str) -> tuple[list[str] | 
     raise RuntimeError(f"Unsupported shell_type: {normalized}")
 
 
-def _resolve_encoding(resolved_shell: str) -> str:
-    """Choose subprocess text encoding based on the resolved shell type.
-
-    - bash / sh on Windows (e.g. Git Bash / MSYS2) output UTF-8 by default.
-    - cmd uses the system code page (typically CP936/GBK on Chinese Windows).
-    - PowerShell also uses the system code page by default; safest to use
-      the system code page and rely on ``errors='replace'`` for edge cases.
-    """
-    if os.name == "nt" and resolved_shell in ("bash", "sh"):
-        return "utf-8"
-    return locale.getpreferredencoding(False) or "utf-8"
+def _decode_subprocess_output(output: bytes | None) -> str:
+    """Decode CLI output as UTF-8, falling back to the system encoding."""
+    if not output:
+        return ""
+    try:
+        return output.decode("utf-8")
+    except UnicodeDecodeError:
+        encoding = locale.getpreferredencoding(False) or "utf-8"
+        return output.decode(encoding, errors="replace")
 
 
 def _run_command_sync(
@@ -679,7 +677,6 @@ def _run_command_sync(
     session_id: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str]:
     plan, use_shell, resolved_shell = _resolve_execution_plan(command, shell_type)
-    encoding = _resolve_encoding(resolved_shell)
     popen_kw: dict[str, Any] = {}
     if os.name != "nt":
         _jw_start_new_session = os.getenv("JW_START_NEW_SESSION", "true").strip().lower()
@@ -691,16 +688,13 @@ def _run_command_sync(
         cwd=str(workdir),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
-        encoding=encoding,
-        errors="replace",
         **popen_kw,
     )
     sid = (session_id or "").strip()
     if sid:
         register_shell_process(sid, proc)
-    stdout: str = ""
-    stderr: str = ""
+    stdout_bytes: bytes | None = b""
+    stderr_bytes: bytes | None = b""
     deadline = time.monotonic() + timeout_seconds
     try:
         while proc.poll() is None:
@@ -719,7 +713,7 @@ def _run_command_sync(
         # forever when a grandchild inherits stdout/stderr (e.g. `cmd &` in shell).
         remaining = max(deadline - time.monotonic(), 1.0)
         try:
-            stdout, stderr = proc.communicate(timeout=remaining)
+            stdout_bytes, stderr_bytes = proc.communicate(timeout=remaining)
         except subprocess.TimeoutExpired:
             terminate_shell_process(proc)
             raise subprocess.TimeoutExpired(cmd=command, timeout=timeout_seconds) from None
@@ -745,8 +739,8 @@ def _run_command_sync(
     return subprocess.CompletedProcess(
         args=plan,
         returncode=proc.returncode if proc.returncode is not None else -1,
-        stdout=stdout or "",
-        stderr=stderr or "",
+        stdout=_decode_subprocess_output(stdout_bytes),
+        stderr=_decode_subprocess_output(stderr_bytes),
     ), resolved_shell
 
 

--- a/tests/unit_tests/agents/test_command_tools_posix_windows.py
+++ b/tests/unit_tests/agents/test_command_tools_posix_windows.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
 from jiuwenswarm.agents.harness.common.tools.command_tools import (
+    _decode_subprocess_output,
     _looks_like_posix,
     _resolve_execution_plan,
+    _run_command_sync,
     _split_shell_segments,
     _translate_mkdir_p_to_powershell,
     _translate_posix_for_powershell,
@@ -16,6 +19,59 @@ from jiuwenswarm.agents.harness.common.tools.command_tools import (
     _available_bash,
     _available_powershell,
 )
+
+
+class TestDecodeSubprocessOutput:
+    def test_prefers_utf8_over_windows_locale(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.command_tools.locale.getpreferredencoding",
+            lambda _do_setlocale: "gbk",
+        )
+
+        assert _decode_subprocess_output("中文 output".encode()) == "中文 output"
+
+    def test_falls_back_to_system_encoding(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.command_tools.locale.getpreferredencoding",
+            lambda _do_setlocale: "gbk",
+        )
+
+        assert _decode_subprocess_output("中文 output".encode("gbk")) == "中文 output"
+
+    def test_sync_command_decodes_stdout_and_stderr_from_bytes(self, monkeypatch) -> None:
+        popen_kwargs = {}
+
+        class FakeProcess:
+            returncode = 0
+            stdout = None
+            stdin = None
+            stderr = None
+
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout):
+                return "标准输出".encode(), "错误输出".encode()
+
+        def fake_popen(*_args, **kwargs):
+            popen_kwargs.update(kwargs)
+            return FakeProcess()
+
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.command_tools._resolve_execution_plan",
+            lambda *_args: (["utf8-cli"], False, "cmd"),
+        )
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.command_tools.subprocess.Popen",
+            fake_popen,
+        )
+
+        completed, _resolved_shell = _run_command_sync("utf8-cli", 5, Path("."), "cmd")
+
+        assert completed.stdout == "标准输出"
+        assert completed.stderr == "错误输出"
+        assert "text" not in popen_kwargs
+        assert "encoding" not in popen_kwargs
 
 
 # ── _translate_mkdir_p_to_powershell ────────────────────────────────


### PR DESCRIPTION
Paired: [GitHub #4054](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4054) ↔ [GitCode !5489](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5489)

/kind bug

### What this PR does / why we need it

On Windows, command tools decoded captured output with the active system code page. UTF-8 output from external CLIs was therefore corrupted on GBK/CP936 systems.

This change captures subprocess output as bytes and decodes stdout and stderr with strict UTF-8 first. If the bytes are not valid UTF-8, it falls back to the system encoding with replacement, preserving compatibility with native code-page CLIs. Background command handling is unchanged, and completed-process output remains text.

### Which issue(s) this PR fixes

Fixes #4026

### Verification

- `pytest -q --no-cov tests/unit_tests/agents/test_command_tools_posix_windows.py`
- 47 passed, 8 skipped

### Compatibility

- UTF-8 CLI output is preferred on every platform.
- Non-UTF-8 Windows CLI output continues to use the system encoding fallback.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4026
<!-- /bot1-related-issues -->
