### PR TITLE
fix(tool-display): stop instructing the model to write call_goal in Chinese

### DIFF
--- a/jiuwenswarm/common/tool_display.py
+++ b/jiuwenswarm/common/tool_display.py
@@ -68,8 +68,12 @@ _SKILL_ARG_KEYS = ("skill_name", "skillName", "name")
 _CALL_GOAL_SCHEMA: dict[str, Any] = {
     "type": "string",
     "description": (
-        "一句简短中文，说明这次工具调用要达成的目标（仅界面展示），"
-        "例如「调研 openJiuwen 官网信息」「创建三子棋对战团队」「通知 player-x 落子」。"
+        "一句简短说明，讲清这次工具调用要达成的目标（仅界面展示）。"
+        "必须使用当前对话所用的语言，不要固定用中文。"
+        "Write it in the same language as the conversation with the user; "
+        "do not default to Chinese. "
+        "中文对话写「调研 openJiuwen 官网信息」「创建三子棋对战团队」「通知 player-x 落子」，"
+        "英文对话写 \"Research the openJiuwen website\" \"Create a tic-tac-toe team\"。"
         "不要只写工具名或裸 URL；不影响工具实际执行。"
         "与工具自带的 display_name（成员/团队展示名）以及 send_message.summary 都不是同一个字段，"
         "调用 spawn_member / spawn_teammate / send_message / build_team 时也必须填写。"

--- a/tests/unit_tests/common/test_tool_display_call_goal.py
+++ b/tests/unit_tests/common/test_tool_display_call_goal.py
@@ -1,0 +1,63 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Tests for the injected ``call_goal`` schema description.
+
+``call_goal`` is produced by the model and rendered by every channel, so the
+description injected into the tool schema must not pin its language: it has to
+follow the conversation instead of mandating one language.
+"""
+
+from __future__ import annotations
+
+from jiuwenswarm.common.tool_display import inject_call_goal_schema
+
+
+def _injected_description() -> str:
+    parameters: dict = {"type": "object", "properties": {}}
+    inject_call_goal_schema(parameters)
+    return str(parameters["properties"]["call_goal"]["description"])
+
+
+class TestCallGoalSchemaLanguage:
+
+    @staticmethod
+    def test_description_does_not_mandate_chinese_output():
+        """描述不得要求模型固定用中文产出 call_goal。"""
+        description = _injected_description()
+        assert "一句简短中文" not in description
+
+    @staticmethod
+    def test_description_ties_the_goal_to_the_conversation_language():
+        """描述必须把 call_goal 的语言绑定到当前对话。"""
+        description = _injected_description()
+        assert "当前对话所用的语言" in description
+        assert "same language as the conversation" in description
+
+    @staticmethod
+    def test_description_shows_a_non_chinese_example():
+        """描述给出非中文示例，避免模型把中文示例当成语言要求。"""
+        description = _injected_description()
+        assert "Research the openJiuwen website" in description
+
+    @staticmethod
+    def test_description_keeps_the_display_name_disambiguation():
+        """仍需保留与 display_name / summary 的区分说明，避免撞名回归。"""
+        description = _injected_description()
+        assert "display_name" in description
+        assert "send_message.summary" in description
+
+    @staticmethod
+    def test_injection_still_adds_an_optional_string_field():
+        """注入形状不变：可选 string 字段，不进 required。"""
+        parameters: dict = {"type": "object", "properties": {}, "required": []}
+        inject_call_goal_schema(parameters)
+        assert parameters["properties"]["call_goal"]["type"] == "string"
+        assert parameters["required"] == []
+
+    @staticmethod
+    def test_injection_does_not_overwrite_an_existing_call_goal():
+        """工具自带 call_goal 定义时不覆盖。"""
+        own = {"type": "string", "description": "tool own"}
+        parameters: dict = {"type": "object", "properties": {"call_goal": own}}
+        inject_call_goal_schema(parameters)
+        assert parameters["properties"]["call_goal"] is own


### PR DESCRIPTION
Paired: [GitHub #4283](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4283) ↔ [GitCode !5651](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5651)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

`inject_call_goal_schema()` in `jiuwenswarm/common/tool_display.py` adds a
`call_goal` property to the parameters of every tool handed to the model. The
description of that property opened with `一句简短中文` — literally "one short
sentence in Chinese" — followed by three Chinese examples.

Models comply. The resulting `call_goal` is Chinese whatever language the
conversation is in, and because it becomes the tool's display name it then
surfaces in every channel that renders tool calls.

The path is short and leaves no room to correct it later.
`StreamEventRail._inject_tool_call_goal_schema` injects the property into the
tools sent to the model; `before_tool_call` pulls the value back out with
`extract_call_goal()` and hands it to `_emit_tool_call`, where

```python
display_name = (model_display_name or "").strip() or build_tool_display_name(name, arguments)
```

gives it priority over the rule-based fallback. The string arrives from the model
already written, nothing between there and the UI can translate it, and the
schema description is the only place its language was ever decided.

Observed in production: a model that is not Chinese-first returned a Chinese
`call_goal` in an otherwise English conversation. The failure is quiet — the
label is well-formed and plausible, it is simply in the wrong language, and a
reader who does not read Chinese gets no display name at all in practice.

### The change

The description now asks for the language of the conversation instead of naming
one:

```python
"一句简短说明，讲清这次工具调用要达成的目标（仅界面展示）。"
"必须使用当前对话所用的语言，不要固定用中文。"
"Write it in the same language as the conversation with the user; "
"do not default to Chinese. "
"中文对话写「调研 openJiuwen 官网信息」「创建三子棋对战团队」「通知 player-x 落子」，"
"英文对话写 \"Research the openJiuwen website\" \"Create a tic-tac-toe team\"。"
```

**The instruction is given in both Chinese and English** so that it does not
depend on the model reading the Chinese prose. A model weak enough at Chinese to
skim past the requirement is exactly the model most likely to have produced the
wrong language in the first place.

**An English example sits alongside the Chinese ones.** The three original
examples were all Chinese, which reads as a language requirement in its own
right even once the prose stops saying so. Showing both languages makes the
examples demonstrate the shape of a goal rather than the choice of a language.

**The language is taken from the conversation, not from `preferred_language`.**
This is the design question worth stating explicitly, because a configured
language is the obvious alternative and it is the wrong one here. `call_goal` is
rendered inline among the turns, so it should match what is being said, not what
the deployment defaults to: a Chinese-configured deployment holding an English
conversation should still produce an English goal, and a configured language
cannot express that. It also keeps the schema a constant — the injection site is
a static method with no language in scope, so a configured language would have to
be threaded down the rail purely in order to arrive at a worse answer.

**The rest of the description is unchanged**, including the note distinguishing
`call_goal` from the tools' own `display_name` and from `send_message.summary`.
That wording exists to stop a field-name collision: the module's own docstring
records that `spawn_teammate` / `build_team` carry a required `display_name` of
their own, and that colliding on the name got those parameters stripped and
produced continuous errors. It is not about language.

### Verification

Before the change, the injected description read (rendered from the constant):

```
一句简短中文，说明这次工具调用要达成的目标（仅界面展示），例如「调研 openJiuwen 官网信息」…
```

After it:

```
一句简短说明，讲清这次工具调用要达成的目标（仅界面展示）。必须使用当前对话所用的语言，不要固定用中文。Write it in the same language as the conversation with the user; do not default to Chinese. 中文对话写「调研 openJiuwen 官网信息」…，英文对话写 "Research the openJiuwen website"…
```

`tests/unit_tests/common/test_tool_display_call_goal.py` is new; nothing covered
`tool_display.py` before. Six tests, all passing on this branch.

Three of them pin the language requirement and are the ones the fix moves:

- the description no longer contains `一句简短中文`;
- it ties the goal's language to the conversation, stated in both Chinese and
  English;
- it carries a non-Chinese example.

Run against the pre-fix source, those three fail on their assertions — not at
import or setup — which is what makes them a check on the description rather than
on the module existing.

The other three pin the injection contract and pass either way, as regression
guards rather than as evidence for this fix:

- the `display_name` / `send_message.summary` disambiguation survives, so a future
  edit cannot quietly reintroduce the field-name collision that wording prevents;
- injection still produces an optional `string` property and does not add it to
  `required`;
- injection still refuses to overwrite a `call_goal` a tool defines itself.

The last two matter because `LocalFunction` invokes a tool as `func(**inputs)`,
so a `call_goal` that reaches the execution-side schema is passed on to the tool
implementation and raises `TypeError`. The module's own docstring records a
failure of that shape from a field-name collision: the tools that carry their
own required `display_name` had arguments wrongly stripped and errored
repeatedly, which is why the schema field is named `call_goal` and why it is
removed from the arguments before execution.

`tests/unit_tests/` was run on the merge base and on this branch back to back
under comparable load and compared by test name. The set of failures and
collection errors is identical on both — 244 names, same names — and the passing
count differs by exactly the six new tests. All of those pre-existing failures
are present on the base and are untouched by this change.

### Related work

One open pull request touches `jiuwenswarm/common/tool_display.py`: #2420 adds two
entries to `_VERB_BY_TOOL`, the rule-based fallback table near the top of the file.
That is a different region and a different mechanism from the `call_goal` schema
description changed here — the table is consulted only when the model omits
`call_goal`, so the two neither collide textually nor overlap in effect. No commit
on `develop` has modified the file since the commit that introduced it.

The nearest open report in the area concerns a Moonshot-flavoured JSON Schema rejection over `anyOf` / `type`
placement inside another tool's nested parameters — a schema *shape* problem in a
different property, not the language of the `call_goal` description — so there is
no functional overlap and nothing here needs to wait on it. (Deliberately cited
by description rather than by number: an issue reference in this body is rewritten
into a closing keyword, and closing that report is not what this PR does.)

### What this deliberately does not do

**It does not touch `build_tool_display_name()`.** That fallback builds its label
from `_VERB_BY_TOOL`, a hardcoded table of Chinese verbs, and applies only when
the model omits `call_goal` entirely. It is a second, independent source of
Chinese display text, but localizing a static table is a different change from
not pinning a generated string's language, and mixing the two would make neither
reviewable.

**It does not add a language knob.** No configuration key selects the language of
`call_goal` today, and this PR does not introduce one, for the reason given
above.

**It does not validate the returned language.** Nothing checks that the model
actually followed the instruction, and nothing rejects or rewrites a `call_goal`
that comes back in the wrong language. A prompt-level fix is what is available at
the only point where the language is decided; enforcement would need a
language-detection step on a display-only string, which costs more than the
defect does.

**Which issue(s) this PR fixes**:

Fixes #4282

<!-- Optional template block, marked honestly. -->

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4282
<!-- /bot1-related-issues -->
