### PR TITLE
fix(skills): stop building shipped skill temp paths from fixed shared names

### DIFF
--- a/jiuwenswarm/resources/agent/workspace/skills/ascend-moe-optimizer-trace-analyzer/analyzers/plots.py
+++ b/jiuwenswarm/resources/agent/workspace/skills/ascend-moe-optimizer-trace-analyzer/analyzers/plots.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import getpass
 import os
+import re
 import tempfile
 from typing import Any, List
 
@@ -32,8 +34,37 @@ _CATEGORY_COLORS = {
 }
 
 
+def _user_scope() -> str:
+    """Return a filesystem-safe token identifying the current user."""
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None:
+        return str(getuid())
+    try:
+        name = getpass.getuser()
+    except (KeyError, OSError):
+        return "unknown"
+    return re.sub(r"[^A-Za-z0-9._-]", "_", name) or "unknown"
+
+
+def _mpl_config_dir() -> str:
+    """Return a per-user matplotlib config directory under the system temp dir."""
+    # The temp directory is shared, so a fixed name is owned by whichever account
+    # creates it first and denied to the rest. Matplotlib does not fail on a
+    # config directory it cannot use: it warns and falls back to a fresh one per
+    # process, rebuilding the font cache on every run.
+    path = os.path.join(tempfile.gettempdir(), f"trace_analysis_matplotlib-{_user_scope()}")
+    try:
+        os.makedirs(path, mode=0o700, exist_ok=True)
+        # Best effort: a usable directory matters more than its exact mode.
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+    return path
+
+
 def _load_pyplot():
-    os.environ.setdefault("MPLCONFIGDIR", os.path.join(tempfile.gettempdir(), "trace_analysis_matplotlib"))
+    if "MPLCONFIGDIR" not in os.environ:
+        os.environ["MPLCONFIGDIR"] = _mpl_config_dir()
     import matplotlib
 
     matplotlib.use("Agg", force=True)

--- a/jiuwenswarm/resources/agent/workspace/skills/skill-creator-normal/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/skill-creator-normal/SKILL.md
@@ -485,7 +485,15 @@ Present the eval set to the user for review using the HTML template:
    - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
    - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
    - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
-3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
+3. Write it into a scratch directory created by `mktemp -d`, then open it — never a fixed path like `/tmp/eval_review_<skill-name>.html`, because the system temp directory is shared between accounts and the first account to create that name owns it, leaving everyone else with a permission error:
+
+   ```bash
+   review_dir=$(mktemp -d)
+   # write the filled-in template to "$review_dir/eval_review.html"
+   open "$review_dir/eval_review.html"
+   ```
+
+   Keep `$review_dir` around for the rest of this step — the browser needs the file to stay on disk while the user works through it.
 4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
 5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
 
@@ -561,8 +569,8 @@ In Claude.ai, the core workflow is the same (draft → test → review → impro
 
 **Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. In this case:
 - **Preserve the original name.** Note the skill's directory name and `name` frontmatter field -- use them unchanged. E.g., if the installed skill is `research-helper`, output `research-helper.skill` (not `research-helper-v2`).
-- **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
-- **If packaging manually, stage in `/tmp/` first**, then copy to the output directory -- direct writes may fail due to permissions.
+- **Copy to a writeable location before editing.** The installed skill path may be read-only. Create a scratch directory with `work_dir=$(mktemp -d)`, copy the skill into it with `cp -r <installed-skill-path> "$work_dir/<skill-name>"`, edit there, and package from the copy. Do not use a fixed path such as `/tmp/<skill-name>/` -- the system temp directory is shared between accounts, so the first account to create that name owns it and every other account gets a permission error.
+- **If packaging manually, stage in that same `$work_dir` first**, then copy to the output directory -- direct writes may fail due to permissions.
 
 ---
 

--- a/jiuwenswarm/resources/agent/workspace/skills/skill-creator-normal/scripts/run_loop.py
+++ b/jiuwenswarm/resources/agent/workspace/skills/skill-creator-normal/scripts/run_loop.py
@@ -10,6 +10,7 @@ overfitting.
 import argparse
 import json
 import logging
+import os
 import random
 import sys
 import tempfile
@@ -431,10 +432,16 @@ def main() -> None:
     # Set up live report path
     if args.report != "none":
         if args.report == "auto":
-            timestamp = time.strftime("%Y%m%d_%H%M%S")
-            live_report_path = Path(tempfile.gettempdir()) / (
-                f"skill_description_report_{skill_path.name}_{timestamp}.html"
+            # Let mkstemp name it. A skill-plus-timestamp name collides between
+            # runs started in the same second, and in the shared temp directory
+            # the loser cannot overwrite the winner's file. Nothing needs to
+            # predict this path.
+            handle, report_name = tempfile.mkstemp(
+                prefix=f"skill_description_report_{skill_path.name}_",
+                suffix=".html",
             )
+            os.close(handle)
+            live_report_path = Path(report_name)
         else:
             live_report_path = Path(args.report)
         # Open the report immediately so the user can watch

--- a/tests/unit_tests/test_skill_resource_temp_paths.py
+++ b/tests/unit_tests/test_skill_resource_temp_paths.py
@@ -1,0 +1,118 @@
+"""Shipped skill resources must not name fixed paths in the shared temp directory.
+
+The system temporary directory is shared between every account on a host, so a
+fixed name there is owned by whichever account creates it first and refused to
+all the others. These guards cover the three shipped skill resources that used
+to build such a name.
+"""
+
+from __future__ import annotations
+
+import getpass
+import importlib.util
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jiuwenswarm.common.utils import get_builtin_skills_dir
+
+_SKILL_CREATOR = "skill-creator-normal"
+
+
+def _load_module_by_path(name: str, path: Path) -> ModuleType:
+    """Import a shipped resource that is not reachable as a package module."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, path
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def plots(tmp_path, monkeypatch) -> ModuleType:
+    """The trace analyzer's plotting module, with the temp dir redirected."""
+    path = (
+        get_builtin_skills_dir()
+        / "ascend-moe-optimizer-trace-analyzer"
+        / "analyzers"
+        / "plots.py"
+    )
+    assert path.is_file(), path
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    return _load_module_by_path("_trace_analyzer_plots", path)
+
+
+def test_matplotlib_config_dir_differs_between_users(plots, tmp_path, monkeypatch):
+    monkeypatch.setattr(os, "getuid", lambda: 4242, raising=False)
+    first = Path(plots._mpl_config_dir())
+    monkeypatch.setattr(os, "getuid", lambda: 4243, raising=False)
+    second = Path(plots._mpl_config_dir())
+
+    assert first != second
+    assert first.parent == tmp_path and second.parent == tmp_path
+    assert first.name == "trace_analysis_matplotlib-4242"
+    assert second.name == "trace_analysis_matplotlib-4243"
+
+
+def test_matplotlib_config_dir_is_reused_by_the_same_user(plots, monkeypatch):
+    monkeypatch.setattr(os, "getuid", lambda: 4242, raising=False)
+    assert plots._mpl_config_dir() == plots._mpl_config_dir()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+def test_matplotlib_config_dir_is_private(plots, monkeypatch):
+    monkeypatch.setattr(os, "getuid", lambda: 4242, raising=False)
+    created = Path(plots._mpl_config_dir())
+
+    assert created.is_dir()
+    assert stat.S_IMODE(created.stat().st_mode) == 0o700
+
+
+def test_user_scope_falls_back_to_a_sanitised_user_name(plots, monkeypatch):
+    """Platforms without POSIX user ids still get a name they can put in a path."""
+    monkeypatch.delattr(os, "getuid", raising=False)
+    monkeypatch.setattr(getpass, "getuser", lambda: "dom\\a in/../user")
+
+    scope = plots._user_scope()
+
+    assert "/" not in scope
+    assert "\\" not in scope
+    assert os.sep not in scope
+    assert scope == "dom_a_in_.._user"
+
+
+def test_user_scope_survives_an_unresolvable_user_name(plots, monkeypatch):
+    def _raise() -> str:
+        raise KeyError("no passwd entry")
+
+    monkeypatch.delattr(os, "getuid", raising=False)
+    monkeypatch.setattr(getpass, "getuser", _raise)
+
+    assert plots._user_scope() == "unknown"
+
+
+def test_skill_creator_report_path_is_not_built_from_the_temp_root():
+    """The live report is allocated by mkstemp, not named from a timestamp."""
+    source = (
+        get_builtin_skills_dir() / _SKILL_CREATOR / "scripts" / "run_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "tempfile.mkstemp(" in source
+    assert "tempfile.gettempdir()" not in source
+
+
+def test_skill_creator_guidance_recommends_a_scratch_directory():
+    """The authoring skill teaches the pattern that its own output will copy."""
+    text = (get_builtin_skills_dir() / _SKILL_CREATOR / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "mktemp -d" in text
+    assert "Write to a temp file (e.g., `/tmp/eval_review_" not in text
+    assert "Copy to `/tmp/skill-name/`" not in text
+    assert "stage in `/tmp/` first" not in text


### PR DESCRIPTION
Paired: [GitHub #4288](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4288) ↔ [GitCode !5653](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5653)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

Three shipped skill resources name a path in the system temporary directory that
is fixed, so every account on the host computes the same one. That directory is
shared and writable by all, which turns a fixed name into a claim: the first
account to create it owns it, and every later account is refused. All three are
the denial-of-access form of that mistake — none of them opens a caller-supplied
path for writing, so none is a redirection risk on its own.

### Trace analyzer matplotlib cache

`skills/ascend-moe-optimizer-trace-analyzer/analyzers/plots.py` pointed
`MPLCONFIGDIR` at `<tempdir>/trace_analysis_matplotlib`.

This one hides. Matplotlib does not fail on a config directory it cannot use: it
warns and falls back to a fresh directory for that process, so the font cache is
rebuilt on every invocation. Every account except the first therefore gets slow,
noisy plotting rather than an error, and nothing in the output points at the
cache directory as the cause.

The name now carries the current user id, with a sanitised user name as the
fallback on platforms that have no POSIX user ids, and the directory is created
`0700`. The `chmod` is best effort and `OSError` is ignored: the failure being
fixed is being locked out of the directory entirely, and a directory with
unexpected mode bits still beats matplotlib's fallback. An `MPLCONFIGDIR` supplied
by the caller is honoured exactly as before — and the directory is now not created
at all in that case, where previously the name was computed unconditionally.

### skill-creator live report

`skills/skill-creator-normal/scripts/run_loop.py` built the live report path from
the skill directory name plus a timestamp of one-second resolution. Two runs of
the same skill started within the same second name the same file, and in the
shared temp directory the loser cannot overwrite the winner's.

`tempfile.mkstemp` with the same descriptive prefix now picks the name: unique by
construction and created `0600`. Nothing outside the run needs to predict the
path, since the run opens the report itself and hands it to a browser. An explicit
`--report <path>` is honoured unchanged.

### skill-creator authoring guidance

`skills/skill-creator-normal/SKILL.md` recommended three fixed paths: an eval
review page at `/tmp/eval_review_<skill-name>.html`, a staging directory at
`/tmp/<skill-name>/`, and staging in `/tmp/` directly.

This costs more than the two sites above, on two counts. A model executes the
guidance directly while creating or updating a skill, so it reproduces the
collision on every run; and this is the authoring skill, so the pattern it
demonstrates is carried into the skills written from it, spreading the same
fixed-name claim to each one produced.

All three are replaced by a scratch directory from `mktemp -d`. The fixed paths
stay in the text as the thing not to do, with the reason, so the guidance teaches
the distinction rather than silently dropping it.

### Relation to the runtime fix for the same defect class

`#2455` fixes three instances of this pattern in runtime and deployment code — a
deployment log redirect, a macOS mount point, and an index cache root. It touches
no file this PR touches, and this PR touches none of its. The two are
complementary halves of one sweep: that one covers code the product runs, this one
covers the resources it ships. Whichever merges second needs no rework beyond a
rebase.

One adjacent pull request moves rather than fixes one of these files. `#2451`
unbundles the Huawei Ascend NPU skills into an optional package, relocating
`ascend-moe-optimizer-trace-analyzer/` — `analyzers/plots.py` included — out of
the shipped resources. That move is byte-for-byte, so it carries the fixed
`MPLCONFIGDIR` name along with it rather than correcting it; the two changes are
complementary. If the relocation lands first, this hunk and the path the new test
derives follow the file to its new home, which is a rebase rather than a rework.

Beyond that, no other open pull request touches these three files — checked
against the changed-file list of every open pull request in this repository —
and a search of open issues for these paths and for the fixed names they build
turns up only the report mentioned above, which covers different sites.

**Which issue(s) this PR fixes**:

Fixes #4286

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

* **Per-account naming, tested directly.** The trace analyzer's helpers are
  ordinary functions, so `tests/unit_tests/test_skill_resource_temp_paths.py`
  exercises them against a redirected temp root: the config directory name changes
  with the user id, is stable within one account, is created `0700`, the fallback
  reduces a user name containing path separators to a single path component, and
  an unresolvable user name yields a usable token rather than an exception. The
  mode assertion is skipped on Windows, which has no POSIX mode bits.

* **The two guards that are load-bearing.** The same file asserts that the live
  report is allocated by `mkstemp` rather than named under the temp root, and that
  the authoring guidance recommends a scratch directory and no longer carries the
  three fixed-path instructions. Against the unfixed tree both fail on their
  assertions.

* **Vacuity check, run rather than assumed.** With the three resource files
  reverted to their `develop` content and the new test file kept, all seven fail.
  Two fail on their assertions, as above. The other five fail with `AttributeError`
  because the helpers do not exist yet, which demonstrates their absence rather
  than the defect — those five are a regression guard on the naming contract, not
  independent evidence, and are labelled as such rather than counted as proof.
  With the change applied the file reports 7 passed, 0 failed.

* **Nothing else moved.** `tests/unit_tests` was run on `develop` and on this
  branch back to back on the same machine and compared by failing test name rather
  than by count. The two name sets are identical, with no addition and no
  removal, and the passing count rises by exactly the seven new tests. That
  suite has a large set of pre-existing failures and collection errors in the
  environment used, present identically in both runs; absolute counts are
  host-dependent and are not the basis of the comparison.

* **Behaviour of the new naming, checked by hand.** With the temp root redirected,
  the previous scheme produces a single path for two runs started in the same
  second and the new one produces two distinct paths, both created `0600`. The
  matplotlib config directory basename carries the user id and is created `0700`.

* **What cannot be tested here.** The authoring guidance is prose addressed to a
  model, and the failure being fixed only appears once a second OS account exists
  on the host. No test was fabricated for either; correctness there rests on
  review.

* No CI result is claimed; the above is what was run locally.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded — `tests/unit_tests/test_skill_resource_temp_paths.py` is included; the two sites that cannot be exercised in process are called out above rather than covered by a token test.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR — see the section above.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed — no external interface is touched. The only observable path changes are the two temporary files named above, neither of which is part of any documented contract.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner — no website documentation is affected. The edited `SKILL.md` is a skill resource shipped from this repository, not published documentation.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4286
<!-- /bot1-related-issues -->
