### PR TITLE
fix(rails): treat a serialised interrupt envelope as a tool placeholder

### DIFF
--- a/jiuwenswarm/agents/harness/common/rails/stream_event_rail.py
+++ b/jiuwenswarm/agents/harness/common/rails/stream_event_rail.py
@@ -50,6 +50,15 @@ from jiuwenswarm.common.todo_snapshot import format_todos_for_frontend
 
 _TODO_TOOL_NAMES = frozenset(["todo_create", "todo_get", "todo_list", "todo_modify"])
 
+# A sub-agent interrupt envelope stringified into a ToolMessage. The envelope is
+# built with "result_type" first, so requiring it at the head of the mapping
+# literal keeps the match anchored instead of merely keyword-based. Both repr()
+# (single quotes) and JSON (double quotes) renderings are accepted.
+_INTERRUPT_ENVELOPE_HEAD_RE = re.compile(
+    r"""^\{\s*(?P<k>['"])result_type(?P=k)\s*:\s*(?P<v>['"])interrupt(?P=v)\s*[,}]"""
+)
+_INTERRUPT_ENVELOPE_IDS_RE = re.compile(r"""(?P<k>['"])interrupt_ids(?P=k)\s*:""")
+
 
 def _structured_tool_result_payload(result: Any) -> Any | None:
     detailed_output = getattr(result, "detailed_output", None)
@@ -362,6 +371,42 @@ class JiuSwarmStreamEventRail(DeepAgentRail):
             for template in legacy_templates
         )
 
+    @staticmethod
+    def _is_serialized_interrupt_envelope_text(content: str) -> bool:
+        """Detect a stringified interrupt envelope stored as a tool result.
+
+        A tool that delegates to a sub-agent does not raise when the sub-agent
+        interrupts: it returns the interrupt envelope
+        ``{"result_type": "interrupt", "state": [...], "interrupt_ids": [...]}``
+        as its result. Dict results are stringified into the ToolMessage, so the
+        parent context receives a ToolMessage whose content is the envelope
+        rather than an answer -- and the envelope embeds the sub-agent's pending
+        question. When the sub-agent resumes and returns for real, a second
+        ToolMessage arrives with the same tool_call_id. Unless the envelope is
+        recognised as a placeholder, the first-wins de-duplication in
+        _fix_incomplete_tool_context keeps the envelope and discards the genuine
+        result, so the parent goes on to answer with the stale question.
+
+        Matching is deliberately narrow because it is text sniffing:
+
+        - the whole content must be a mapping literal (``{`` ... ``}``);
+        - ``result_type`` must be its *first* key and must map to
+          ``interrupt`` -- which is exactly how the envelope is built;
+        - an ``interrupt_ids`` key must also be present.
+
+        The ``result_type``/``interrupt_ids`` pair is what the interrupt handling
+        itself tests on the live dict. Anchoring that pair to the head of the
+        literal means an ordinary result which merely mentions these words -- in
+        prose, in a quoted snippet, or as a nested value -- cannot match, because
+        such a result never *begins* with the envelope's first key.
+        """
+        stripped = content.strip()
+        if not stripped.startswith("{") or not stripped.endswith("}"):
+            return False
+        if not _INTERRUPT_ENVELOPE_HEAD_RE.match(stripped):
+            return False
+        return bool(_INTERRUPT_ENVELOPE_IDS_RE.search(stripped))
+
     def _is_tool_interrupt_placeholder(
         self,
         message: Any,
@@ -377,6 +422,9 @@ class JiuSwarmStreamEventRail(DeepAgentRail):
         3. We then compare content against known interrupt placeholder text
            variants for that tool. So fake/real is still determined by content,
            not by tool_call_id alone.
+        4. A stringified interrupt envelope counts as a placeholder too: it is
+           the "no result yet" marker a delegating tool leaves behind, and it
+           carries no tool name, so it is matched on its own shape.
         """
         if not isinstance(message, ToolMessage):
             return False
@@ -388,6 +436,8 @@ class JiuSwarmStreamEventRail(DeepAgentRail):
         if not content:
             return False
         if expected and content == expected:
+            return True
+        if self._is_serialized_interrupt_envelope_text(content):
             return True
         tool_name = tool_names_by_id.get(tool_call_id, "")
         if not tool_name:

--- a/tests/unit_tests/agentserver/rails/test_stream_event_rail_interrupt_dedup.py
+++ b/tests/unit_tests/agentserver/rails/test_stream_event_rail_interrupt_dedup.py
@@ -1,0 +1,294 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Regression tests for interrupt-envelope handling in _fix_incomplete_tool_context.
+
+A delegating tool (task/sub-agent) does not raise when its sub-agent interrupts;
+it returns the interrupt envelope as an ordinary result, which is stringified
+into a ToolMessage on the parent context. After the sub-agent resumes, a second
+ToolMessage arrives with the same tool_call_id carrying the genuine answer.
+
+_fix_incomplete_tool_context de-duplicates ToolMessages first-wins, so unless the
+envelope is classified as a placeholder the genuine answer is dropped and the
+parent keeps replying with the sub-agent's own pending question.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from openjiuwen.core.foundation.llm import (
+    AssistantMessage,
+    ToolMessage,
+    UserMessage,
+)
+from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
+
+from jiuwenswarm.agents.harness.common.rails.stream_event_rail import (
+    JiuSwarmStreamEventRail,
+)
+import jiuwenswarm.agents.harness.common.rails.stream_event_rail as rail_module
+
+
+# A faithful rendering of str({"result_type": "interrupt", "state": [...],
+# "interrupt_ids": [...]}) as produced when the envelope reaches a ToolMessage.
+ENVELOPE = (
+    "{'result_type': 'interrupt', 'state': [OutputSchema(type='__interaction__', "
+    "index=0, payload=InteractionOutput(id='chatcmpl-tool-fake0001', "
+    "value=ToolCallInterruptRequest(message='Which naming style do you want?', "
+    "payload_schema={'description': 'Payload'})))], "
+    "'interrupt_ids': ['chatcmpl-tool-fake0001']}"
+)
+ENVELOPE_JSON = (
+    '{"result_type": "interrupt", "state": [], '
+    '"interrupt_ids": ["chatcmpl-tool-fake0001"]}'
+)
+REAL = (
+    "success=True data={'output': 'Three candidates: retry_budget, "
+    "retry_ceiling, retry_allowance.'}"
+)
+
+
+class FakeContext:
+    """Minimal ModelContext stand-in with the three methods the rail uses."""
+
+    def __init__(self, messages: list[Any]) -> None:
+        self._messages = list(messages)
+
+    def get_messages(self) -> list[Any]:
+        return list(self._messages)
+
+    def pop_messages(self, size: int) -> None:
+        if size:
+            self._messages = self._messages[:-size]
+
+    async def add_messages(self, message: Any) -> None:
+        self._messages.append(message)
+
+
+class FakeInputs:
+    tools: list[Any] = []
+
+
+class FakeCallbackContext:
+    def __init__(self, context: FakeContext) -> None:
+        self.context = context
+        self.inputs = FakeInputs()
+        self.extra: dict[str, Any] = {}
+
+
+class LogCapture(logging.Handler):
+    """Capture records straight off the module logger.
+
+    jiuwenswarm loggers do not propagate, so pytest's caplog fixture sees
+    nothing; attach to the emitting logger instead.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+@pytest.fixture
+def repair_log():
+    capture = LogCapture()
+    logger = rail_module.logger
+    previous_level = logger.level
+    logger.addHandler(capture)
+    logger.setLevel(logging.INFO)
+    try:
+        yield capture
+    finally:
+        logger.removeHandler(capture)
+        logger.setLevel(previous_level)
+
+
+def _tool_call(tool_call_id: str = "tc1", name: str = "task") -> ToolCall:
+    return ToolCall(
+        id=tool_call_id,
+        type="function",
+        name=name,
+        arguments='{"subagent_type": "general-purpose"}',
+    )
+
+
+async def _repair(messages: list[Any]) -> list[Any]:
+    ctx = FakeCallbackContext(FakeContext(messages))
+    rail = JiuSwarmStreamEventRail()
+    await rail._fix_incomplete_tool_context(ctx)
+    return ctx.context.get_messages()
+
+
+def _tool_messages(messages: list[Any]) -> list[ToolMessage]:
+    return [m for m in messages if isinstance(m, ToolMessage)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("envelope", [ENVELOPE, ENVELOPE_JSON])
+async def test_envelope_then_real_keeps_the_real_result(envelope, repair_log):
+    """The genuine post-resume result must survive, not the interrupt envelope."""
+    messages = [
+        UserMessage(content="delegate please"),
+        AssistantMessage(content="", tool_calls=[_tool_call()]),
+        ToolMessage(content=envelope, tool_call_id="tc1"),
+        ToolMessage(content=REAL, tool_call_id="tc1"),
+    ]
+
+    result = await _repair(messages)
+
+    tool_messages = _tool_messages(result)
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == REAL
+    # The pending question must not survive into the parent context.
+    assert "Which naming style" not in str(tool_messages[0].content)
+
+    # The repair is reported as a placeholder replacement. The trailing real
+    # message is additionally tallied as a removed duplicate because it was
+    # hoisted into the placeholder's slot; that accounting is shared with the
+    # pre-existing "[Tool interrupted]" path and is not what this test guards.
+    repair_lines = [m for m in repair_log.messages if "Repaired tool message context" in m]
+    assert repair_lines, repair_log.messages
+    assert "placeholder_replaced=1" in repair_lines[-1]
+
+
+@pytest.mark.asyncio
+async def test_envelope_alone_is_left_in_place():
+    """While the sub-agent is still interrupted there is nothing to swap in."""
+    messages = [
+        UserMessage(content="delegate please"),
+        AssistantMessage(content="", tool_calls=[_tool_call()]),
+        ToolMessage(content=ENVELOPE, tool_call_id="tc1"),
+    ]
+
+    result = await _repair(messages)
+
+    tool_messages = _tool_messages(result)
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == ENVELOPE
+
+
+@pytest.mark.asyncio
+async def test_real_result_only_is_unchanged():
+    messages = [
+        UserMessage(content="delegate please"),
+        AssistantMessage(content="", tool_calls=[_tool_call()]),
+        ToolMessage(content=REAL, tool_call_id="tc1"),
+    ]
+
+    result = await _repair(messages)
+
+    tool_messages = _tool_messages(result)
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == REAL
+
+
+@pytest.mark.asyncio
+async def test_legacy_interrupt_placeholder_is_still_replaced(repair_log):
+    """The pre-existing '[Tool interrupted]' path keeps working."""
+    placeholder = (
+        "[Tool interrupted] Tool task was interrupted by the user and has no result."
+    )
+    messages = [
+        UserMessage(content="delegate please"),
+        AssistantMessage(content="", tool_calls=[_tool_call()]),
+        ToolMessage(content=placeholder, tool_call_id="tc1"),
+        ToolMessage(content=REAL, tool_call_id="tc1"),
+    ]
+
+    result = await _repair(messages)
+
+    tool_messages = _tool_messages(result)
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == REAL
+
+    repair_lines = [m for m in repair_log.messages if "Repaired tool message context" in m]
+    assert repair_lines, repair_log.messages
+    assert "placeholder_replaced=1" in repair_lines[-1]
+
+
+@pytest.mark.asyncio
+async def test_two_genuine_results_still_deduplicate_first_wins():
+    """Non-placeholder duplicates keep the existing first-wins behaviour."""
+    first = "success=True data={'output': 'first'}"
+    second = "success=True data={'output': 'second'}"
+    messages = [
+        UserMessage(content="delegate please"),
+        AssistantMessage(content="", tool_calls=[_tool_call()]),
+        ToolMessage(content=first, tool_call_id="tc1"),
+        ToolMessage(content=second, tool_call_id="tc1"),
+    ]
+
+    result = await _repair(messages)
+
+    tool_messages = _tool_messages(result)
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == first
+
+
+# --- false-positive guards -------------------------------------------------
+
+NOT_ENVELOPES = [
+    pytest.param(
+        "The sub-agent returned result_type interrupt with interrupt_ids set; "
+        "that is the envelope shape to look for.",
+        id="prose-mentioning-the-keys",
+    ),
+    pytest.param(
+        "success=True data={'output': \"grep for 'result_type': 'interrupt' and "
+        "'interrupt_ids' in handler.py\"}",
+        id="quoted-snippet-inside-a-real-result",
+    ),
+    pytest.param(
+        "{'output': \"the envelope is {'result_type': 'interrupt', "
+        "'interrupt_ids': []}\", 'result_type': 'answer'}",
+        id="envelope-nested-as-a-value",
+    ),
+    pytest.param(
+        "{'result_type': 'answer', 'interrupt_ids': [], 'output': 'done'}",
+        id="answer-envelope-carrying-interrupt_ids",
+    ),
+    pytest.param(
+        "{'result_type': 'interrupt', 'state': []}",
+        id="interrupt-without-interrupt_ids",
+    ),
+    pytest.param(
+        "{'result_type': 'interrupted', 'interrupt_ids': ['x']}",
+        id="near-miss-result_type-value",
+    ),
+    pytest.param("", id="empty"),
+]
+
+
+@pytest.mark.parametrize("content", NOT_ENVELOPES)
+def test_non_envelope_text_is_not_classified_as_an_envelope(content):
+    assert not JiuSwarmStreamEventRail._is_serialized_interrupt_envelope_text(content)
+
+
+@pytest.mark.parametrize("content", [ENVELOPE, ENVELOPE_JSON])
+def test_envelope_text_is_classified_as_an_envelope(content):
+    assert JiuSwarmStreamEventRail._is_serialized_interrupt_envelope_text(content)
+
+
+@pytest.mark.asyncio
+async def test_real_result_mentioning_the_keys_is_not_dropped():
+    """A genuine answer that merely talks about interrupts must win the dedup."""
+    chatty = (
+        "success=True data={'output': \"The check is result_type == 'interrupt' "
+        "plus 'interrupt_ids' in the dict.\"}"
+    )
+    messages = [
+        UserMessage(content="delegate please"),
+        AssistantMessage(content="", tool_calls=[_tool_call()]),
+        ToolMessage(content=chatty, tool_call_id="tc1"),
+    ]
+
+    result = await _repair(messages)
+
+    tool_messages = _tool_messages(result)
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == chatty


### PR DESCRIPTION
Paired: [GitHub #4292](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4292) ↔ [GitCode !5655](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5655)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

`JiuSwarmStreamEventRail._fix_incomplete_tool_context` runs before every model
call and repairs tool-call history. Part of that repair is a first-wins
de-duplication: the first ToolMessage carrying a given `tool_call_id` is taken
as the real result, and every later ToolMessage with that id is dropped.
Interrupt placeholders are exempt, so that a tool which was interrupted and
later resumed has its placeholder replaced in place by the genuine result.

`8ca6cc4a9`, which added both the de-duplication and the exemption, wrote the
exemption for the path in front of it: a tool that raises on interrupt and has
this rail write the placeholder. So the exemption recognises only the placeholder
texts the rail writes itself — the English and Chinese wordings
`_tool_interrupted_message` emits, plus one older English wording kept for
compatibility. A tool that delegates to a sub-agent never produces any of them,
because it does not raise when the sub-agent interrupts. It returns the
interrupt envelope

    {"result_type": "interrupt", "state": [...], "interrupt_ids": [...]}

as an ordinary dict result, and a dict result is stringified into the
ToolMessage. The envelope was therefore classified as a real result, and the
parent context ended up holding two ToolMessages for one `tool_call_id`: the
envelope, written when the sub-agent interrupted, and the genuine result,
written after it resumed. First-wins kept the envelope and discarded the answer.

### Why this is worse than a lost result

The envelope embeds the sub-agent's own pending interrupt request. So the
surviving ToolMessage does not read as an empty or malformed result — it reads
as the question the sub-agent asked. The parent then answers from that stale
question and relays it back verbatim instead of the work the sub-agent actually
completed, while the resumed sub-agent's output is dropped with no error
anywhere. Observed in production as a delegated question being put to the user a
second time after it had already been answered.

### The change

A stringified interrupt envelope is classified as a placeholder, so the existing
replacement path swaps in the real result. Nothing else in the repair changes.

The discriminator is the `result_type`/`interrupt_ids` pair that the interrupt
handling already tests for on the live dict, but matched as text and anchored:

- the whole content must be a mapping literal;
- `result_type` must be its **first** key and must map to `interrupt`, which is
  exactly how the envelope is constructed;
- an `interrupt_ids` key must be present.

Anchoring is the point of the design, not an implementation detail. This is text
sniffing on a tool result, and tool results routinely quote code and discuss
mechanisms. A result that merely mentions these words — in prose, in a quoted
snippet, or as a nested value — never *begins* with the envelope's first key, so
it cannot match. Both `repr()` (single quotes) and JSON (double quotes)
renderings are accepted, since either can reach a ToolMessage depending on how
the result was serialised.

### Why the fix belongs here as well as at the producer

A companion change is proposed against the agent framework repository
(`openJiuwen-ai/agent-core`, pull request 962) which stops a ToolMessage being
emitted for an interrupt envelope at all. The two are not alternatives, for two
reasons.

First, this repair runs before **every** model call, over the history as it
already stands. It therefore also repairs conversations that already carry the
bad ToolMessage — sessions persisted before any producer-side fix ships, and
sessions running against a framework version that does not have it. A
producer-side fix can only stop new ones being written.

Second, the classification is on the shape of the content, not on the identity
of the writer, so any other producer of the same envelope shape is covered
without further change here.

Neither change depends on the other to be correct, and applying both leaves this
one inert on the paths the other covers, which is the intended outcome for a
consumer-side repair.

### What was deliberately not done

- **No parsing of the envelope.** The content is classified and discarded, never
  read. Recovering the pending question from it and re-raising it would be a
  behaviour change to the interrupt lifecycle rather than a repair, and the
  lifecycle already owns that path.
- **No `json.loads`/`ast.literal_eval` round trip.** A tolerant parse would
  widen the match to anything a parser happens to accept, which is the opposite
  of what a text sniff on arbitrary tool output should do. Two anchored regular
  expressions match strictly less.
- **No change to first-wins for genuine duplicates.** Two real results for one
  `tool_call_id` still resolve to the first, unchanged.
- **The near-identical envelope built with `component_ids`** rather than
  `interrupt_ids` (the workflow interrupt path) is not matched. It does not
  reach a delegating tool's result, and widening the match on speculation would
  weaken the anchor for no observed defect.

**Which issue(s) this PR fixes**:

Fixes #4289

**What scenarios were tested, and what were the verification results（Function,
performance, reliability, etc.）**：

Sixteen tests added in one new file, `test_stream_event_rail_interrupt_dedup.py`:

- an envelope followed by the genuine post-resume result, in both `repr()` and
  JSON rendering, keeping the real result and reporting a placeholder
  replacement — and asserting the sub-agent's pending question does not survive
  into the parent context (two);
- an envelope with no successor left in place, since there is nothing to swap in
  while the sub-agent is still interrupted (one);
- a genuine result alone left untouched (one);
- the pre-existing `[Tool interrupted]` replacement path still working (one);
- two genuine results still resolving first-wins (one);
- the classifier accepting both envelope renderings (two);
- the classifier rejecting seven near misses: prose mentioning both key names, a
  quoted snippet inside a real result, an envelope nested as a value, an
  `answer` envelope that also carries `interrupt_ids`, an interrupt envelope
  without `interrupt_ids`, `result_type: 'interrupted'`, and empty content
  (seven);
- an end-to-end check that a genuine answer which merely discusses interrupts
  wins the de-duplication (one).

Against the unmodified source, eleven of the sixteen fail: the two behavioural
cases fail on their assertions — the envelope survives and the answer is gone —
and the nine classifier cases fail because the classifier does not exist. The
remaining five pass on both trees, as they should: they cover the paths this
change must not disturb.

Verification was by name-level comparison rather than by totals.
`tests/unit_tests/agentserver/` was run on this branch and on a clean checkout
of the base it sits on, with the same command in the same environment, back to
back:

- the set of failing test ids is byte-identical on both trees — none added, none
  fixed;
- the set of modules that fail to collect is identical on both trees;
- the passing count rises by exactly sixteen, the tests added here.

The counts behind that, for completeness rather than as the claim: on each side
110 tests fail, 63 modules fail to collect and four further tests error during
fixture setup, and passes go from 1687 to 1703. Those absolutes are
host-dependent and will differ elsewhere: on the machine used here the failures
come from tests that share fixed-name paths under the system temporary directory
with concurrent processes, and the collection errors come from a framework module
the installed version does not provide. Neither is touched by this change. No CI
result is claimed.

**Performance and reliability.** The added cost is one `str.strip()` and at most
two regular-expression matches per ToolMessage already being examined by a
function that walks the whole message list. The first is anchored with `match`
and rejects on the first character for any content that is not a mapping
literal, which is every ordinary tool result. Reliability moves in one direction:
every path that worked before still resolves to the same message, and the only
behaviour that changes is which of two competing ToolMessages survives for an
id where one of them is an envelope.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets.
We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

**Special notes for your reviewers**:

+ - [ ] Whether it causes forward compatibility failure
+ - [ ] Whether the dependent third-party library change is involved

On the **Design** box: not reviewed by a Maintainer. The point most wanting a
maintainer's judgement is the anchored text match. Classifying a tool result by
the shape of its text is a heuristic, and the alternative — having the producer
never write the message — is the subject of the companion framework change
described above. The argument for doing both is given there; a maintainer who
disagrees would be rejecting the "repair histories that already carry it" half,
which is the half a producer-side fix cannot supply.

On the **Interface** box: no external interface changes. The three names added —
`_is_serialized_interrupt_envelope_text` and two module-level compiled
patterns — are private to the rail module. No public signature, payload key or
message schema changes.

**Adjacent work that a reviewer may mistake for overlap.** #4261 sits on the
same resume path and touches this file, and is complementary rather than
competing. It repairs one specific producer: on the skill-acceleration
human-in-the-loop path the rail previously set `tool_msg` to `None`, and it now
has that path emit the rail's own `_tool_interrupted_message` text so
`_fix_incomplete_tool_context` can recognise and replace it. That is the same
mechanism this PR relies on, applied to a producer whose placeholder text the
classifier already knows. It leaves `_is_tool_interrupt_placeholder` and the
de-duplication itself unchanged, so it does not cover the delegating-tool
envelope described here, which carries no placeholder text and no tool name at
all. The hunks are in different methods and do not overlap. #4257 also touches
this file, in `after_model_call`, and is unrelated to interrupt handling.

On the **forward compatibility** box: no compatibility failure. The change is
additive to a classification predicate — content that did not match before still
does not match, and content that now matches was previously mishandled. A
history repaired by an older version is not made invalid by a newer one, and the
reverse holds too: this version repairs a history an older one left broken. The
**third-party library** box is likewise unchecked; no dependency changes. Both
boxes are shown rather than left commented out so the answers are visible rather
than implied.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4289
<!-- /bot1-related-issues -->
