### PR TITLE
fix(rails): recognise plain-string tool failures in ToolResultErrorDetector

### DIFF
--- a/jiuwenswarm/agents/harness/common/rails/execution_guard/circuit_breaker_rail.py
+++ b/jiuwenswarm/agents/harness/common/rails/execution_guard/circuit_breaker_rail.py
@@ -116,6 +116,38 @@ class ToolResultErrorDetector:
     _REPR_SUCCESS_FALSE = re.compile(r"^success\s*=\s*False\b", re.IGNORECASE)
     _REPR_SUCCESS_TRUE = re.compile(r"^success\s*=\s*True\b", re.IGNORECASE)
 
+    # 裸字符串失败标记：部分工具无法通过结构化 success 字段表达失败，只能在
+    # 没有产出结构化结果的路径上返回纯文本。只有当某个前缀是失败结果独有、
+    # 成功输出绝不会以其开头时才能加入（契约见
+    # tests/unit_tests/agentserver/rails/test_tool_result_error_detector.py）。
+    #
+    # ``[ERROR]:`` 是项目内工具失败的通用约定（见
+    # jiuwenswarm/agents/harness/common/tools/ 下的 search / image / audio /
+    # video / pdf / web_fetch 等模块）。这些工具成功时本就返回纯文本 —— 结果
+    # 列表、转写、模型回答 —— 失败时没有结构化字段可用，只能靠该前缀表达。
+    #
+    # 功能特定的标记不应写死在这个通用探测器里 —— 类文档已声明它可被其他模块
+    # 直接复用，而各调用方对误判/漏判的容忍度并不相同，一个错误的前缀会同时
+    # 影响所有调用方。功能模块改用 register_plain_error_prefix 注册自己的
+    # 标记，无需改动本文件。
+    _PLAIN_ERROR_PREFIXES = ("[ERROR]:",)
+    _extra_plain_error_prefixes: set[str] = set()
+
+    @classmethod
+    def register_plain_error_prefix(cls, prefix: str) -> None:
+        """为"失败即裸字符串"的工具注册一个专属前缀，无需改动本文件。
+
+        前缀必须是失败结果独有的标记，成功输出绝不会以其开头，否则会把成功
+        结果误判为失败。匹配大小写不敏感。
+        """
+        marker = prefix.strip().upper()
+        if marker:
+            cls._extra_plain_error_prefixes.add(marker)
+
+    @classmethod
+    def _plain_error_prefixes(cls) -> tuple[str, ...]:
+        return cls._PLAIN_ERROR_PREFIXES + tuple(cls._extra_plain_error_prefixes)
+
     @staticmethod
     def has_error(value: Any) -> bool:
         """结构化字段明确指示错误时返回 True，否则返回 False。"""
@@ -192,6 +224,10 @@ class ToolResultErrorDetector:
                 return {"success": False}
             if ToolResultErrorDetector._REPR_SUCCESS_TRUE.match(text):
                 return {"success": True}
+            upper = text.upper()
+            for prefix in ToolResultErrorDetector._plain_error_prefixes():
+                if upper.startswith(prefix):
+                    return {"success": False, "error": text}
         return None
 
     @staticmethod

--- a/tests/unit_tests/agentserver/rails/test_tool_result_error_detector.py
+++ b/tests/unit_tests/agentserver/rails/test_tool_result_error_detector.py
@@ -1,0 +1,255 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Contract tests for ToolResultErrorDetector.
+
+The detector's own docstring invites any module to import and reuse it, so
+its behaviour is a shared contract rather than a private helper of
+CircuitBreakerRail. Different consumers can want opposite things from it: a
+circuit breaker counting consecutive failures of one tool must not fire on a
+healthy result, while a rail that holds a task open until a required tool has
+succeeded must not read a failure as success.
+
+An unrecognised shape resolves to "no error", which is conservative for a
+consumer that only wants to avoid false positives and dangerous for one that
+must not miss a failure. That asymmetry is why every tool contract the
+detector is expected to understand is pinned here rather than left to
+whichever rail happens to exercise it.
+
+Adding a tool that signals failure in a bare string means registering its
+marker via ``ToolResultErrorDetector.register_plain_error_prefix`` from the
+feature's own module -- not editing ``_PLAIN_ERROR_PREFIXES``. That tuple
+stays generic; only ``[ERROR]:``, the project-wide tool-failure convention,
+belongs in it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from jiuwenswarm.agents.harness.common.rails.execution_guard.circuit_breaker_rail import (
+    ToolResultErrorDetector as Detector,
+)
+
+
+class _Result:
+    """A tool result object exposing success/data/error attributes."""
+
+    def __init__(self, success: bool, data=None, error=None) -> None:
+        self.success = success
+        self.data = data
+        self.error = error
+
+
+# ---------------------------------------------------------------------------
+# Failures the detector must recognise
+# ---------------------------------------------------------------------------
+
+FAILURES = [
+    pytest.param({"success": False, "error": "boom"}, id="dict-success-false"),
+    pytest.param({"is_error": True}, id="dict-is-error"),
+    pytest.param({"isError": "true"}, id="dict-isError-string"),
+    pytest.param({"status": "failed"}, id="dict-status-failed"),
+    pytest.param({"result_type": "error"}, id="dict-result-type"),
+    pytest.param({"error": "something went wrong"}, id="dict-error-field"),
+    pytest.param({"data": {"success": False}}, id="dict-nested-data"),
+    # mcp_exec_command: a completed command that exited non-zero.
+    pytest.param(
+        json.dumps({"command": "git log", "exit_code": 128, "stdout": "",
+                    "stderr": "fatal: Out of memory, realloc failed"}),
+        id="json-exit-code",
+    ),
+    pytest.param({"returncode": 1}, id="dict-returncode"),
+    # Repr of a result object, as it reaches the session history.
+    pytest.param("success=False data={'content': 'x'} error='boom'", id="repr-false"),
+    # mcp_exec_command: the paths that never produce an exit code.
+    pytest.param("[ERROR]: command timed out after 300s.", id="shell-timeout"),
+    pytest.param("[ERROR]: command failed to start: No such file", id="shell-spawn"),
+    pytest.param("[ERROR]: command execution failed: boom", id="shell-exec"),
+    pytest.param("[ERROR]: background command failed: nope", id="shell-background"),
+    # The same convention from other tool modules.
+    pytest.param("[ERROR]: query cannot be empty.", id="search-empty-query"),
+    pytest.param("[ERROR]: failed to fetch webpage: timeout", id="web-fetch-failed"),
+    pytest.param("[ERROR]: read_pdf failed: boom", id="pdf-failed"),
+    pytest.param(_Result(False, error="boom"), id="object-success-false"),
+]
+
+
+@pytest.mark.parametrize("value", FAILURES)
+def test_failures_are_recognised(value) -> None:
+    assert Detector.has_error(value) is True
+
+
+# ---------------------------------------------------------------------------
+# Successes the detector must not misread
+# ---------------------------------------------------------------------------
+
+SUCCESSES = [
+    pytest.param({"success": True, "data": {"content": "ok"}}, id="dict-success-true"),
+    pytest.param({"status": "ok"}, id="dict-status-ok"),
+    pytest.param({"error": None}, id="dict-error-none"),
+    pytest.param({"error": "none"}, id="dict-error-literal-none"),
+    pytest.param(
+        json.dumps({"command": "git log", "exit_code": 0, "stdout": "d4c3e32a",
+                    "stderr": ""}),
+        id="json-exit-zero",
+    ),
+    pytest.param("success=True data={'content': 'ok'} error=None", id="repr-true"),
+    # mcp_free_search on success: bare prose, no envelope, no marker.
+    pytest.param(
+        "Free search results (DuckDuckGo) for: circuit breaker\n"
+        "1. Circuit breaker pattern\n   https://example.invalid/cb",
+        id="search-plain-success",
+    ),
+    # wiki_query on success: the model's answer, returned bare. Nothing in
+    # its shape separates it from arbitrary prose, which is exactly why a
+    # plain-string convention has to be a marker no success can start with.
+    pytest.param(
+        "The retry budget is consumed per tool, not per session.",
+        id="wiki-plain-success",
+    ),
+    pytest.param(_Result(True, data={"content": "ok"}), id="object-success-true"),
+]
+
+
+@pytest.mark.parametrize("value", SUCCESSES)
+def test_successes_are_not_flagged(value) -> None:
+    assert Detector.has_error(value) is False
+
+
+# ---------------------------------------------------------------------------
+# Shapes the detector cannot classify
+# ---------------------------------------------------------------------------
+
+UNCLASSIFIABLE = [
+    pytest.param(None, id="none"),
+    pytest.param("", id="empty-string"),
+    pytest.param("plain prose with no contract", id="free-text"),
+    pytest.param("{not json", id="broken-json"),
+]
+
+
+@pytest.mark.parametrize("value", UNCLASSIFIABLE)
+def test_unclassifiable_shapes_claim_neither(value) -> None:
+    """Neither an error nor an explicit success, and the consequences differ.
+
+    A consumer that only wants to avoid false positives reads "not an error"
+    and declines to count the call -- conservative, and it will not interrupt
+    a run spuriously.
+
+    A consumer that must not miss a failure reads the same value as
+    satisfied, because its rule is `if not errored`. That is not an oversight
+    to be tightened later: several tools return a bare string on success --
+    `wiki_query` returns the model's answer, `mcp_free_search` returns a
+    formatted result list -- so a gate that demanded explicit success would
+    reject every one of them.
+
+    The cost is real and worth stating plainly. A tool that signals failure
+    in free text opens the gate for such a consumer. That is exactly the
+    failure mode `_PLAIN_ERROR_PREFIXES` and `register_plain_error_prefix`
+    exist to close: for any tool whose failure is a bare string, a registered
+    marker is the only thing standing between a rejection and a task marked
+    complete.
+    """
+    assert Detector.has_error(value) is False
+    assert Detector.has_explicit_success(value) is False
+
+
+# ---------------------------------------------------------------------------
+# has_explicit_success is narrower than "not an error"
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_success_requires_the_success_field() -> None:
+    assert Detector.has_explicit_success({"success": True}) is True
+    assert Detector.has_explicit_success({"status": "ok"}) is False
+    assert Detector.has_explicit_success("Free search results for: anything") is False
+
+
+def test_a_success_field_beats_a_nonzero_exit_code() -> None:
+    """An explicit success wins over the exit-code heuristic."""
+    assert Detector.has_error({"success": True, "exit_code": 1}) is False
+
+
+def test_plain_error_prefix_is_matched_case_insensitively() -> None:
+    assert Detector.has_error("[error]: command timed out after 300s.") is True
+
+
+def test_a_prefix_must_start_the_string() -> None:
+    """A mention inside prose is not a failure signal."""
+    assert Detector.has_error(
+        "The tool replied [ERROR]: earlier, but this run succeeded."
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# A deliberate non-match
+# ---------------------------------------------------------------------------
+
+WIKI_FAILURES = [
+    pytest.param("Error: Query cannot be empty.", id="wiki-error-colon"),
+    pytest.param("Error querying wiki: connection refused", id="wiki-error-querying"),
+    pytest.param("Wiki Query Error: boom", id="wiki-error-suffix"),
+]
+
+
+@pytest.mark.parametrize("value", WIKI_FAILURES)
+def test_bare_error_prose_is_not_matched(value) -> None:
+    """`wiki_tools` signals failure in prose, and that stays unrecognised.
+
+    Three different shapes appear in one file, and the common part is the word
+    "Error" in ordinary prose. Adding it as a prefix would flag any tool whose
+    successful output begins with that word, so the detector deliberately does
+    not match it.
+
+    This is a decision, not an oversight. The fix belongs in the tools:
+    converge those returns on the project's `[ERROR]:` convention, and they
+    are covered by the existing entry with no change here. Teaching this
+    detector every dialect is what produced the gap it was written to close.
+    """
+    assert Detector.has_error(value) is False
+
+
+# ---------------------------------------------------------------------------
+# register_plain_error_prefix: feature-owned markers, without editing the rail
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _clean_registered_prefixes():
+    """Isolate a test's registrations from every other test in the suite."""
+    saved = set(Detector._extra_plain_error_prefixes)
+    try:
+        yield
+    finally:
+        Detector._extra_plain_error_prefixes.clear()
+        Detector._extra_plain_error_prefixes.update(saved)
+
+
+def test_registered_prefix_is_recognised(_clean_registered_prefixes) -> None:
+    """A feature can teach the detector its own bare-string convention.
+
+    A tool whose failure contract is a bare string of its own -- rather than
+    the project-wide `[ERROR]:` -- registers that marker from its own module.
+    Nothing feature-specific has to be added to the rail for it to be counted.
+    """
+    assert Detector.has_error("EXAMPLE_TOOL_ERROR: unknown snapshot id.") is False
+
+    Detector.register_plain_error_prefix("EXAMPLE_TOOL_ERROR:")
+
+    assert Detector.has_error(
+        "EXAMPLE_TOOL_ERROR: unknown snapshot id. Correct the payload and "
+        "call the tool again."
+    ) is True
+
+
+def test_registered_prefix_is_matched_case_insensitively(_clean_registered_prefixes) -> None:
+    Detector.register_plain_error_prefix("my_tool_error:")
+    assert Detector.has_error("My_Tool_Error: boom") is True
+
+
+def test_registering_a_blank_prefix_is_a_no_op(_clean_registered_prefixes) -> None:
+    before = set(Detector._extra_plain_error_prefixes)
+    Detector.register_plain_error_prefix("   ")
+    assert Detector._extra_plain_error_prefixes == before


### PR DESCRIPTION
Paired: [GitHub #4294](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4294) ↔ [GitCode !5656](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5656)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

`ToolResultErrorDetector` decides whether a tool call failed by reading structured fields — `success`, `is_error` / `isError`, `status`, `result_type`, `error`, `exit_code` and friends. `_normalize` returns `None` for a bare string that is neither JSON nor a `success=...` repr, and `has_error` then reports `False`.

Many tool paths never produce a structured result. They return the failure as the whole result: a plain string starting with the project's `[ERROR]:` marker.

`CircuitBreakerRail._get_unknown_tool_streak` walks the history backwards and stops at the first record whose `has_error` is `False`. A bare-string failure is recorded with `has_error = False`, so it does not merely fail to advance the streak — it resets one that structured failures had already built up. `unknown_tool_repeat` therefore cannot fire for these tools, and the failures affected are the ones that reproduce identically on every retry by construction: a timeout, a safety rejection, a missing API key, a search provider that is not configured.

---

### Recognise the project-wide marker

`[ERROR]:` is treated as a plain-string failure marker, anchored at the start of the string and matched case-insensitively, so a mention of it inside prose is not a failure signal. It appears 36 times across eight tool modules (`command_tools`, `bash_tool_safety`, `search_tools`, `image_tools`, `audio_tools`, `video_tools`, `pdf_tools`, `web_fetch_tools`); 33 of those return it as the entire result and the remaining three carry it inside a dict the detector already reads. Every one of those call sites uses the marker exclusively on failure, which is the condition the detector already sets for itself: a prefix is only safe to add if a successful result can never start with it.

The new branch is reached only after every structured path has declined to classify the value, so no result the detector already understood changes classification.

### Why this rather than converting each tool

Converting a tool to return a structured failure payload is the better fix where it can be done, and **#2521 does exactly that** for `command_tools`' eight sites, keeping the `[ERROR]:` text inside `stderr`. This PR is complementary to it, not an alternative:

- That route has to be taken one tool at a time. #2521 covers `command_tools`; the remaining 28 occurrences across the other seven modules — 25 of them bare-string returns — are untouched by it.
- It is not equally available everywhere. `search_tools`, `image_tools`, `audio_tools`, `video_tools`, `pdf_tools` and `web_fetch_tools` all return prose on success — a formatted result list, a transcription, a model's answer — so wrapping their failures in a JSON envelope gives them an asymmetric contract, and wrapping their successes too changes what the model reads. Either is a contract change, not a bug fix.
- The two do not collide. A tool converted to structured JSON never reaches the plain-string branch, so recognising the marker stays correct as tools are converted and simply stops applying to each one in turn.

### Let a feature declare its own marker instead of hardcoding one here

`register_plain_error_prefix` is added alongside the constant, so a tool whose failure contract is its own bare string — rather than the project-wide marker — registers that string from its own module.

The alternative, adding each such string to `_PLAIN_ERROR_PREFIXES`, puts feature-specific constants in a shared rail. The detector's docstring invites any module to import and reuse it, and its consumers do not share a tolerance for false positives versus missed failures, so a prefix that is wrong for one of them is wrong for all of them at once. Keeping the constant to the one convention the whole harness already treats as generic means a mistaken registration is scoped to the module that made it.

### What was deliberately not done

`wiki_tools` signals failure in ordinary prose — `Error: Query cannot be empty.`, `Error querying wiki: ...`, `Wiki Query Error: ...`, three shapes in one file — and those stay unrecognised. The common part is the word "Error" in prose, and a successful output cannot be trusted never to begin with it. The fix for that file is to converge its returns on `[ERROR]:`, after which they are covered here with no further change. Teaching this detector every dialect of failure prose would reintroduce the class of gap it is being changed to close. The three prose shapes are pinned as expected non-matches, so the decision is visible rather than inferred from their absence.

### Verification

Against the branch point, before the change:

```
has_error('{"command": "git log", "exit_code": 128, ...}')       -> True
has_error('[ERROR]: command timed out after 300s.')              -> False
has_explicit_success('[ERROR]: command timed out after 300s.')   -> False
```

The second and third together are the defect: the value is not classified as a failure, and it is not classified as a success either — it is unclassifiable, and the fallback resolves that to "not an error". After the change the second is `True`, and the first and third are unchanged.

New tests: `tests/unit_tests/agentserver/rails/test_tool_result_error_detector.py`, 41 tests. Applied to the unmodified source they produce 8 assertion failures — the seven plain-string failure shapes and the case-insensitivity check — plus 3 setup errors on the tests for `register_plain_error_prefix`, which cannot exist before the change. All 41 pass with it.

The whole detector contract is pinned rather than only the new branch, because the fallback to "no error" is conservative for a consumer that only wants to avoid false positives and dangerous for one that must not miss a failure, and only a pinned contract lets a second consumer rely on it. Covered: every recognised failure shape including the new plain-string ones; the successes that must not be misread, in particular `wiki_query` returning the model's answer bare and `mcp_free_search` returning a formatted result list, neither distinguishable in shape from arbitrary prose; the `wiki_tools` prose non-matches above; and the registration path, including case-insensitive matching and the no-op on a blank prefix.

`pytest tests/unit_tests/agentserver/` was run on the branch point and on this branch back to back. The set of failing and erroring test names is identical, compared name by name rather than by count, and the passing count rises by exactly the 41 tests added here. The pre-existing failures and collection errors in that directory are unrelated to this change and are present on the branch point as well.

**Which issue(s) this PR fixes**:

Fixes #4291

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

**Special notes for your reviewers**:

**Relationship to #2521.** That PR fixes the same root cause from the tool side for `command_tools`, and also touches `circuit_breaker_rail.py` — to add an identical-repeat detector with its two thresholds and message strings, to reword the `unknown_tool_repeat` strings, and to change the critical force-finish payload's `result_type` from `answer` to `error`. It does not touch `ToolResultErrorDetector`, `_normalize`, or the plain-string branch this PR adds. The hunks do not overlap: this change inserts into the `ToolResultErrorDetector` class body and into `_normalize`, and the hunks in #2521 sit above and below both. Whichever merges second rebases.

The two are worth having together, and one of them strengthens the other. #2521 makes the command tool's failures structured, which is the stronger fix for that tool. Its identical-repeat abort counts only records whose `has_error` is true, and `has_error` is inferred through `ToolResultErrorDetector`, so a bare-string failure is currently invisible to that abort exactly as it is to the streak — the change here restores both at once. In the other direction nothing is required: this PR is correct and complete on its own, and stays correct whether or not #2521 lands.

Beyond the command tool, this PR restores the error streak for the 25 remaining bare-string sites in the other seven modules, and gives any future tool with a bare-string failure contract a way to be counted without another edit to this rail.

**The rail on other branches.** `circuit_breaker_rail.py` was removed on `dev-stable` by #3644, which replaced the `execution_guard.circuit_breaker` configuration with an `agent_ras` section whose detectors live in the agent framework rather than in this repository. On `develop` that replacement is not present: the rail in this file is the implementation that runs, and `ToolResultErrorDetector` is the only classifier deciding whether a tool call failed. This PR is scoped to `develop` accordingly. Whether `develop` takes the same migration, and how the replacement classifies a bare-string tool result, is a maintainer's call; nothing here depends on that answer, and the change is a strict addition inside `ToolResultErrorDetector` that a later migration carries or drops as a unit.

This branch is one commit on the current develop tip (cfe09ccf1) and merges into it cleanly. No commit on develop has touched `circuit_breaker_rail.py` since the branch point, so the file is byte-identical to the tip apart from this change.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4291
<!-- /bot1-related-issues -->
