### PR TITLE
fix(ask_user): guard the question read, state a remedy in every rejection

### DIFF
--- a/jiuwenswarm/agents/harness/common/rails/ask_user_rail.py
+++ b/jiuwenswarm/agents/harness/common/rails/ask_user_rail.py
@@ -292,13 +292,29 @@ class StructuredAskUserRail(AskUserRail):
         a rejection with the answer text.
 
         For plain query: delegate to parent class behavior (AskUserPayload).
+
+        每条拒绝信息都必须给出应当改成什么，而不只是指出哪里错了。
+
+        Every rejection below states the remedy as well as the fault. A
+        rejection from here never reaches a person: it is handed back to the
+        model as the tool result, and the model's only move is to call the tool
+        again. A message that names what was wrong without naming what to send
+        instead gives it nothing new to write, so the retry carries identical
+        arguments -- and repeated identical tool calls are what the loop
+        detector ends the run over, with its abort text delivered to the user in
+        place of an answer. Quoting the shape to send is what breaks that cycle,
+        so a rejection added later should quote one too.
         """
         args = self._parse_tool_args(tool_call)
         raw_questions = args.get("questions")
         if "questions" in args and not isinstance(raw_questions, list):
             return self.reject(
                 tool_result=(
-                    "[INVALID_ARGUMENT] questions must be an array when provided."
+                    "[INVALID_ARGUMENT] questions must be an array of question "
+                    "objects. Send it as a JSON array, e.g. questions: "
+                    '[{"question": "Which one?", "options": [{"label": "A"}, '
+                    '{"label": "B"}]}]. To ask a single free-text question '
+                    "instead, omit questions entirely and send only query."
                 )
             )
         questions_data = raw_questions if raw_questions else None
@@ -311,7 +327,9 @@ class StructuredAskUserRail(AskUserRail):
                     "[INVALID_ARGUMENT] ask_user accepts at most "
                     f"{MAX_STRUCTURED_QUESTIONS} questions per call; "
                     f"received {len(questions_data)}. "
-                    "Split them across multiple calls."
+                    "Call ask_user again with the first "
+                    f"{MAX_STRUCTURED_QUESTIONS} questions, and ask the "
+                    "remaining ones in a further call once these are answered."
                 )
             )
 
@@ -320,7 +338,10 @@ class StructuredAskUserRail(AskUserRail):
                 return self.reject(
                     tool_result=(
                         f"[INVALID_ARGUMENT] questions[{question_index}] "
-                        "must be an object."
+                        "must be an object. Replace it with an object carrying "
+                        "the question text, plus 2-4 options when the answer is "
+                        'a choice, e.g. {"question": "Which one?", "options": '
+                        '[{"label": "A"}, {"label": "B"}]}.'
                     )
                 )
             question_text = question.get("question")
@@ -328,14 +349,18 @@ class StructuredAskUserRail(AskUserRail):
                 return self.reject(
                     tool_result=(
                         f"[INVALID_ARGUMENT] questions[{question_index}].question "
-                        "is required and must be a non-empty string."
+                        "is required and must be a non-empty string. Add the "
+                        'sentence to put to the user, e.g. "question": "Which '
+                        'branch should the fix go on?".'
                     )
                 )
             if "header" in question and not isinstance(question["header"], str):
                 return self.reject(
                     tool_result=(
                         f"[INVALID_ARGUMENT] questions[{question_index}].header "
-                        "must be a string when provided."
+                        "must be a string when provided. Send a short label of "
+                        'a few words, e.g. header: "Deployment", or drop the '
+                        "field."
                     )
                 )
             if "options" not in question:
@@ -345,7 +370,10 @@ class StructuredAskUserRail(AskUserRail):
                 return self.reject(
                     tool_result=(
                         f"[INVALID_ARGUMENT] questions[{question_index}].options "
-                        "must be an array when provided."
+                        "must be an array of option objects. Send it as a JSON "
+                        'array, e.g. options: [{"label": "Yes"}, '
+                        '{"label": "No"}]. To let the user answer in their own '
+                        "words instead, omit options entirely."
                     )
                 )
             for option_index, option in enumerate(options):
@@ -358,7 +386,9 @@ class StructuredAskUserRail(AskUserRail):
                     return self.reject(
                         tool_result=(
                             f"[INVALID_ARGUMENT] {path} is required "
-                            "and must be a non-empty string."
+                            "and must be a non-empty string. Give the option "
+                            "the 1-5 words the user should see, e.g. "
+                            '{"label": "Apply update"}.'
                         )
                     )
             if options and not 2 <= len(options) <= 4:
@@ -366,7 +396,10 @@ class StructuredAskUserRail(AskUserRail):
                     tool_result=(
                         f"[INVALID_ARGUMENT] questions[{question_index}].options "
                         "must contain either 0 or 2-4 items; "
-                        f"received {len(options)}."
+                        f"received {len(options)}. Merge or drop choices until "
+                        "at most 4 remain, ask the rest in a further ask_user "
+                        "call, or omit options entirely to let the user answer "
+                        "in their own words."
                     )
                 )
 
@@ -420,7 +453,10 @@ class StructuredAskUserRail(AskUserRail):
                     return self.reject(
                         tool_result=(
                             "[INVALID_ARGUMENT] answers must include at least "
-                            "one non-empty response."
+                            "one non-empty response; the user submitted "
+                            "nothing. Do not treat this as an answer: either "
+                            "call ask_user again with the same question, or "
+                            "continue without it and say what you assumed."
                         )
                     )
                 logger.info(

--- a/jiuwenswarm/agents/harness/common/rails/interrupt/interrupt_helpers.py
+++ b/jiuwenswarm/agents/harness/common/rails/interrupt/interrupt_helpers.py
@@ -7,9 +7,10 @@ and building permission rails.
 """
 from __future__ import annotations
 
+import copy
 import json
 import re
-from typing import Any
+from typing import Any, Mapping
 
 from jiuwenswarm.agents.harness.code.prompt.plan_approval import (
     build_plan_approval_actions,
@@ -579,7 +580,9 @@ def convert_interactions_to_ask_user_question(state_outputs: list) -> dict | Non
         if questions_raw is None:
             continue
 
-        questions = _build_multi_questions(questions_raw)
+        questions = _build_multi_questions(
+            questions_raw, _extract_ask_user_query(value_obj)
+        )
         return {
             "event_type": "chat.ask_user_question",
             "request_id": request_id,
@@ -706,11 +709,72 @@ def _extract_questions_from_value(value_obj: Any) -> list | None:
     return None
 
 
-def _build_multi_questions(questions_data: list) -> list:
+def _extract_ask_user_query(value_obj: Any) -> str:
+    """The call's top-level ``query``, or ``""`` when there is none.
+
+    Read from the same place ``_extract_questions_from_value`` reads the
+    questions: ``ToolCallInterruptRequest.tool_args`` preserves the original
+    ``ask_user`` arguments. It is the last source of prompt text for a question
+    that arrived without any of its own, and the only one still available once
+    the tool call itself has been consumed.
+    """
+    query = getattr(value_obj, "query", None)
+    if isinstance(query, str) and query.strip():
+        return query
+    if isinstance(value_obj, dict):
+        query = value_obj.get("query")
+        if isinstance(query, str) and query.strip():
+            return query
+
+    tool_args = getattr(value_obj, "tool_args", None)
+    if isinstance(tool_args, str):
+        try:
+            tool_args = json.loads(tool_args)
+        except (ValueError, TypeError):
+            tool_args = None
+    if isinstance(tool_args, dict):
+        query = tool_args.get("query")
+        if isinstance(query, str) and query.strip():
+            return query
+    return ""
+
+
+def _resolve_question_text(question: Mapping[str, Any], fallback_query: str) -> str:
+    """The prompt to show for one question.
+
+    Three sources in order: the question's own ``question``, its ``header``,
+    then the call's top-level ``query``. A call that satisfied the ask_user rail
+    never reaches past the first, because that rail rejects a question carrying
+    no text. The fallbacks are for questions that did not come through it -- the
+    same class of input the non-array ``options`` guard in
+    ``_build_multi_questions`` already accounts for. There a malformed value
+    built a question out of single characters; here a missing one raised
+    ``KeyError``, losing the whole conversion and every question in the call
+    with it.
+    """
+    for candidate in (
+        question.get("question"),
+        question.get("header"),
+        fallback_query,
+    ):
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate
+    return ""
+
+
+def _build_multi_questions(questions_data: list, fallback_query: str = "") -> list:
     """Build frontend PendingQuestionItem list from questions data.
 
     有选项的问题: 保留原始选项 + 追加 __other__ (自定义输入)
     无选项的问题: 不追加 __other__, 前端应直接进入自由输入模式
+
+    问题若声明了 ``inputs``，该键原样带出，本函数不解释其内容。
+
+    A question's ``inputs`` declaration is carried through as opaque data. This
+    is the one normalisation point every channel's question passes through, so
+    it must not learn what any single channel's renderer makes of the
+    declaration: it neither reads nor validates nor reshapes it. A channel with
+    no renderer for it never looks the key up and behaves exactly as before.
     """
     questions = []
     for q in questions_data:
@@ -724,11 +788,17 @@ def _build_multi_questions(questions_data: list) -> list:
         else:
             options = []
         question_payload = {
-            "question": q["question"],
+            "question": _resolve_question_text(q, fallback_query),
             "header": q.get("header") or "Question",
             "options": options,
             "multi_select": q.get("multi_select", False),
         }
+        # A non-empty array only, so a question declaring nothing keeps the
+        # payload it had; copied, not referenced, because one question can reach
+        # several channels and none may edit what the next one receives.
+        declared_inputs = q.get("inputs")
+        if isinstance(declared_inputs, list) and declared_inputs:
+            question_payload["inputs"] = copy.deepcopy(declared_inputs)
         questions.append(question_payload)
     return questions
 

--- a/tests/unit_tests/agentserver/test_ask_user_validation.py
+++ b/tests/unit_tests/agentserver/test_ask_user_validation.py
@@ -98,3 +98,128 @@ async def test_empty_structured_answers_are_rejected():
 
     assert isinstance(decision, RejectResult)
     assert "answers must include at least one non-empty response" in decision.tool_result
+
+
+# Every rejection the model can reach while writing an ask_user call. A
+# rejection naming only the fault is retried unchanged -- the model has nothing
+# new to try -- and repeated identical tool calls end the run at the loop
+# detector, whose abort text is delivered to the user in place of an answer. So
+# each message must also name what to send instead, which in practice means
+# quoting a shape.
+_REJECTION_CASES = [
+    ("questions_not_array", {"query": "Q", "questions": "a,b"}),
+    (
+        "too_many_questions",
+        {"query": "Q", "questions": [{"question": f"Q{i}"} for i in range(5)]},
+    ),
+    ("question_not_object", {"query": "Q", "questions": ["just a string"]}),
+    ("question_text_missing", {"query": "Q", "questions": [{"header": "H"}]}),
+    (
+        "header_not_string",
+        {"query": "Q", "questions": [{"question": "Q1", "header": 123}]},
+    ),
+    (
+        "options_not_array",
+        {"query": "Q", "questions": [{"question": "Q1", "options": "a,b"}]},
+    ),
+    (
+        "option_without_label",
+        {"query": "Q", "questions": [{"question": "Q1", "options": [{}, {}]}]},
+    ),
+    (
+        "one_option",
+        {"query": "Q", "questions": [{"question": "Q1", "options": [{"label": "A"}]}]},
+    ),
+]
+
+# An instruction to do something, as opposed to a restatement of the rule that
+# was broken. Deliberately a word list rather than a shape check: what matters
+# is that the model is told to act, and the wording of any one message is free
+# to change.
+_REMEDY_WORDS = (
+    "Send",
+    "send",
+    "Add",
+    "add",
+    "Replace",
+    "replace",
+    "Call",
+    "call",
+    "Give",
+    "give",
+    "Merge",
+    "merge",
+    "omit",
+    "drop",
+    "continue",
+)
+
+
+@pytest.mark.parametrize(
+    "case_name,arguments",
+    _REJECTION_CASES,
+    ids=[name for name, _ in _REJECTION_CASES],
+)
+@pytest.mark.asyncio
+async def test_every_rejection_states_a_remedy(case_name, arguments):
+    rail = StructuredAskUserRail()
+
+    decision = await rail.resolve_interrupt(
+        MagicMock(), _make_tool_call(arguments), None
+    )
+
+    assert isinstance(decision, RejectResult), case_name
+    message = decision.tool_result
+    assert message.startswith("[INVALID_ARGUMENT]"), case_name
+    assert any(word in message for word in _REMEDY_WORDS), message
+
+
+@pytest.mark.asyncio
+async def test_empty_answers_rejection_states_a_remedy():
+    """The resume-path rejection is on the same loop: it too must say what to do.
+
+    Reached when the user submits nothing at all. Without the closing clause an
+    empty response has been read as agreement, so the message says explicitly
+    that it is not an answer and gives both ways forward.
+    """
+    rail = StructuredAskUserRail()
+    tc = _make_tool_call(
+        {
+            "query": "Choose",
+            "questions": [
+                {
+                    "question": "Which option?",
+                    "options": [{"label": "A"}, {"label": "B"}],
+                }
+            ],
+        }
+    )
+
+    decision = await rail.resolve_interrupt(MagicMock(), tc, {"answers": {}})
+
+    assert isinstance(decision, RejectResult)
+    assert any(word in decision.tool_result for word in _REMEDY_WORDS)
+    assert "call ask_user again" in decision.tool_result
+    assert "continue without it" in decision.tool_result
+
+
+@pytest.mark.asyncio
+async def test_a_valid_call_still_raises_an_interrupt():
+    """The rejections are all this changes: a well-formed call is untouched."""
+    rail = StructuredAskUserRail()
+    tc = _make_tool_call(
+        {
+            "query": "Choose",
+            "questions": [
+                {
+                    "question": "Which option?",
+                    "header": "Choice",
+                    "options": [{"label": "A"}, {"label": "B"}],
+                }
+            ],
+        }
+    )
+
+    decision = await rail.resolve_interrupt(MagicMock(), tc, None)
+
+    assert isinstance(decision, InterruptResult)

--- a/tests/unit_tests/agentserver/test_interrupt_helpers.py
+++ b/tests/unit_tests/agentserver/test_interrupt_helpers.py
@@ -207,3 +207,146 @@ def test_build_multi_questions_appends_other_for_valid_options():
     )
 
     assert [opt["label"] for opt in questions[0]["options"]] == ["A", "B", "Other"]
+
+
+def test_build_multi_questions_survives_a_question_without_text():
+    """A missing question key must not take the whole conversion down.
+
+    Same class of input as the #2331 guard above: a question that did not come
+    through the ask_user rail's validation. There a malformed ``options`` value
+    built a question out of single characters; here a missing ``question`` key
+    raised ``KeyError``, losing every question in the call rather than the one
+    that was malformed.
+    """
+    from jiuwenswarm.agents.harness.common.rails.interrupt.interrupt_helpers import (
+        _build_multi_questions,
+    )
+
+    questions = _build_multi_questions([{"header": "Follow-up"}])
+
+    assert questions[0]["question"] == "Follow-up"
+    assert questions[0]["header"] == "Follow-up"
+
+
+def test_build_multi_questions_falls_back_to_the_calls_query():
+    from jiuwenswarm.agents.harness.common.rails.interrupt.interrupt_helpers import (
+        _build_multi_questions,
+    )
+
+    questions = _build_multi_questions(
+        [{"options": [{"label": "A"}, {"label": "B"}]}],
+        "When should the follow-up happen?",
+    )
+
+    assert questions[0]["question"] == "When should the follow-up happen?"
+    # No header was written, so the existing placeholder still applies.
+    assert questions[0]["header"] == "Question"
+
+
+def test_build_multi_questions_prefers_question_over_the_fallbacks():
+    from jiuwenswarm.agents.harness.common.rails.interrupt.interrupt_helpers import (
+        _build_multi_questions,
+    )
+
+    questions = _build_multi_questions(
+        [{"question": "Own text", "header": "Follow-up"}],
+        "Top level query",
+    )
+
+    assert questions[0]["question"] == "Own text"
+
+
+def test_build_multi_questions_derives_nothing_without_any_source():
+    """No text anywhere yields an empty string, never a KeyError."""
+    from jiuwenswarm.agents.harness.common.rails.interrupt.interrupt_helpers import (
+        _build_multi_questions,
+    )
+
+    questions = _build_multi_questions([{"multi_select": True}])
+
+    assert questions[0]["question"] == ""
+    assert questions[0]["multi_select"] is True
+
+
+def test_build_multi_questions_carries_an_inputs_declaration_through():
+    """A declaration the caller supplied must reach the connector intact.
+
+    ``_build_multi_questions`` rebuilt every question as a closed four-key
+    literal, so ``inputs`` was discarded one layer below whatever would have
+    rendered it. It is carried as opaque data: this is the normalisation point
+    every channel's question passes through, so it cannot interpret a key one
+    channel's renderer owns.
+    """
+    from jiuwenswarm.agents.harness.common.rails.interrupt.interrupt_helpers import (
+        _build_multi_questions,
+    )
+
+    declaration = [{"type": "date", "label": "First run"}]
+    questions = _build_multi_questions(
+        [{"question": "When?", "header": "Schedule", "inputs": declaration}]
+    )
+
+    assert questions[0]["inputs"] == declaration
+    # Opaque means copied, not shared: one question can reach several channels,
+    # and neither may edit what the next receives or the recorded arguments.
+    assert questions[0]["inputs"] is not declaration
+    questions[0]["inputs"][0]["label"] = "edited"
+    assert declaration[0]["label"] == "First run"
+
+
+@pytest.mark.parametrize(
+    "declared",
+    [None, [], "date", {"type": "date"}, 0],
+    ids=["absent", "empty", "string", "object", "zero"],
+)
+def test_build_multi_questions_omits_anything_but_a_non_empty_array(declared):
+    """A question declaring nothing usable keeps exactly the payload it had."""
+    from jiuwenswarm.agents.harness.common.rails.interrupt.interrupt_helpers import (
+        _build_multi_questions,
+    )
+
+    question = {"question": "Which option?", "header": "Choice"}
+    if declared is not None:
+        question["inputs"] = declared
+
+    questions = _build_multi_questions([question])
+
+    assert questions == [
+        {
+            "question": "Which option?",
+            "header": "Choice",
+            "options": [],
+            "multi_select": False,
+        }
+    ]
+
+
+def test_convert_interactions_derives_prompt_from_the_calls_query():
+    """End to end over the extraction point: query reaches the built question.
+
+    The top-level ``query`` lives in ``tool_args`` beside the questions, which
+    is the only place the fallback is still readable once the tool call has been
+    consumed.
+    """
+    from openjiuwen.core.single_agent.interrupt import ToolCallInterruptRequest
+
+    value = ToolCallInterruptRequest(
+        message="Please provide the details for your follow-up:",
+        payload_schema={},
+        tool_name="ask_user",
+        tool_call_id="tc_001",
+        tool_args={
+            "query": "Please provide the details for your follow-up:",
+            "questions": [{"inputs": [{"type": "date", "name": "d"}]}],
+        },
+    )
+
+    payload = convert_interactions_to_ask_user_question(
+        [{"id": "req_1", "value": value}]
+    )
+
+    assert payload is not None
+    assert payload["source"] == "ask_user_interrupt"
+    question = payload["questions"][0]
+    assert question["question"] == "Please provide the details for your follow-up:"
+    assert question["inputs"] == [{"type": "date", "name": "d"}]


### PR DESCRIPTION
Paired: [GitHub #4300](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4300) ↔ [GitCode !5660](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5660)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

Two faults on the `ask_user` path. Each one turns a single malformed tool call
into a lost turn instead of a corrected one.

**1. `_build_multi_questions` raises `KeyError` on a question with no
`question` key, and discards every key it does not recognise.**

`_build_multi_questions` in `rails/interrupt/interrupt_helpers.py` is the one
normalisation point every channel's question passes through. It rebuilt each
question as a closed four-key literal:

```python
question_payload = {
    "question": q["question"],
    "header": q.get("header") or "Question",
    "options": options,
    "multi_select": q.get("multi_select", False),
}
```

Two problems in four lines. The `question` read is unguarded, so a question
without that key raises. The literal is closed, so any other key the caller
supplied is dropped one layer below whatever would have consumed it.

The `KeyError` does not cost only the offending question. It propagates out of
`convert_interactions_to_ask_user_question`, so the whole conversion is lost
and no interrupt payload is built for any question in the call.

That this function receives questions the `ask_user` validator would have
rejected is already established in the file. The line immediately above the
`question` read coerces a non-array `options` so it is not iterated as single
characters, and that guard was added after the validator existed, for a shape
seen in the wild. A missing `question` is the same class of input and was left
unguarded next to it.

**2. Validator rejections name the fault without naming the remedy, and the
model has no way to respond except to send the same call again.**

A rejection from `StructuredAskUserRail.resolve_interrupt` never reaches a
person. The tool is skipped, nothing is posted, and the message is handed back
to the model as the tool result. Its only move is to call the tool again. A
message that says what was wrong without saying what to send instead gives it
nothing new to write, so the retry carries identical arguments — and repeated
identical tool calls are what the loop detector ends the run over, with its
abort text delivered in place of an answer.

Observed in production: a call rejected for a missing per-question `question`,
retried unchanged, and the run aborted, with nothing ever posted for the user
to answer. The rejection was
`[INVALID_ARGUMENT] questions[0].question is required and must be a non-empty
string.` — accurate, and useless to the only reader it has.

**What changed**:

* The question text is derived from three sources in order: the question's own
  `question`, its `header`, then the call's top-level `query`. `query` is read
  from `tool_args`, which preserves it beside the questions and is the only
  place it is still readable once the tool call has been consumed. When none of
  the three has anything, the result is an empty string, never an exception.
* An `inputs` declaration is carried through the normalisation, and only when
  it is a non-empty list. A question that declares nothing keeps byte-for-byte
  the payload it had; a malformed declaration is left out here rather than
  forwarded for a renderer to choke on. It is deep-copied rather than
  referenced, because one question can be delivered to more than one channel
  and a consumer that edits what it was handed must not edit what the next one
  receives, nor the recorded tool arguments. Nothing in this repository renders
  `inputs` today and the schema does not advertise it, so this changes no
  behaviour on its own; it stops a channel-neutral normalisation step from
  silently discarding a key its caller supplied.
* Every rejection message now quotes the shape to send:
  * `questions` not an array: the array form, and that a free-text question is
    asked by omitting `questions` altogether.
  * more than four questions: call again with the first four and ask the rest
    once those are answered, rather than the bare "split them across multiple
    calls".
  * a question that is not an object: the object form.
  * a missing or empty `question`: the sentence to put to the user.
  * a non-string `header`: a short label, or drop the field.
  * `options` not an array: the array form, and that omitting `options` lets
    the user answer in their own words.
  * an option with no label: the 1-5 words the user should see.
  * an option count outside 0 or 2-4: merge, drop, or ask the rest in a further
    call.
  * an empty `answers` map on resume: this is not an answer, so either ask
    again or continue without it and say what was assumed. Without that last
    clause an empty response has previously been read as agreement.

**Cross-references**:

* This continues #2071, which hardened the same validator against a non-array
  `options` and an empty Other. Several of the messages that PR added are among
  those given a remedy here.
* #2480 is complementary, not competing: it delivers a built question payload
  out to channels and touches no file in this PR. It reads `question` off the
  payload this normalisation produces; when a question arrived without that
  key, no payload was produced at all, so nothing reached it.

**Deliberately not done**:

* No retry counting and no loop breaking. The loop detector already exists and
  is doing its job; what was missing is a rejection the model can act on.
* No validator rule is relaxed. The set of calls that are rejected is exactly
  what it was; only what the rejections say has changed. A well-formed call
  still raises the same interrupt.
* The tool schema is untouched. Nothing new is advertised to the model.
* `inputs` is carried, not interpreted. Nothing in this repository renders it
  today and the schema does not offer it, so this PR claims no new capability.
  What is fixed is narrower and independent of any renderer: a channel-neutral
  normalisation step silently deleted a key its caller supplied. A layer that
  must not know what any single channel means by a field also has no business
  deciding that field does not exist.
* The `KeyError` is guarded, not made unreachable. Callers that construct a
  question payload directly are not audited here; the conversion simply no
  longer takes the whole call down when one arrives malformed, which is the
  same posture as the non-array `options` guard beside it.

**Which issue(s) this PR fixes**:

Fixes #4297

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

21 test cases were added: 11 in
`tests/unit_tests/agentserver/test_interrupt_helpers.py` and 10 in
`tests/unit_tests/agentserver/test_ask_user_validation.py`, both alongside the
existing cases for this code.

The rejection tests are parametrised over every rejection reachable while
writing an `ask_user` call, plus the resume-path rejection, and assert each
message contains an instruction rather than only a restatement of the rule — so
a rejection added later cannot quietly reintroduce the stall.

Reverting only the two production files and keeping the new tests, 14 of the 21
fail:

* `test_build_multi_questions_survives_a_question_without_text` fails with the
  `KeyError` this PR is about;
* five more fail on the derivation, the pass-through, and the end-to-end
  conversion through `convert_interactions_to_ask_user_question`;
* eight fail on the remedy assertion, against the old messages.

The remaining seven pass both before and after and are labelled as what they
are — regression guards, not evidence:

* five assert the pass-through stays narrow, so a question declaring nothing
  (or declaring something malformed) keeps exactly the payload it had;
* one asserts a well-formed call still raises an interrupt;
* one covers the "more than four questions" message, whose old text happened to
  contain an instruction already.

`tests/unit_tests/agentserver` and `tests/system_tests` were run on the base
commit and on this branch back to back on the same host. The set of failing and
erroring test names is identical between the two — 173 node ids either way —
and the passing count rises by exactly the 21 new cases (1927 → 1948). The absolute
failure and error counts on that host are large and host-dependent — an
unrelated dependency version mismatch accounts for all of them, identically on
base and branch — so only the name-level comparison carries weight here. No CI
result is claimed.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

**Special notes for your reviewers**:

+ - [ ] Whether it causes forward compatibility failure
+ - [ ] Whether the dependent third-party library change is involved

On the **Interface** box: left unchecked because no interface review has taken
place, not because nothing changed. The tool schema is unchanged, so nothing
the model sees differs apart from the text of a rejection. The frontend
question payload does gain one optional key, and only for a question whose
caller supplied it: no key is removed and no type changes, a consumer that does
not know the key never looks it up, and a question that does not declare it is
byte-for-byte what it was. Still, it is a visible change to what that payload
can look like on the wire and deserves a reviewer's explicit sign-off.

On the **forward compatibility** box: a client that does not know `inputs`
behaves exactly as before, since it never reads the key. The **Document** and
**third-party library** boxes are unchecked: no website documentation and no
dependency changes here.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4297
<!-- /bot1-related-issues -->
