### PR TITLE
fix(permission): decode approval answers through one shared option vocabulary

### DIFF
--- a/jiuwenswarm/agents/harness/common/rails/interrupt/interrupt_helpers.py
+++ b/jiuwenswarm/agents/harness/common/rails/interrupt/interrupt_helpers.py
@@ -20,6 +20,12 @@ from jiuwenswarm.agents.harness.code.rails.code_plan_approval_interrupt_rail imp
     is_plan_approval_message,
     strip_inline_plan_approval_choices,
 )
+from jiuwenswarm.agents.harness.common.rails.interrupt.permission_options import (
+    ALLOW_ONCE,
+    ALWAYS_ALLOW,
+    REJECT,
+    SESSION_ALLOW,
+)
 from jiuwenswarm.common.utils import logger
 
 SKILL_EVOLUTION_APPROVAL_SCHEMA = "openjiuwen.skill_evolution_approval.v1"
@@ -769,12 +775,15 @@ def _normalize_question_option(option: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+# 权限审批的兜底选项。``value`` 取自 ``permission_options``，与解析回答用的是同一份
+# 词表：web / CLI 回传 ``value``，TUI 回传 ``label``，两条路都要能被 ``build_inputs``
+# 解出同一个动作。label / description 保持原样，渲染出的文案不变。
 def _default_interrupt_options() -> list[dict[str, str]]:
     return [
-        {"label": "本次允许", "description": "仅本次授权执行"},
-        {"label": "会话内记住", "description": "本次会话内自动放行同类操作"},
-        {"label": "永久记住", "description": "写回磁盘，所有会话均自动放行"},
-        {"label": "拒绝", "description": "拒绝执行此工具"},
+        {"value": ALLOW_ONCE, "label": "本次允许", "description": "仅本次授权执行"},
+        {"value": SESSION_ALLOW, "label": "会话内记住", "description": "本次会话内自动放行同类操作"},
+        {"value": ALWAYS_ALLOW, "label": "永久记住", "description": "写回磁盘，所有会话均自动放行"},
+        {"value": REJECT, "label": "拒绝", "description": "拒绝执行此工具"},
     ]
 
 

--- a/jiuwenswarm/agents/harness/common/rails/interrupt/permission_options.py
+++ b/jiuwenswarm/agents/harness/common/rails/interrupt/permission_options.py
@@ -1,0 +1,92 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""权限/确认审批选项的统一词表。
+
+审批提示的选项文案同时充当协议取值：渲染端拿到 ``label``/``value``，回答时
+web、CLI 回传 ``option.value || option.label``，TUI 一律回传 ``option.label``，
+后端再把这个字符串解回 ``approved`` / ``auto_confirm`` / ``persist_allow``。
+出题端与解题端因此必须共用一份词表，否则任何一端改动文案都会让回答落到
+"未知选项"，而未知选项是按拒绝处理的——用户点了同意，工具却被拒。
+
+本模块只放稳定标识和它们的别名，不放任何展示文案：展示文案归出题端所有、可以
+改，而这里的取值不随之变化。除标准库外不依赖任何东西，出题端与解题端都能引。
+"""
+
+from __future__ import annotations
+
+import re
+
+# ── 稳定标识 ────────────────────────────────────────────────────────────────
+# 四个动作的规范取值。出题端把它们写进选项的 ``value``，解题端解回同一个动作。
+ALLOW_ONCE = "allow_once"
+SESSION_ALLOW = "session_allow"
+ALWAYS_ALLOW = "always_allow"
+REJECT = "reject"
+
+# 归一化：首尾空白、大小写、以及空格/下划线/连字符的混用都不应影响解析。
+# ``Allow Once``、``allow_once``、``Allow-once`` 是同一个取值的不同写法，历史上
+# 只有部分写法被接受。CJK 文案没有词间分隔，归一化对其无影响。
+_SEPARATORS = re.compile(r"[\s_\-]+")
+
+
+def normalize_option_value(value: object) -> str:
+    """把回传的选项字符串归一化成可比较的形式。"""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return _SEPARATORS.sub("_", text).casefold()
+
+
+# ── 别名 → 动作 ─────────────────────────────────────────────────────────────
+# 只收录各出题端确实下发过的写法。这段映射与计划审批共用同一条 if/elif，因此
+# 不要加入 "skip"/"跳过"/"ok" 这类通用词：别的确认流出现同名按钮会被误判。
+_ALIAS_SOURCES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        ALLOW_ONCE,
+        ("allow_once", "approve", "accept", "proceed", "本次允许", "批准", "开始执行", "接收", "接受"),
+    ),
+    (SESSION_ALLOW, ("session_allow", "会话内记住")),
+    (ALWAYS_ALLOW, ("always_allow", "allow_always", "永久记住", "总是允许")),
+    (
+        # ``reject_once`` 是 ACP 的写法（``reject-once``）。ACP 走的是
+        # ``session/request_permission``，正常不会回到这里，收下只是兜底。
+        REJECT,
+        ("reject", "reject_once", "拒绝", "继续规划", "其他意见", "keep_planning"),
+    ),
+)
+
+_OPTION_ALIASES: dict[str, str] = {
+    normalize_option_value(alias): action
+    for action, aliases in _ALIAS_SOURCES
+    for alias in aliases
+}
+
+# 归一化后仍表示"继续规划"而非"拒绝"的取值，用于挑选写给模型的反馈文案。
+_KEEP_PLANNING_VALUES: frozenset[str] = frozenset(
+    normalize_option_value(alias) for alias in ("keep_planning", "继续规划", "其他意见")
+)
+
+
+def resolve_permission_action(value: object) -> str | None:
+    """解出选项对应的动作，无法识别时返回 ``None``。
+
+    返回 ``None`` 表示"没认出来"，与"用户拒绝"是两回事：调用方应当记录告警后
+    再按拒绝兜底，这样一次解析失败是可诊断的，而不是静默变成一次拒绝。
+    """
+    return _OPTION_ALIASES.get(normalize_option_value(value))
+
+
+def is_keep_planning_value(value: object) -> bool:
+    """判断拒绝类取值是否属于"继续规划"。"""
+    return normalize_option_value(value) in _KEEP_PLANNING_VALUES
+
+
+__all__ = [
+    "ALLOW_ONCE",
+    "ALWAYS_ALLOW",
+    "REJECT",
+    "SESSION_ALLOW",
+    "is_keep_planning_value",
+    "normalize_option_value",
+    "resolve_permission_action",
+]

--- a/jiuwenswarm/server/runtime/agent_adapter/interface.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface.py
@@ -54,6 +54,15 @@ from jiuwenswarm.agents.harness.code.prompt.plan_approval import (
     PLAN_SKIP_OPTION_VALUES,
     plan_skip_feedback,
 )
+from jiuwenswarm.agents.harness.common.rails.interrupt.permission_options import (
+    ALLOW_ONCE,
+    ALWAYS_ALLOW,
+    REJECT,
+    SESSION_ALLOW,
+    is_keep_planning_value,
+    normalize_option_value,
+    resolve_permission_action,
+)
 from jiuwenswarm.common.mode_matrix import (
     canonicalize_mode_text,
     is_code_profile_mode,
@@ -175,6 +184,38 @@ def _history_user_content(params: Any, query: Any) -> Any:
     if isinstance(content, str):
         return collapse_file_content_blocks(content)
     return content
+
+
+def _warn_unrecognised_approval_option(
+    branch: str,
+    source: Any,
+    request_id: Any,
+    value: Any,
+    outcome: str,
+) -> None:
+    """审批选项没认出来时留一条告警，然后才按拒绝兜底。
+
+    兜底成拒绝是对的：认不出来就不该放行。但在此之前它是静默的——用户点了同意，
+    工具被拒，现场只剩一句用户看不到的 feedback，排查时无从下手。选项文案是跨端
+    约定，任何一端改了字面量都会以"用户拒绝"的形式出现，因此这条告警要带上原始
+    取值和落到哪个分支。
+
+    取值为空是渲染端的"取消"（TUI 无拒绝项时按 Esc 即回传空串），属于正常路径，
+    不是解析失败，不告警。
+    """
+    if not normalize_option_value(value):
+        return
+    logger.warning(
+        "[JiuWenSwarm] %s unrecognised approval option: source=%s request_id=%s "
+        "value=%r outcome=%s. The answer is refused because it could not be decoded, "
+        "not because the user declined; check that the option vocabulary in "
+        "permission_options matches what the channel sends.",
+        branch,
+        source,
+        request_id,
+        value,
+        outcome,
+    )
 
 
 def _should_record_user_history(params: Any) -> bool:
@@ -1473,6 +1514,9 @@ class JiuWenSwarm:
             }
             action = action_by_value.get(value)
             if action is None:
+                _warn_unrecognised_approval_option(
+                    "SkillEvolutionApproval", source, request_id, value, "rejected_as_unknown_option"
+                )
                 action = "reject"
             payload = {"action": action}
             if custom_input:
@@ -1496,22 +1540,20 @@ class JiuWenSwarm:
 
         value = selected_options[0] if selected_options else ""
 
-        if value in ("approve", "本次允许", "Approve", "Proceed", "批准", "开始执行"):
+        # 选项字符串来自各渲染端：web / CLI 回传 ``value``，TUI 回传 ``label``。
+        # 统一走 ``permission_options`` 的词表解析，别在这里再维护一份字面量元组。
+        action = resolve_permission_action(value)
+
+        if action == ALLOW_ONCE:
             confirm_payload = {"approved": True, "auto_confirm": False, "feedback": ""}
-        elif value in ("session_allow", "会话内记住", "Session Allow"):
+        elif action == SESSION_ALLOW:
             confirm_payload = {
                 "approved": True,
                 "auto_confirm": True,
                 "persist_allow": False,
                 "feedback": "",
             }
-        elif value in (
-            "always_allow",
-            "allow_always",
-            "永久记住",
-            "总是允许",
-            "Always Allow",
-        ):
+        elif action == ALWAYS_ALLOW:
             confirm_payload = {
                 "approved": True,
                 "auto_confirm": True,
@@ -1549,14 +1591,22 @@ class JiuWenSwarm:
                 "feedback": custom_input or "用户希望继续规划",
                 "plan_revise": True,
             }
-        elif value in ("reject", "拒绝", "Reject", "继续规划", "其他意见"):
+        elif action == REJECT:
             feedback = custom_input or (
-                "用户希望继续规划" if value in ("Keep planning", "继续规划", "其他意见") else "用户拒绝"
+                "用户希望继续规划" if is_keep_planning_value(value) else "用户拒绝"
             )
             confirm_payload = {"approved": False, "auto_confirm": False, "feedback": feedback}
         elif custom_input:
+            # 选项没认出来，但用户填了自由文本，就用文本当反馈继续拒绝。取值仍然
+            # 是没解出来的，同样要告警。
+            _warn_unrecognised_approval_option(
+                "PermissionRail", source, request_id, value, "rejected_with_custom_input"
+            )
             confirm_payload = {"approved": False, "auto_confirm": False, "feedback": custom_input}
         else:
+            _warn_unrecognised_approval_option(
+                "PermissionRail", source, request_id, value, "rejected_as_unknown_option"
+            )
             confirm_payload = {"approved": False, "auto_confirm": False, "feedback": f"未知选项: {value}"}
 
         interactive_input.update(request_id, confirm_payload)

--- a/tests/unit_tests/agentserver/test_permission_option_decode.py
+++ b/tests/unit_tests/agentserver/test_permission_option_decode.py
@@ -1,0 +1,173 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""权限/确认审批回答的解析。
+
+选项文案同时充当协议取值，渲染端回传的可能是 ``value``（web / CLI）也可能是
+``label``（TUI）。解析必须落到同一个动作上，且认不出来时只能拒绝、不能批准。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.agents.harness.common.rails.interrupt.permission_options import (
+    ALLOW_ONCE,
+    ALWAYS_ALLOW,
+    REJECT,
+    SESSION_ALLOW,
+    normalize_option_value,
+    resolve_permission_action,
+)
+from jiuwenswarm.common.schema.agent import AgentRequest
+
+# 修改前那份字面量元组接受的全部取值。放宽识别范围只能增不能减，任何一个从这里
+# 掉出去都意味着一个曾经可用的按钮变成了拒绝。
+LEGACY_ACCEPTED = {
+    "approve": ALLOW_ONCE,
+    "本次允许": ALLOW_ONCE,
+    "Approve": ALLOW_ONCE,
+    "Proceed": ALLOW_ONCE,
+    "批准": ALLOW_ONCE,
+    "开始执行": ALLOW_ONCE,
+    "session_allow": SESSION_ALLOW,
+    "会话内记住": SESSION_ALLOW,
+    "Session Allow": SESSION_ALLOW,
+    "always_allow": ALWAYS_ALLOW,
+    "allow_always": ALWAYS_ALLOW,
+    "永久记住": ALWAYS_ALLOW,
+    "总是允许": ALWAYS_ALLOW,
+    "Always Allow": ALWAYS_ALLOW,
+    "reject": REJECT,
+    "拒绝": REJECT,
+    "Reject": REJECT,
+    "继续规划": REJECT,
+    "其他意见": REJECT,
+}
+
+
+def _decode(monkeypatch, selected_option: str, source: str = "permission_interrupt") -> dict:
+    from jiuwenswarm.server.runtime.agent_adapter import interface as interface_module
+
+    monkeypatch.setattr(interface_module, "get_config", lambda: {"preferred_language": "zh"})
+    monkeypatch.setattr(interface_module, "get_memory_mode", lambda _config: "disabled")
+
+    request = AgentRequest(
+        request_id="req-answer",
+        channel_id="web",
+        session_id="web_session",
+        params={
+            "query": "",
+            "request_id": "call_123",
+            "answers": [{"selected_options": [selected_option], "custom_input": ""}],
+            "source": source,
+        },
+    )
+    inputs, _, _ = interface_module.JiuWenSwarm().build_inputs(request)
+    return inputs["query"].user_inputs["call_123"]
+
+
+class TestVocabulary:
+    """词表本身：归一化与别名解析。"""
+
+    @staticmethod
+    @pytest.mark.parametrize(("value", "action"), sorted(LEGACY_ACCEPTED.items()))
+    def test_every_previously_accepted_value_still_resolves(value, action):
+        """放宽识别范围不得丢掉任何一个原本认识的取值。"""
+        assert resolve_permission_action(value) == action
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "value",
+        ["Allow Once", "allow_once", "Allow-Once", "ALLOW_ONCE", "  allow_once  "],
+    )
+    def test_allow_once_spellings_agree(value):
+        """大小写、分隔符与首尾空白都不改变取值的含义。"""
+        assert resolve_permission_action(value) == ALLOW_ONCE
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("value", "action"),
+        [
+            ("Session allow", SESSION_ALLOW),
+            ("session-allow", SESSION_ALLOW),
+            ("Always allow", ALWAYS_ALLOW),
+            ("ALWAYS ALLOW", ALWAYS_ALLOW),
+            ("Keep planning", REJECT),
+        ],
+    )
+    def test_case_only_and_separator_only_variants_resolve(value, action):
+        """仅大小写或分隔符不同的写法曾经会落到未知选项。"""
+        assert resolve_permission_action(value) == action
+
+    @staticmethod
+    @pytest.mark.parametrize("value", ["", "   ", None, "no-such-option", "skip", "确定"])
+    def test_unrecognised_values_resolve_to_none(value):
+        """认不出来返回 None，由调用方决定兜底；None 不等于"用户拒绝"。"""
+        assert resolve_permission_action(value) is None
+
+    @staticmethod
+    def test_normalisation_does_not_touch_cjk():
+        """中文文案没有词间分隔，归一化必须原样保留。"""
+        assert normalize_option_value("  本次允许 ") == "本次允许"
+
+
+class TestDecodedPayloads:
+    """经过 build_inputs 的端到端解析。"""
+
+    @staticmethod
+    @pytest.mark.parametrize("value", ["approve", "allow_once", "本次允许", "Allow once"])
+    def test_allow_once_approves_without_auto_confirm(monkeypatch, value):
+        payload = _decode(monkeypatch, value)
+        assert payload["approved"] is True
+        assert payload["auto_confirm"] is False
+
+    @staticmethod
+    @pytest.mark.parametrize("value", ["session_allow", "会话内记住", "Session allow"])
+    def test_session_allow_does_not_persist(monkeypatch, value):
+        payload = _decode(monkeypatch, value)
+        assert payload["approved"] is True
+        assert payload["auto_confirm"] is True
+        assert payload["persist_allow"] is False
+
+    @staticmethod
+    @pytest.mark.parametrize("value", ["always_allow", "allow_always", "永久记住", "Always allow"])
+    def test_always_allow_persists(monkeypatch, value):
+        payload = _decode(monkeypatch, value)
+        assert payload["approved"] is True
+        assert payload["auto_confirm"] is True
+        assert payload["persist_allow"] is True
+
+    @staticmethod
+    @pytest.mark.parametrize("value", ["reject", "拒绝", "Reject"])
+    def test_reject_is_refused(monkeypatch, value):
+        payload = _decode(monkeypatch, value)
+        assert payload["approved"] is False
+        assert payload["feedback"] == "用户拒绝"
+
+    @staticmethod
+    @pytest.mark.parametrize("value", ["继续规划", "其他意见", "Keep planning"])
+    def test_keep_planning_refuses_with_its_own_feedback(monkeypatch, value):
+        """"继续规划"仍是拒绝，但写给模型的反馈不同。"""
+        payload = _decode(monkeypatch, value)
+        assert payload["approved"] is False
+        assert payload["feedback"] == "用户希望继续规划"
+
+    @staticmethod
+    def test_plan_execute_still_matches_exactly(monkeypatch):
+        """计划审批取值走独立分支，不受词表放宽影响。"""
+        payload = _decode(monkeypatch, "plan_execute", source="confirm_interrupt")
+        assert payload["approved"] is True
+        assert payload["plan_execute"] is True
+
+    @staticmethod
+    def test_plan_skip_still_matches_exactly(monkeypatch):
+        payload = _decode(monkeypatch, "plan_skip", source="confirm_interrupt")
+        assert payload["approved"] is False
+        assert payload["plan_skip"] is True
+
+    @staticmethod
+    def test_unknown_option_still_falls_closed(monkeypatch):
+        """未知选项仍按拒绝处理：放宽识别范围不得吞掉这道兜底。"""
+        payload = _decode(monkeypatch, "no-such-option")
+        assert payload["approved"] is False
+        assert "未知选项" in payload["feedback"]

--- a/tests/unit_tests/agentserver/test_permission_option_decode_logging.py
+++ b/tests/unit_tests/agentserver/test_permission_option_decode_logging.py
@@ -1,0 +1,127 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""认不出来的审批选项必须留下告警。
+
+兜底成拒绝是对的，静默地兜底不是：用户点了同意、工具被拒，现场却只有一句用户
+看不到的 feedback。这里断言"未识别"会以 WARNING 记下原始取值，而正常路径（包括
+渲染端回传空串的取消）不得产生噪声。
+
+不使用 caplog：本仓库的 logger 不向 root 传播，caplog 收不到记录。改为直接替换
+发出日志的那个 logger。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.schema.agent import AgentRequest
+
+
+class _RecordingLogger:
+    """只记录调用的 logger 替身。"""
+
+    def __init__(self) -> None:
+        self.warnings: list[tuple] = []
+        self.infos: list[tuple] = []
+
+    def warning(self, msg, *args, **kwargs) -> None:
+        self.warnings.append((msg, args))
+
+    def info(self, msg, *args, **kwargs) -> None:
+        self.infos.append((msg, args))
+
+    def error(self, msg, *args, **kwargs) -> None:
+        pass
+
+    def debug(self, msg, *args, **kwargs) -> None:
+        pass
+
+
+def _decode(monkeypatch, selected_option, source="permission_interrupt", custom_input=""):
+    from jiuwenswarm.server.runtime.agent_adapter import interface as interface_module
+
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(interface_module, "logger", recorder)
+    monkeypatch.setattr(interface_module, "get_config", lambda: {"preferred_language": "zh"})
+    monkeypatch.setattr(interface_module, "get_memory_mode", lambda _config: "disabled")
+
+    selected_options = [] if selected_option is None else [selected_option]
+    request = AgentRequest(
+        request_id="req-answer",
+        channel_id="web",
+        session_id="web_session",
+        params={
+            "query": "",
+            "request_id": "call_123",
+            "answers": [
+                {"selected_options": selected_options, "custom_input": custom_input}
+            ],
+            "source": source,
+        },
+    )
+    inputs, _, _ = interface_module.JiuWenSwarm().build_inputs(request)
+    return inputs["query"].user_inputs["call_123"], recorder
+
+
+def _warned_values(recorder) -> list:
+    """告警里携带的原始取值。"""
+    return [args[3] for _msg, args in recorder.warnings]
+
+
+class TestUnrecognisedOptionsWarn:
+
+    @staticmethod
+    def test_unknown_option_warns_and_still_refuses(monkeypatch):
+        """未识别取值：先告警，再按拒绝兜底。"""
+        payload, recorder = _decode(monkeypatch, "no-such-option")
+        assert payload["approved"] is False
+        assert len(recorder.warnings) == 1
+        assert "no-such-option" in _warned_values(recorder)
+
+    @staticmethod
+    def test_warning_names_the_branch_and_the_outcome(monkeypatch):
+        """告警要能定位到分支，否则日志里认不出是哪条路。"""
+        _payload, recorder = _decode(monkeypatch, "no-such-option")
+        msg, args = recorder.warnings[0]
+        assert "unrecognised approval option" in msg
+        assert args[0] == "PermissionRail"
+        assert args[4] == "rejected_as_unknown_option"
+
+    @staticmethod
+    def test_unknown_option_with_custom_input_also_warns(monkeypatch):
+        """带自由文本的拒绝同样是没解出取值，不能因为有 feedback 就不告警。"""
+        payload, recorder = _decode(monkeypatch, "no-such-option", custom_input="别跑")
+        assert payload["approved"] is False
+        assert payload["feedback"] == "别跑"
+        assert len(recorder.warnings) == 1
+        assert recorder.warnings[0][1][4] == "rejected_with_custom_input"
+
+    @staticmethod
+    def test_evolution_branch_warns_on_unknown_action(monkeypatch):
+        """技能演进分支同样会把未识别取值变成拒绝，同样要告警。"""
+        payload, recorder = _decode(
+            monkeypatch, "no-such-option", source="skill_evolution_approval"
+        )
+        assert payload["action"] == "reject"
+        assert len(recorder.warnings) == 1
+        assert recorder.warnings[0][1][0] == "SkillEvolutionApproval"
+
+
+class TestQuietPaths:
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "value", ["approve", "本次允许", "allow_once", "Session allow", "拒绝", "plan_execute"]
+    )
+    def test_recognised_values_do_not_warn(monkeypatch, value):
+        """认识的取值不产生告警，否则告警本身没有信噪比。"""
+        _payload, recorder = _decode(monkeypatch, value, source="confirm_interrupt")
+        assert recorder.warnings == []
+
+    @staticmethod
+    @pytest.mark.parametrize("value", ["", "   ", None])
+    def test_cancel_does_not_warn(monkeypatch, value):
+        """空取值是渲染端的取消（TUI 无拒绝项时按 Esc），属正常路径。"""
+        payload, recorder = _decode(monkeypatch, value)
+        assert payload["approved"] is False
+        assert recorder.warnings == []

--- a/tests/unit_tests/agentserver/test_permission_option_roundtrip.py
+++ b/tests/unit_tests/agentserver/test_permission_option_roundtrip.py
@@ -1,0 +1,56 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""出题端下发的每个选项都要能被解题端解回原本的动作。
+
+这是共用词表的意义所在：兜底选项的 ``value`` 与 ``label`` 都可能被回传（web /
+CLI 回传 ``value``，TUI 回传 ``label``），两条路都必须落到同一个动作上。缺了这
+条断言，两端各自维护字面量就会重新漂移。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from jiuwenswarm.agents.harness.common.rails.interrupt.interrupt_helpers import (
+    convert_interactions_to_ask_user_question,
+)
+from jiuwenswarm.agents.harness.common.rails.interrupt.permission_options import (
+    ALLOW_ONCE,
+    ALWAYS_ALLOW,
+    REJECT,
+    SESSION_ALLOW,
+    resolve_permission_action,
+)
+
+EXPECTED_ACTIONS = [ALLOW_ONCE, SESSION_ALLOW, ALWAYS_ALLOW, REJECT]
+
+
+def _default_options() -> list[dict]:
+    interrupt = SimpleNamespace(
+        id="call_123",
+        value={"message": "", "tool_name": "run_command"},
+    )
+    payload = convert_interactions_to_ask_user_question([interrupt])
+    assert payload is not None
+    return payload["questions"][0]["options"]
+
+
+def test_default_options_carry_the_shared_tokens():
+    """兜底选项的稳定标识就是词表里的四个动作。"""
+    assert [option["value"] for option in _default_options()] == EXPECTED_ACTIONS
+
+
+def test_stable_values_do_not_displace_the_display_text():
+    """``value`` 是新增字段，不得挤掉展示文案。"""
+    for option in _default_options():
+        assert option["label"]
+        assert option["description"]
+
+
+@pytest.mark.parametrize("field", ["value", "label"])
+def test_every_emitted_option_decodes_back_to_its_action(field):
+    """回传 value 或回传 label，解出来必须是同一个动作。"""
+    options = _default_options()
+    assert [resolve_permission_action(option[field]) for option in options] == EXPECTED_ACTIONS


### PR DESCRIPTION
Paired: [GitHub #4301](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4301) ↔ [GitCode !5658](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5658)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

A tool permission prompt can be approved by the user and refused by the backend
in the same turn, with nothing in the logs to say why.

The approval prompt's option strings double as the protocol token. Options
built by `_default_interrupt_options()` carry `label` and `description` and no
`value`, so each channel sends back whatever string it was given — web and the
CLI send `option.value || option.label`, the TUI always sends `option.label`.
`_build_interactive_input_from_answers`, which `build_inputs` reaches, then
matches that string against hardcoded literal tuples to decide `approved` /
`auto_confirm` / `persist_allow`. The display text is the protocol, with nothing
shared between the end that writes the options and the end that reads the answer
back.

Two hand-maintained vocabularies live in that one decoder and they have
drifted apart. The skill-evolution branch maps `allow_once` explicitly; the
permission branch accepts it nowhere, so an `allow_once` arriving on a
permission prompt falls through to the unknown-option path and is decoded as a
rejection. The evolution branch is the mirror image: it accepts `allow_always`
and `总是允许`, but neither `always_allow` — the token the permission branch
treats as canonical — nor `永久记住`, the label the permission prompt actually
renders for that action. Matching is also exact, so `Session allow` misses
`Session Allow` on case alone and `Allow Once` misses `allow_once` on a
separator alone.

Reproduced on the base commit with no channel and no configuration involved:

```python
request = AgentRequest(
    request_id="req-answer", channel_id="web", session_id="web_session",
    params={"query": "", "request_id": "call_123",
            "answers": [{"selected_options": ["allow_once"], "custom_input": ""}],
            "source": "permission_interrupt"},
)
inputs, _, _ = JiuWenSwarm().build_inputs(request)
```

Before: `{'approved': False, 'auto_confirm': False, 'feedback': '未知选项: allow_once'}`.
After: `{'approved': True, 'auto_confirm': False, 'feedback': ''}`.
`"Session allow"`, `"Always allow"` and `"Allow once"` behave the same way, and
none of them warns on the base commit.

### The change

**One vocabulary, matched on a normalised form.** The option vocabulary moves
into a new leaf module `permission_options`, which both the prompt builder and
the decoder import. It holds the four stable tokens, their aliases, and the
normalisation used to compare them, and depends on nothing but the standard
library so either end can import it without pulling in the other. Matching
ignores surrounding whitespace, case, and the space/underscore/hyphen spelling
of a separator, so `Allow Once`, `allow_once` and `Allow-once` are one value.
CJK labels have no inter-word separators, so normalisation leaves them
unchanged.

Recognition only grows. Every literal the tuples accepted before resolves to
the same action as before, and the test suite guards that with an explicit
table of the previously accepted values, so a later edit cannot quietly drop
one.

**Stable `value` tokens on the fallback options.** `_default_interrupt_options()`
returned only `label` and `description`, making it the last option set on this
wire field whose display text was its only identifier — plan approval already
holds the option structure and its wording deliberately apart, and
`_normalize_question_option()` already forwards a `value` whenever an interrupt
supplies one. The four fallback options now carry the tokens from
`permission_options`. `label` and `description` are byte-identical, so no
rendered string changes, and a channel that echoes the label still decodes as
before because the labels remain aliases of the same four actions.

This ordering is load-bearing rather than cosmetic, which is why both parts are
in one change: adding those tokens while the decoder still rejected
`allow_once` would have made web and the CLI start sending a value that decodes
to a refusal, turning a cosmetic-looking addition into a prompt that denies
what the user approved.

**A warning when an answer cannot be decoded.** Refusing an undecodable answer
is the right default — an option the backend does not understand must not open
a tool — but refusing it silently is not. Both decoders turned "unrecognised"
into "the user declined" and recorded nothing to distinguish the two, so drift
on either side surfaced to the user as an approval that did nothing and to the
operator as an ordinary denial. The warning names the branch, the source, the
request, the raw value and which fallback was taken, then falls closed exactly
as before. No decision changes. An empty value stays quiet: a channel with no
reject option sends an empty string to mean "cancel", which is a normal path
and not a decode failure.

### What is deliberately not changed

- **The plan-approval values are still matched exactly.** `plan_execute`,
  `plan_skip` and `plan_revise` keep their frozenset membership tests, for the
  reason `PLAN_SKIP_OPTION_VALUES` already records: the same `if`/`elif` chain
  is shared by every confirm interrupt, so a generic word admitted there would
  misread an unrelated flow's button. Their branches also keep their existing
  position in the chain.
- **The skill-evolution branch keeps its own map.** Its values are the
  evolution protocol's action names rather than prompt option tokens, so
  folding it into this vocabulary would conflate two value spaces. It gains the
  warning and nothing else, which is what makes its half of the drift visible.
- **Rendered wording.** The four labels and descriptions are unchanged, and
  nothing added here reads configuration. The point of stable tokens is that
  changing that wording later becomes a display-only change instead of a
  protocol change.
- **ACP.** `session/request_permission` carries its own option kinds and
  resolves its outcome without reaching this decoder. Its `reject-once`
  spelling is accepted as a defensive alias and nothing else.

One pre-existing gap closes as a side effect: `Keep planning` was tested for
when the reject branch picks which feedback string to write to the model, but
it was absent from the tuple guarding entry to that branch, so that test could
never fire. It is a rejection either way; only the feedback text differs.

### Relationship to #2539

#2539 localizes the permission prompt and, on its English branch, gives the
options a `value` that is the Chinese display string (`"value": "本次允许"`).
That keeps display text as the protocol token, which is the coupling this
change removes; the two touch the same function but solve different halves.
This branch changes no rendered string and reads no language configuration, so
it does not depend on that PR landing and does not pre-empt its wording
decisions.

#3610, which separates permissions into global, user and session layers, is the
open change to `interrupt_helpers.py` most easily read as overlapping. It is
not: its hunks are in `build_permission_rail`, `_permission_scene_hook`,
`_build_plain_ask_user_question` and `extract_question_from_interaction`, it
leaves `_default_interrupt_options()` alone, and it touches no decoder. Across
every open pull request in this repository, #2539 is the only one that rewrites
`_default_interrupt_options()` and the only one that edits the decode path in
`agent_adapter/interface.py`. The others that touch either file edit different
functions, so whichever lands second rebases without rework.

**Which issue(s) this PR fixes**:

Fixes #4299

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

* **Function** — three new backend test modules, 73 cases, all passing:
  * `test_permission_option_decode.py` — the vocabulary itself and the decoded
    payloads. A parametrised table asserts that every value the previous
    literal tuples accepted still resolves to the same action; further cases
    cover the case-only and separator-only spellings that used to fall through,
    that unrecognised and empty values resolve to "not recognised" rather than
    to a rejection, that normalisation leaves CJK labels untouched, and that
    `plan_execute` / `plan_skip` still take their own branches.
  * `test_permission_option_roundtrip.py` — every option the prompt builder
    emits decodes back to its own action through both its `value` and its
    `label`, and the added `value` does not displace the display text.
  * `test_permission_option_decode_logging.py` — an unrecognised value warns
    once and still refuses, on both the permission and the skill-evolution
    branch; the warning names the branch and the fallback taken; recognised
    values and an empty value stay silent.
* **Reliability / regression** — vacuity check: with the two production files
  reverted and the new tests kept, 11 of the 73 fail, each on an assertion or a
  `KeyError` rather than at import — five on the widened decoding, two on the
  stable `value` tokens, four on the warning. The remaining 62 pass either way
  and are regression guards, not evidence, chiefly the table of
  previously-accepted values.
* **Verification method** — `pytest tests/unit_tests/agentserver tests/system_tests`
  run on the base commit and on this branch back to back on the same host and
  compared by failure **name**, not by count: 173 failing or erroring node ids,
  identical sets, 1927 passing on base and 2000 on the branch — the difference
  is exactly the 73 new cases. That host has an older dependency set than the
  suite expects, so the absolute failure count is host-specific and is not
  claimed as a CI result; what the comparison establishes is that this change
  introduces no new failure.
* **Performance** — no measurable effect. The decode path gains one dict lookup
  and one regex substitution on a short string, per answered prompt.
* **Security** — the fall-closed behaviour is unchanged: an answer that cannot
  be decoded is still refused, and the warning added around that refusal
  changes no decision. Recognition does widen, and the set of newly approved
  values is enumerable: the four canonical tokens, the case and separator
  spellings of values already accepted, and exactly three further aliases —
  `accept`, `接收` and `接受` — each of which the skill-evolution map in the
  same function already decodes as an allow-once. They are carried so the two
  vocabularies stop disagreeing; no option set in the tree emits any of them
  on a permission or confirm prompt today. Nothing generic enters the
  vocabulary: `ok`, `skip` and `确定` are deliberately absent, because the
  `if`/`elif` chain is shared with every other confirm interrupt.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

**Special notes for your reviewers**:

+ - [ ] Whether it causes forward compatibility failure
+ - [ ] Whether the dependent third-party library change is involved

On the **Interface** box: left unchecked because no interface review has taken
place, not because nothing changed. The four fallback options on
`chat.ask_user_question` gain a `value` field. No key is removed and no type
changes; `value` is already an optional part of that option shape, already
emitted by other option sets, and the web option classifier that picks button
styling already carries these four tokens in its own set alongside the labels,
so it classifies the same options the same way. Still, it is a visible change
to what a permission prompt looks like on the wire and deserves a reviewer's
explicit sign-off.

On the **forward compatibility** box: an older client that ignores `value` and
echoes `label` decodes exactly as before, and a client that prefers `value`
sends a token this change teaches the backend to accept. The reverse pairing is
the one that would break — a client sending the new tokens to a backend without
this change — which is why the decoder work and the tokens ship together rather
than separately. The **third-party library** box is unchecked: no dependency
changes here. Both boxes are shown rather than left commented out so that the
answers are visible rather than implied.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4299
<!-- /bot1-related-issues -->
