### PR TITLE
Fix paths in bundled skill instructions

### DIFF
--- a/jiuwenswarm/resources/agent/workspace/skills/advanced-daily-report/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/advanced-daily-report/SKILL.md
@@ -48,7 +48,7 @@ allowed_tools: [read_memory, write_memory, bash, read_file, write_file]
 ## 目录结构
 
 ```
-daily-report/
+advanced-daily-report/
 ├── SKILL.md              # 技能定义（本文件）
 ├── collectors/           # 数据采集模块
 │   ├── __init__.py
@@ -85,19 +85,19 @@ daily-report/
 
 ```bash
 # 生成今日日报（记忆/待办/Git 等；Git 在仓库根目录统计）
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py daily --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py daily --save
 
 # 生成指定日期日报
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py daily --date 2026-03-06 --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py daily --date 2026-03-06 --save
 
 # 生成周报（聚合一周数据）
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py weekly --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py weekly --save
 
 # 生成月报（聚合一月数据，包含每日Git提交统计）
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py monthly --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py monthly --save
 
 # 生成月报（指定月份）
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py monthly --year 2026 --month 3 --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py monthly --year 2026 --month 3 --save
 ```
 
 ### 执行步骤

--- a/jiuwenswarm/resources/agent/workspace/skills/cross-channel-history-retrieval/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/cross-channel-history-retrieval/SKILL.md
@@ -24,7 +24,7 @@ allowed_tools: [mcp_exec_command]
 python ~/.jiuwenswarm/agent/workspace/skills/cross-channel-history-retrieval/scripts/search_history.py --channel feishu --query "报销 审批" --start "2026-03-26 09:00" --end "2026-03-26 18:00" --limit 30
 ```
 
-（Windows：**`--channel` / `--query` / 时间参数等与 Unix 相同**；默认 `mcp_exec_command` 走 **cmd**，**cmd 不会展开 `~`**，不要用 `~/.jiuwenswarm`，应写 `python %USERPROFILE%\.jiuwenswarm\agent\skills\cross-channel-history-retrieval\scripts\search_history.py` 再接同样参数。若整条命令在 PowerShell 里执行，`~` 一般会展开，也可用 `$env:USERPROFILE\...`。）
+（Windows：**`--channel` / `--query` / 时间参数等与 Unix 相同**；默认 `mcp_exec_command` 走 **cmd**，**cmd 不会展开 `~`**，不要用 `~/.jiuwenswarm`，应写 `python %USERPROFILE%\.jiuwenswarm\agent\workspace\skills\cross-channel-history-retrieval\scripts\search_history.py` 再接同样参数。若整条命令在 PowerShell 里执行，`~` 一般会展开，也可用 `$env:USERPROFILE\...`。）
 
 ## 参数说明
 

--- a/jiuwenswarm/resources/agent/workspace/skills/delayed-restart-app/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/delayed-restart-app/SKILL.md
@@ -18,7 +18,7 @@ description: 安排延迟重启本 Agent 所在的服务（JiuwenSwarm app）。
 使用 `bash` 工具执行（必须使用 launcher，否则重启时会连同脚本一起被终止）：
 
 ```bash
-python %USERPROFILE%\.jiuwenswarm\agent\skills\delayed-restart-app\launch_delayed_restart.py --pid <当前 app 的 PID> --delay 5
+python %USERPROFILE%\.jiuwenswarm\agent\workspace\skills\delayed-restart-app\launch_delayed_restart.py --pid <当前 app 的 PID> --delay 5
 ```
 
 （Unix/macOS 使用：`python ~/.jiuwenswarm/agent/workspace/skills/delayed-restart-app/launch_delayed_restart.py --pid <PID> --delay 5`）

--- a/tests/test_builtin_skill_paths.py
+++ b/tests/test_builtin_skill_paths.py
@@ -1,0 +1,44 @@
+"""Static checks for paths embedded in bundled skill instructions."""
+
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+BUILTIN_SKILLS_ROOT = (
+    PROJECT_ROOT / "jiuwenswarm" / "resources" / "agent" / "workspace" / "skills"
+)
+
+LEGACY_SKILLS_ROOT = re.compile(
+    r"(?:~[/\\]|%USERPROFILE%[/\\])\.jiuwenswarm[/\\]agent[/\\]skills[/\\]",
+    re.IGNORECASE,
+)
+CURRENT_SKILL_PATH = re.compile(
+    r"(?:~[/\\]|%USERPROFILE%[/\\])\.jiuwenswarm[/\\]agent[/\\]workspace[/\\]skills[/\\]([^/\\\s`'\"]+)",
+    re.IGNORECASE,
+)
+
+
+def test_builtin_skill_documents_use_current_skill_root():
+    """Bundled skill paths must use the current root and their own directory."""
+    skill_dirs = sorted(path for path in BUILTIN_SKILLS_ROOT.iterdir() if path.is_dir())
+    assert skill_dirs, f"no bundled skills found under {BUILTIN_SKILLS_ROOT}"
+
+    violations = []
+    for skill_dir in skill_dirs:
+        skill_file = skill_dir / "SKILL.md"
+        assert skill_file.is_file(), f"missing SKILL.md: {skill_dir}"
+
+        for line_number, line in enumerate(
+            skill_file.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if LEGACY_SKILLS_ROOT.search(line):
+                violations.append(f"{skill_file}:{line_number}: legacy skills root")
+
+            for match in CURRENT_SKILL_PATH.finditer(line):
+                referenced_name = match.group(1).rstrip(".,;:)]}")
+                if referenced_name not in {skill_dir.name, "<skill-name>", "<name>"}:
+                    violations.append(
+                        f"{skill_file}:{line_number}: references {referenced_name!r}"
+                    )
+
+    assert not violations, "invalid bundled skill paths:\n" + "\n".join(violations)


### PR DESCRIPTION
Paired: [GitHub #4303](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4303) ↔ [GitCode !5676](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5676)

/kind bug

## What does this PR do / why do we need it

The three affected bundled skills document paths that cannot work after installation:

- `advanced-daily-report/SKILL.md` now uses `advanced-daily-report/` in its tree and all report commands.
- The Windows examples in `cross-channel-history-retrieval/SKILL.md` and `delayed-restart-app/SKILL.md` now use `agent\\workspace\\skills`.
- A static regression test scans every bundled `SKILL.md`, rejects the legacy `agent/skills` root, and checks explicit current-root references against their containing skill directory.

## Which issue(s) this PR fixes

Fixes #4302

## What scenarios were tested, and what were the verification results

- `python -m pytest tests/test_builtin_skill_paths.py -q -o addopts=""` — 1 passed.
- `python -m ruff check tests/test_builtin_skill_paths.py` — passed.
- `python -m ruff format --check tests/test_builtin_skill_paths.py` — passed.
- `python -m compileall -q tests/test_builtin_skill_paths.py` — passed.
- A repository-wide search found no remaining legacy `~/.jiuwenswarm/agent/skills/` or `%USERPROFILE%\\.jiuwenswarm\\agent\\skills\\` references in bundled skill documents.

The focused test is run with `addopts` overridden because the checkout's default `pytest.ini` requires the optional `pytest-asyncio` plugin, which is not installed in this local environment.

## Self-checklist

+ - [ ] **Design**: Maintainer review is pending.
+ - [x] **Test**: The regression test is included in this PR.
+ - [x] **Verification**: Focused test, lint, formatting, compilation, and static path scan completed.
+ - [ ] **Interface**: No external API or interface is changed.
+ - [ ] **Document**: No official website documentation is changed; these are shipped skill resources.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4302
<!-- /bot1-related-issues -->
