### PR TITLE
fix(skills): correct the hardcoded skill paths in three builtin skills

### DIFF
--- a/jiuwenswarm/resources/agent/workspace/skills/advanced-daily-report/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/advanced-daily-report/SKILL.md
@@ -48,7 +48,7 @@ allowed_tools: [read_memory, write_memory, bash, read_file, write_file]
 ## 目录结构
 
 ```
-daily-report/
+advanced-daily-report/
 ├── SKILL.md              # 技能定义（本文件）
 ├── collectors/           # 数据采集模块
 │   ├── __init__.py
@@ -85,19 +85,19 @@ daily-report/
 
 ```bash
 # 生成今日日报（记忆/待办/Git 等；Git 在仓库根目录统计）
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py daily --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py daily --save
 
 # 生成指定日期日报
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py daily --date 2026-03-06 --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py daily --date 2026-03-06 --save
 
 # 生成周报（聚合一周数据）
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py weekly --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py weekly --save
 
 # 生成月报（聚合一月数据，包含每日Git提交统计）
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py monthly --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py monthly --save
 
 # 生成月报（指定月份）
-python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py monthly --year 2026 --month 3 --save
+python ~/.jiuwenswarm/agent/workspace/skills/advanced-daily-report/run_report.py monthly --year 2026 --month 3 --save
 ```
 
 ### 执行步骤

--- a/jiuwenswarm/resources/agent/workspace/skills/cross-channel-history-retrieval/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/cross-channel-history-retrieval/SKILL.md
@@ -24,7 +24,7 @@ allowed_tools: [mcp_exec_command]
 python ~/.jiuwenswarm/agent/workspace/skills/cross-channel-history-retrieval/scripts/search_history.py --channel feishu --query "报销 审批" --start "2026-03-26 09:00" --end "2026-03-26 18:00" --limit 30
 ```
 
-（Windows：**`--channel` / `--query` / 时间参数等与 Unix 相同**；默认 `mcp_exec_command` 走 **cmd**，**cmd 不会展开 `~`**，不要用 `~/.jiuwenswarm`，应写 `python %USERPROFILE%\.jiuwenswarm\agent\skills\cross-channel-history-retrieval\scripts\search_history.py` 再接同样参数。若整条命令在 PowerShell 里执行，`~` 一般会展开，也可用 `$env:USERPROFILE\...`。）
+（Windows：**`--channel` / `--query` / 时间参数等与 Unix 相同**；默认 `mcp_exec_command` 走 **cmd**，**cmd 不会展开 `~`**，不要用 `~/.jiuwenswarm`，应写 `python %USERPROFILE%\.jiuwenswarm\agent\workspace\skills\cross-channel-history-retrieval\scripts\search_history.py` 再接同样参数。若整条命令在 PowerShell 里执行，`~` 一般会展开，也可用 `$env:USERPROFILE\...`。）
 
 ## 参数说明
 

--- a/jiuwenswarm/resources/agent/workspace/skills/delayed-restart-app/SKILL.md
+++ b/jiuwenswarm/resources/agent/workspace/skills/delayed-restart-app/SKILL.md
@@ -18,7 +18,7 @@ description: 安排延迟重启本 Agent 所在的服务（JiuwenSwarm app）。
 使用 `bash` 工具执行（必须使用 launcher，否则重启时会连同脚本一起被终止）：
 
 ```bash
-python %USERPROFILE%\.jiuwenswarm\agent\skills\delayed-restart-app\launch_delayed_restart.py --pid <当前 app 的 PID> --delay 5
+python %USERPROFILE%\.jiuwenswarm\agent\workspace\skills\delayed-restart-app\launch_delayed_restart.py --pid <当前 app 的 PID> --delay 5
 ```
 
 （Unix/macOS 使用：`python ~/.jiuwenswarm/agent/workspace/skills/delayed-restart-app/launch_delayed_restart.py --pid <PID> --delay 5`）

--- a/tests/unit_tests/test_builtin_skill_paths.py
+++ b/tests/unit_tests/test_builtin_skill_paths.py
@@ -1,0 +1,71 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""内置技能中写死的技能路径必须指向该技能自己的安装目录。
+
+技能随附的脚本和参考文档以相对路径出现在 ``SKILL.md`` 中，一旦文中写死的
+绝对路径指向别的目录名或过时的 skills 根目录，模型按该路径执行就会失败，
+并且只能退化为在工作目录里盲搜——而 skills 目录通常是会话目录的兄弟目录，
+搜不到。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_BUILTIN_SKILLS_ROOT = (
+    Path(__file__).resolve().parents[2]
+    / "jiuwenswarm"
+    / "resources"
+    / "agent"
+    / "workspace"
+    / "skills"
+)
+
+# 当前 skills 根目录的结尾，直接取自随包发布的目录布局，不在断言里再写死一遍：
+# 布局一旦搬家，随包目录先动，这里跟着动。``agent/skills`` 是迁移前的旧布局。
+_EXPECTED_ROOT_TAIL = "/".join(_BUILTIN_SKILLS_ROOT.parts[-2:])
+
+# 匹配 SKILL.md 中写死的 skills 根目录，Unix 与 Windows 两种写法。
+_SKILLS_ROOT_RE = re.compile(
+    r"[~%][^\s`\"']*?[/\\]\.jiuwenswarm[/\\][^\s`\"']*?skills[/\\]([\w.-]+)"
+)
+
+
+def _builtin_skill_dirs() -> list[Path]:
+    return sorted(
+        path
+        for path in _BUILTIN_SKILLS_ROOT.iterdir()
+        if path.is_dir() and (path / "SKILL.md").is_file()
+    )
+
+
+def test_builtin_skills_root_is_populated():
+    assert _builtin_skill_dirs(), f"no builtin skills under {_BUILTIN_SKILLS_ROOT}"
+
+
+@pytest.mark.parametrize(
+    "skill_dir", _builtin_skill_dirs(), ids=lambda path: path.name
+)
+def test_hardcoded_skill_paths_name_their_own_skill(skill_dir: Path):
+    text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+    referenced = {match.group(1) for match in _SKILLS_ROOT_RE.finditer(text)}
+
+    assert referenced <= {skill_dir.name}, (
+        f"{skill_dir.name}/SKILL.md hardcodes paths under other skill "
+        f"directories: {sorted(referenced - {skill_dir.name})}"
+    )
+
+
+@pytest.mark.parametrize(
+    "skill_dir", _builtin_skill_dirs(), ids=lambda path: path.name
+)
+def test_hardcoded_skill_paths_use_the_current_skills_root(skill_dir: Path):
+    text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+    for match in _SKILLS_ROOT_RE.finditer(text):
+        normalized = match.group(0).replace("\\", "/")
+        assert _EXPECTED_ROOT_TAIL in normalized, (
+            f"{skill_dir.name}/SKILL.md uses a stale skills root: {match.group(0)}"
+        )


### PR DESCRIPTION
Paired: [GitHub #4304](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4304) ↔ [GitCode !5661](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5661)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

The `SKILL.md` of a builtin skill tells the model how to invoke that skill's own
bundled scripts, and does so with a hardcoded absolute path. Three of those paths
no longer point at anything, so the skills they belong to cannot run as documented.

* `advanced-daily-report` writes `daily-report/` in its directory-structure example
  and in all five of its commands, for example
  `python ~/.jiuwenswarm/agent/workspace/skills/daily-report/run_report.py daily --save`.
  That directory name belongs to an older version of the skill. No `daily-report`
  directory ships anywhere in the tree, and `_migrate_legacy_workspace` in
  `jiuwenswarm/common/utils.py` explicitly removes any surviving one while moving
  `agent/skills/` to `agent/workspace/skills/`:

  ```python
  for skill_dir in new_skills.iterdir():
      if skill_dir.is_dir() and (skill_dir.name in builtin_skill_names \
           or skill_dir.name in ["daily-report", "skill-creation"]):
          shutil.rmtree(skill_dir)
  ```

  The five commands therefore name the one directory the migration is written to
  delete. They fail by construction, not by accident. The script they mean,
  `run_report.py`, sits beside `SKILL.md` under `advanced-daily-report/`.

* `cross-channel-history-retrieval` and `delayed-restart-app` write `agent\skills\`
  in their Windows commands. That is the same pre-migration layout; the current root
  is `agent\workspace\skills\`, which the Unix commands in those same two files
  already use. Each file consequently gives a different answer depending on which
  platform section is read, and the Windows one is wrong.

Why this matters beyond a wrong string: a hardcoded path pointing at a directory
that does not exist leaves the model nothing to do but search the working directory
blindly. The skills directory is not under the session directory, so a
recursive search without an explicit path never reaches it. The skill still
triggers and the command still runs, so the only symptom is a file-not-found from
the interpreter, with nothing pointing back at the `SKILL.md` text as the cause.

What the change does:

* `advanced-daily-report/SKILL.md`: `daily-report/` becomes `advanced-daily-report/`
  in the directory-structure example and in all five commands.
* `cross-channel-history-retrieval/SKILL.md` and `delayed-restart-app/SKILL.md`: the
  Windows path root `agent\skills\` becomes `agent\workspace\skills\`, matching the
  Unix commands already present in those files.
* `tests/unit_tests/test_builtin_skill_paths.py` walks every builtin skill and
  checks that a hardcoded skills path in its `SKILL.md` neither points into a
  different skill's directory nor uses the stale skills root. The expected root is
  derived from the shipped resources layout rather than spelled out a second time,
  so a later move of the skills directory fails the guard instead of quietly
  passing it. Reading it from `get_agent_skills_dir()` was the obvious alternative
  and was rejected: that call resolves the real user home and can move a legacy
  directory as a side effect, which a static text assertion has no business doing.

Deliberately out of scope: the stale `agent/skills/daily-report/` paths in the
case-study documents under `docs/en/development-practices/`. Those record a past
project on one machine and are prose, not instructions any model executes.

The change is text plus one new test. No runtime code is modified.

**Which issue(s) this PR fixes**:

Fixes #4302

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

* **The guard is load-bearing.** With only the three `SKILL.md` files reverted to
  their current `develop` content and the new test kept, the test reports exactly
  three failures — one per fault, each on its assertion rather than at setup:
  `test_hardcoded_skill_paths_name_their_own_skill[advanced-daily-report]`,
  `test_hardcoded_skill_paths_use_the_current_skills_root[cross-channel-history-retrieval]`,
  and `test_hardcoded_skill_paths_use_the_current_skills_root[delayed-restart-app]`.
  With the corrections applied the same file reports 53 passed, 0 failed. A guard
  that would pass either way would be worth nothing, so this was checked rather
  than assumed.
* **Nothing else moved.** `tests/unit_tests` was run on `develop` and on this branch
  back to back on the same machine, and the two runs were compared by failing test
  name rather than by count. The sets are identical; this branch introduces no new
  failure and fixes none outside its own file. That suite has pre-existing
  collection errors in the environment used, present identically in both runs.
* **Path resolution after the fix.** Every corrected path now names a directory that
  exists in the shipped tree: `advanced-daily-report/run_report.py`,
  `cross-channel-history-retrieval/scripts/search_history.py`, and
  `delayed-restart-app/launch_delayed_restart.py` are all present beside their
  `SKILL.md`.
* No CI result is claimed here; the above is what was run locally.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised — text-only correction of three shipped paths, there is no design decision to review, and the correct value of each path is determined by the tree itself.
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded — `tests/unit_tests/test_builtin_skill_paths.py` is included and covers every builtin skill, not only the three corrected here.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR — see the section above.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed — no external interface is touched.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner — no website documentation is affected; the corrected files are skill resources shipped from this repository.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4302
<!-- /bot1-related-issues -->
