### PR TITLE
Fix: Cron job can create other cron jobs

### DIFF
--- a/jiuwenswarm/gateway/__init__.py
+++ b/jiuwenswarm/gateway/__init__.py
@@ -4,6 +4,7 @@
 
 from jiuwenswarm.gateway.routing.agent_client import AgentServerClient, WebSocketAgentServerClient
 from jiuwenswarm.gateway.channel_manager import ChannelManager
+from jiuwenswarm.gateway.cron.scheduler import CRON_CHANNEL_ID
 from jiuwenswarm.gateway.health_check import (
     HEALTH_CHECK_CHANNEL_ID,
     GatewayHealthCheckService,
@@ -16,6 +17,7 @@ __all__ = [
     "AgentServerClient",
     "WebSocketAgentServerClient",
     "ChannelManager",
+    "CRON_CHANNEL_ID",
     # 旧探活由 gateway.health_check 提供。
     "GatewayHealthCheckService",
     "HEALTH_CHECK_CHANNEL_ID",

--- a/jiuwenswarm/gateway/cron/scheduler.py
+++ b/jiuwenswarm/gateway/cron/scheduler.py
@@ -31,6 +31,8 @@ from jiuwenswarm.common.work_mode import DEFAULT_WEB_WORK_MODE
 
 logger = logging.getLogger(__name__)
 
+CRON_CHANNEL_ID = "__cron__"
+
 
 def _now_utc_ts() -> float:
     return time.time()
@@ -353,7 +355,7 @@ class CronSchedulerService:
         try:
             interrupt_env = e2a_from_agent_fields(
                 request_id=f"cron-cancel-{state.run_id}",
-                channel_id="__cron__",
+                channel_id=CRON_CHANNEL_ID,
                 session_id=target_session_id,
                 req_method=ReqMethod.CHAT_CANCEL,
                 params={"cron": {"job_id": state.job_id, "run_id": state.run_id}},
@@ -608,7 +610,7 @@ class CronSchedulerService:
                 ts=ts,
                 message_handler=self._message_handler,
             )
-        return "__cron__", f"cron_{ts}_{job.id}"
+        return CRON_CHANNEL_ID, f"cron_{ts}_{job.id}"
 
     async def _allocate_single_agent_session(
         self,
@@ -620,7 +622,7 @@ class CronSchedulerService:
         cron_user_id = str(job.user_id or "").strip()
         env = e2a_from_agent_fields(
             request_id=f"cron-session-create-{run_id}",
-            channel_id="__cron__",
+            channel_id=CRON_CHANNEL_ID,
             req_method=ReqMethod.SESSION_CREATE,
             params={
                 "create_token": f"cron:{run_id}",
@@ -780,7 +782,7 @@ class CronSchedulerService:
                 # Send proactive.tick request to AgentServer via WebSocket
                 envelope = e2a_from_agent_fields(
                     request_id=f"proactive-tick-{ev.run_id}",
-                    channel_id="__cron__",
+                    channel_id=CRON_CHANNEL_ID,
                     session_id=f"cron_{job.id}",
                     req_method=ReqMethod.PROACTIVE_TICK,
                     params={"target_channel": job.targets or None},
@@ -1014,7 +1016,7 @@ class CronSchedulerService:
                         mode=mode,
                         run_id=run_id,
                     )
-                    state.exec_channel_id = "__cron__"
+                    state.exec_channel_id = CRON_CHANNEL_ID
                     state.exec_session_id = exec_session_id
                 cron_meta = {
                     "job_id": job.id,
@@ -1150,7 +1152,7 @@ class CronSchedulerService:
         """Persist cron failure history in the routed user's AgentServer directory."""
         envelope = e2a_from_agent_fields(
             request_id=f"cron-history-{request_id or int(self._now_fn() * 1000)}",
-            channel_id="__cron__",
+            channel_id=CRON_CHANNEL_ID,
             session_id=session_id,
             req_method=ReqMethod.HISTORY_APPEND_RECORD,
             params={

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -386,6 +386,7 @@ from jiuwenswarm.server.runtime.agent_adapter.sysop_builder import (
 from jiuwenswarm.server.runtime.agent_adapter.user_turn import TEAM_USER_TURN_KEY, UserTurn
 from jiuwenswarm.agents.harness.common.auto_harness.service import _HARNESS_PACKAGES_FILE
 from jiuwenswarm.agents.harness.common.plugins.rail_manager import get_rail_manager
+from jiuwenswarm.gateway import CRON_CHANNEL_ID, HEALTH_CHECK_CHANNEL_ID
 from jiuwenswarm.gateway.cron import CronTargetChannel
 from jiuwenswarm.common.schema.agent import AgentRequest, AgentResponse, AgentResponseChunk
 from jiuwenswarm.common.schema.message import ReqMethod
@@ -8745,7 +8746,7 @@ class JiuWenSwarmDeepAdapter:
                 sessions drive the scheduler themselves and get no cron tools.
         """
         if session_id is not None and session_id.startswith(
-            ("heartbeat", "health_check", "cron")
+            ("heartbeat", HEALTH_CHECK_CHANNEL_ID, CRON_CHANNEL_ID)
         ):
             return
         language = self._resolve_runtime_language()

--- a/tests/unit_tests/agentserver/test_deep_adapter_cron_tool_registration.py
+++ b/tests/unit_tests/agentserver/test_deep_adapter_cron_tool_registration.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import pytest
 
 from jiuwenswarm.server.runtime.agent_adapter.interface_deep import JiuWenSwarmDeepAdapter
-
+from jiuwenswarm.gateway import CRON_CHANNEL_ID, HEALTH_CHECK_CHANNEL_ID
 
 class _FakeCard:
     def __init__(self, name: str) -> None:
@@ -112,7 +112,7 @@ def test_agent_rebuild_reregisters_cron_tools() -> None:
     }
 
 
-@pytest.mark.parametrize("session_id", ["heartbeat_1", "cron_job_7"])
+@pytest.mark.parametrize("session_id", ["heartbeat_1", f"{CRON_CHANNEL_ID}_7", f"{HEALTH_CHECK_CHANNEL_ID}_4"])
 def test_scheduler_driven_sessions_get_no_cron_tools(session_id: str) -> None:
     """Heartbeat and cron sessions drive the scheduler; they must not carry the tools."""
     adapter, counters = _make_adapter()


### PR DESCRIPTION
Paired: [GitHub #4419](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4419) ↔ [GitCode !5729](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5729)

Fix a bug in which tool registration did not detect if it the task was a cronjob or a heartbeat/health-check

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind bug


**What does this PR do / why do we need it**:
Scheduled tasks are not supposed to be able to create other scheduled tasks. This check did not work anymore due to a renaming of the cron job's `session_id` from `cron_id` to `__cron__id` and check relies on prefix matching.

Now, it relies on both a `CRON_CHANNEL_ID` and `HEALTH_CHECK_CHANNEL_ID` variables to be more robust to future changes. Notice that the "heartbeat" value has not been changed since this is a check for backwards compatibility (it has been replaced by `health-check` on newer versions of the app).

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4415 


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
The user side check is to simply create a scheduled task with the prompt "Create a blank task to run everyday at 9AM". Before, if this was run, a new task would be created. After this modification, this is not the case anymore.

In the unit tests side, I am now using the channel names variables to prevent the problem that occurred in the past: the session id was changed but the tests tested against the old session id, so the regression was not caught.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4415
<!-- /bot1-related-issues -->
