### PR TITLE
Apply the user location as default timezone in the web UI

### DIFF
--- a/jiuwenswarm/channels/web/frontend/src/components/CronPanel/CronTaskDrawer.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/CronPanel/CronTaskDrawer.tsx
@@ -70,7 +70,7 @@ function emptyForm(): CronTaskFormValue {
     targets: 'web',
     cronExpr: '',
     wakeOffsetSeconds: 0,
-    timezone: 'Asia/Shanghai',
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     effectiveDate: null,
     enabled: true,
   };
@@ -106,7 +106,7 @@ export function templateToForm(tpl: CronTemplateUI, title: string, description: 
     targets: 'web',
     cronExpr: tpl.cronExpr,
     wakeOffsetSeconds: 0,
-    timezone: 'Asia/Shanghai',
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     effectiveDate: null,
     enabled: true,
   };
@@ -147,6 +147,7 @@ export default function CronTaskDrawer({ mode, initial, projects, targetOptions,
   };
 
   const submittedForm = form;
+  const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   const title = mode === 'edit' ? t('cron.drawer.titleEdit') : mode === 'template' ? t('cron.drawer.titleTemplate') : t('cron.drawer.titleCreate');
   // 显式加一条 value 为空串的"-"选项，代表"未选项目"，放在真实项目列表最后面（列表顺序：
@@ -158,7 +159,9 @@ export default function CronTaskDrawer({ mode, initial, projects, targetOptions,
     ...filterNonDefaultProjects(projects).map((p) => ({ value: p.project_dir, label: getProjectDisplayName(p) })),
     { value: '', label: t('cron.drawer.placeholderProject') ?? '-' },
   ];
-  const timezoneOptions = TIMEZONE_OPTIONS.map((tz) => ({ value: tz, label: tz }));
+  const timezoneOptions = TIMEZONE_OPTIONS.includes(localTimeZone)
+    ? TIMEZONE_OPTIONS.map((tz) => ({ value: tz, label: tz }))
+    : [{ value: localTimeZone, label: localTimeZone }].concat(TIMEZONE_OPTIONS.map((tz) => ({ value: tz, label: tz })));
   // 必填项缺失时，收集清单用来在"确定"按钮旁给出具体提示（而不是只让按钮变灰、不说原因）
   const missingFieldLabels: string[] = [];
   if (!form.name.trim()) missingFieldLabels.push(t('cron.drawer.fieldName'));


### PR DESCRIPTION
Paired: [GitHub #4552](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4552) ↔ [GitCode !5814](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5814)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind bug


**What does this PR do / why do we need it**:
In the web UI, when creating a new scheduled task, the default time zone is always set to Asia/Shanghai and can only be set to a small, pre-defined list of options. If the user is not in one of those time zones, setting it to their local time zone is impossible

Now, the local time zone is always added as the first element in the list and is set as the default

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4415 


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
Now, the cron job creating UI looks like this when the user's system is set to Brazilian time: 

<img width="545" height="935" alt="image" src="https://github.com/user-attachments/assets/9373234a-7a50-4938-b9a0-54c5543a5b20" />

Before, this not only was not the default value, but it was also impossible to set it from the UI.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4415
<!-- /bot1-related-issues -->
