### PR TITLE
fix(gateway): 小艺入站按 conv_id 复用本机 desktop 会话

### DIFF
--- a/jiuwenswarm/gateway/message_handler/external_conv_session.py
+++ b/jiuwenswarm/gateway/message_handler/external_conv_session.py
@@ -1,0 +1,123 @@
+"""Map cloud/report conv_id back onto an existing AgentServer session.
+
+Desktop ReportConversations uses ``toLocalConvId(session_id)`` (see claw_desktop
+``conversation-report.ts``). Phone A2A continues with that ``conv_*`` as
+``conversationId`` / inbound ``session_id``. Without reverse lookup, MessageHandler
+always ``session.create``s a fresh ``xiaoyi_*`` session and loses PC history.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_ALNUM = re.compile(r"[^a-zA-Z0-9]")
+
+
+def to_local_conv_id(session_id: str) -> str:
+    """Mirror claw_desktop ``toLocalConvId``: stable ``conv_`` + first 24 alnum chars."""
+    raw = str(session_id or "").strip()
+    if not raw:
+        return ""
+    if raw.startswith("conv_"):
+        return raw
+    compact = _ALNUM.sub("", raw)[:24]
+    return f"conv_{compact}" if compact else ""
+
+
+def _read_session_metadata_raw(session_dir: Path) -> dict[str, Any]:
+    meta_path = session_dir / "metadata.json"
+    if not meta_path.is_file():
+        return {}
+    try:
+        raw = json.loads(meta_path.read_text(encoding="utf-8") or "{}")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("skip session meta %s: %s", session_dir.name, exc)
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _channel_meta_matches(meta: dict[str, Any], external_id: str) -> bool:
+    channel_meta = meta.get("channel_metadata")
+    if not isinstance(channel_meta, dict):
+        return False
+    for key in (
+        "xiaoyi_conversation_id",
+        "xiaoyi_session_id",
+        "conversation_id",
+        "external_session_id",
+    ):
+        if str(channel_meta.get(key) or "").strip() == external_id:
+            return True
+    return False
+
+
+def _session_priority(session_id: str) -> int:
+    """Prefer desktop-originated sessions when multiple map to the same conv_id."""
+    sid = str(session_id or "")
+    if sid.startswith("desktop_"):
+        return 0
+    if sid.startswith("xiaoyi_"):
+        return 2
+    return 1
+
+
+def find_local_session_for_external_conv_id(
+    external_id: str,
+    *,
+    sessions_dir: Path | None = None,
+) -> str | None:
+    """Return an existing local session_id for cloud ``conv_*``, or None.
+
+    Match rules (any one):
+    1. ``to_local_conv_id(session_id) == external_id``
+    2. ``channel_metadata`` stores the same conversation / external id
+
+    When several match, prefer ``desktop_*``, then newest ``last_message_at``.
+    """
+    key = str(external_id or "").strip()
+    if not key.startswith("conv_"):
+        return None
+
+    if sessions_dir is None:
+        from jiuwenswarm.common.utils import get_agent_sessions_dir
+
+        sessions_dir = get_agent_sessions_dir()
+    if not sessions_dir.is_dir():
+        return None
+
+    candidates: list[tuple[int, float, str]] = []
+    for session_dir in sessions_dir.iterdir():
+        if not session_dir.is_dir():
+            continue
+        sid = session_dir.name.strip()
+        if not sid or sid == "default":
+            continue
+
+        matched = to_local_conv_id(sid) == key
+        meta: dict[str, Any] = {}
+        if not matched:
+            meta = _read_session_metadata_raw(session_dir)
+            if not meta:
+                continue
+            matched = _channel_meta_matches(meta, key)
+        if not matched:
+            continue
+
+        if not meta:
+            meta = _read_session_metadata_raw(session_dir)
+        try:
+            last_at = float(meta.get("last_message_at") or meta.get("created_at") or 0.0)
+        except (TypeError, ValueError):
+            last_at = 0.0
+        candidates.append((_session_priority(sid), -last_at, sid))
+
+    if not candidates:
+        return None
+    candidates.sort()
+    return candidates[0][2]

--- a/jiuwenswarm/gateway/message_handler/message_handler.py
+++ b/jiuwenswarm/gateway/message_handler/message_handler.py
@@ -712,11 +712,17 @@ class MessageHandler(ABC):
 
     async def _resolve_external_channel_session(self, msg: "Message") -> None:
         """Map A2A/SSH protocol IDs onto AgentServer-owned product Sessions."""
+        from jiuwenswarm.gateway.message_handler.external_conv_session import (
+            find_local_session_for_external_conv_id,
+        )
+
         channel_id = str(msg.channel_id or "").strip()
         external_id = str(msg.session_id or "").strip()
         # xiaoyi 的入站 msg.session_id 是稳定的 conversation_id（跨多轮不变），
         # 但并非 AgentServer 认识的 session id；这里按 (channel, conversation_id)
         # 分配并缓存 AgentServer session，让同一对话复用同一 session、历史不丢。
+        # 若 conversation_id 已是桌面 ReportConversations 的 conv_*（toLocalConvId），
+        # 优先挂回已有 desktop_*（或曾绑定该 conv 的会话），避免新建空 xiaoyi_* 丢上下文。
         if channel_id not in {"a2a", "ssh", "xiaoyi"} or not external_id:
             return
         key = (channel_id, external_id)
@@ -725,30 +731,43 @@ class MessageHandler(ABC):
             async with self._external_session_alias_lock:
                 resolved = self._external_session_aliases.get(key)
                 if resolved is None:
-                    logger.info(
-                        "[MessageHandler] 分配通道会话(session.create): channel=%s external=%s",
-                        channel_id,
-                        external_id,
-                    )
-                    raw_mode = str((msg.params or {}).get("mode") or "agent")
-                    try:
-                        mode = ChannelMode(raw_mode)
-                    except ValueError:
-                        mode = ChannelMode.AGENT
-                    resolved = await self._allocate_channel_session(
-                        msg, ChannelControlState(mode=mode)
-                    )
-                    self._external_session_aliases[key] = resolved
-                    logger.info(
-                        "[MessageHandler] 通道会话分配完成: channel=%s external=%s -> %s",
-                        channel_id,
-                        external_id,
-                        resolved,
-                    )
+                    reused = find_local_session_for_external_conv_id(external_id)
+                    if reused:
+                        resolved = reused
+                        self._external_session_aliases[key] = resolved
+                        logger.info(
+                            "[MessageHandler] 复用本机会话(conv 反查): channel=%s external=%s -> %s",
+                            channel_id,
+                            external_id,
+                            resolved,
+                        )
+                    else:
+                        logger.info(
+                            "[MessageHandler] 分配通道会话(session.create): channel=%s external=%s",
+                            channel_id,
+                            external_id,
+                        )
+                        raw_mode = str((msg.params or {}).get("mode") or "agent")
+                        try:
+                            mode = ChannelMode(raw_mode)
+                        except ValueError:
+                            mode = ChannelMode.AGENT
+                        resolved = await self._allocate_channel_session(
+                            msg, ChannelControlState(mode=mode)
+                        )
+                        self._external_session_aliases[key] = resolved
+                        logger.info(
+                            "[MessageHandler] 通道会话分配完成: channel=%s external=%s -> %s",
+                            channel_id,
+                            external_id,
+                            resolved,
+                        )
         metadata = dict(msg.metadata or {})
         metadata.setdefault("external_session_id", external_id)
         msg.metadata = metadata
         msg.session_id = resolved
+        if isinstance(msg.params, dict) and "session_id" in msg.params:
+            msg.params["session_id"] = resolved
 
     @staticmethod
     def _extract_identity_tuple(msg: "Message") -> tuple[str, str, str, str] | None:
@@ -2190,12 +2209,13 @@ class MessageHandler(ABC):
                 msg.session_id = sid
             else:
                 msg.session_id = None
-        elif state.session_id:
-            msg.session_id = state.session_id
         elif isinstance(msg.metadata, dict) and msg.metadata.get("external_session_id"):
             # 已由 _resolve_external_channel_session 映射到 AgentServer session
-            # （如 a2a/ssh/xiaoyi），不要覆盖，否则会把已分配的 session_id 清成 None。
+            # （如 a2a/ssh/xiaoyi，含 conv_* 反查复用 desktop_*），不要被
+            # channel default_session_id 覆盖，否则跨端续聊会丢上下文。
             pass
+        elif state.session_id:
+            msg.session_id = state.session_id
         else:
             msg.session_id = None
 

--- a/tests/unit_tests/gateway/test_external_conv_session.py
+++ b/tests/unit_tests/gateway/test_external_conv_session.py
@@ -1,0 +1,83 @@
+"""Tests for cloud conv_id → local session reverse lookup."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jiuwenswarm.gateway.message_handler.external_conv_session import (
+    find_local_session_for_external_conv_id,
+    to_local_conv_id,
+)
+
+
+def test_to_local_conv_id_matches_desktop_report_shape() -> None:
+    sid = "desktop_1a061727c1f_65690918081e"
+    assert to_local_conv_id(sid) == "conv_desktop1a061727c1f656909"
+    assert to_local_conv_id("conv_already") == "conv_already"
+    assert to_local_conv_id("") == ""
+
+
+def test_find_prefers_desktop_over_xiaoyi_for_same_conv(tmp_path: Path) -> None:
+    desktop = "desktop_1a061727c1f_65690918081e"
+    conv = to_local_conv_id(desktop)
+    assert conv == "conv_desktop1a061727c1f656909"
+
+    desk_dir = tmp_path / desktop
+    desk_dir.mkdir()
+    (desk_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "session_id": desktop,
+                "title": "今天天气真好",
+                "last_message_at": 100.0,
+                "channel_id": "desktop",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    xiaoyi = "xiaoyi_1a061734c32_b7a0cc1f59ad"
+    x_dir = tmp_path / xiaoyi
+    x_dir.mkdir()
+    (x_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "session_id": xiaoyi,
+                "title": "你真的在办公室吗",
+                "last_message_at": 200.0,
+                "channel_id": "xiaoyi",
+                "channel_metadata": {
+                    "xiaoyi_conversation_id": conv,
+                    "xiaoyi_session_id": conv,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    found = find_local_session_for_external_conv_id(conv, sessions_dir=tmp_path)
+    assert found == desktop
+
+
+def test_find_by_channel_metadata_when_prefix_mismatch(tmp_path: Path) -> None:
+    sid = "xiaoyi_abc123"
+    conv = "conv_desktop1a0615d0634e1a588"
+    s_dir = tmp_path / sid
+    s_dir.mkdir()
+    (s_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "last_message_at": 10.0,
+                "channel_metadata": {"xiaoyi_conversation_id": conv},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert find_local_session_for_external_conv_id(conv, sessions_dir=tmp_path) == sid
+
+
+def test_find_returns_none_for_non_conv_or_missing(tmp_path: Path) -> None:
+    assert find_local_session_for_external_conv_id("1788330011489", sessions_dir=tmp_path) is None
+    assert find_local_session_for_external_conv_id("conv_nosuch", sessions_dir=tmp_path) is None

--- a/tests/unit_tests/gateway/test_resolve_external_conv_reuse.py
+++ b/tests/unit_tests/gateway/test_resolve_external_conv_reuse.py
@@ -1,0 +1,77 @@
+"""MessageHandler should reuse desktop session for phone conv_* continue."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from collections.abc import AsyncIterator
+
+import pytest
+
+from jiuwenswarm.common.schema import Message
+from jiuwenswarm.gateway.message_handler.external_conv_session import to_local_conv_id
+from jiuwenswarm.gateway.message_handler.message_handler import MessageHandler
+
+
+class _FakeAgentClient:
+    sent_requests: list[object] = []
+
+    @staticmethod
+    async def send_request(env: object) -> SimpleNamespace:
+        _FakeAgentClient.sent_requests.append(env)
+        raise AssertionError("session.create must not run when conv maps to desktop")
+
+    @staticmethod
+    async def send_request_stream(env: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover
+            yield env
+        return
+
+
+class _TestMessageHandler(MessageHandler):
+    @classmethod
+    def create(cls) -> "_TestMessageHandler":
+        setattr(MessageHandler, "_instance", None)
+        setattr(cls, "_instance", None)
+        _FakeAgentClient.sent_requests = []
+        return cls(_FakeAgentClient())
+
+
+@pytest.mark.asyncio
+async def test_resolve_external_reuses_desktop_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    desktop = "desktop_1a061727c1f_65690918081e"
+    conv = to_local_conv_id(desktop)
+    desk_dir = tmp_path / desktop
+    desk_dir.mkdir()
+    (desk_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "session_id": desktop,
+                "title": "今天天气真好",
+                "last_message_at": 100.0,
+                "channel_id": "desktop",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "jiuwenswarm.common.utils.get_agent_sessions_dir",
+        lambda: tmp_path,
+    )
+
+    handler = _TestMessageHandler.create()
+    msg = Message(
+        id="req-1",
+        type="req",
+        channel_id="xiaoyi",
+        session_id=conv,
+        params={"query": "你真的在办公室吗"},
+        timestamp=1.0,
+        ok=True,
+        metadata={"xiaoyi_session_id": conv},
+    )
+    await handler._resolve_external_channel_session(msg)
+    assert msg.session_id == desktop
+    assert msg.metadata["external_session_id"] == conv
+    assert _FakeAgentClient.sent_requests == []


### PR DESCRIPTION
## 问题
PC 发起话题并 ReportConversations（`conv_desktop…`）后，手机用同一 `conversationId` 续聊时，MessageHandler 仍 `session.create` 新 `xiaoyi_*`，导致无上下文、话题栏分裂。

## 改动
- 入站 `conv_*` 时反查本机会话（`toLocalConvId` 对齐桌面，或 channel_metadata 已绑定）
- 优先复用 `desktop_*`，不再一律新建
- `external_session_id` 映射不被 channel 默认 session 覆盖
- 补充单测

## 测试
`pytest tests/unit_tests/gateway/test_external_conv_session.py tests/unit_tests/gateway/test_resolve_external_conv_reuse.py`