### PR TITLE
fix(tests): 修复单测套件在非默认环境下的可移植性问题

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -41,3 +41,4 @@ filterwarnings =
     ignore::PendingDeprecationWarning
     ignore::ResourceWarning
     ignore::pytest.PytestUnraisableExceptionWarning
+    ignore:invalid escape sequence:SyntaxWarning

--- a/tests/unit_tests/agentserver/test_skill_manager_team_skills_hub.py
+++ b/tests/unit_tests/agentserver/test_skill_manager_team_skills_hub.py
@@ -10,6 +10,10 @@ import pytest
 
 from jiuwenswarm.server.runtime.skill.skill_manager import SkillManager, SkillRpcError
 
+# import_local 的源在 pytest 临时目录下；macOS 上该目录位于 /private/var，
+# 需绕过内置 /var 黑名单（与 test_skill_manager_path_safety.py 一致）。
+pytestmark = pytest.mark.usefixtures("allow_macos_pytest_temp_sources")
+
 _TEAM_SKILLS_HUB_ZIP_URL = "https://openjiuwen-market.obs.ap-southeast-1.myhuaweicloud.com/plugins/demo.zip"
 
 

--- a/tests/unit_tests/agentserver/test_skills_import_local_token.py
+++ b/tests/unit_tests/agentserver/test_skills_import_local_token.py
@@ -30,6 +30,10 @@ from jiuwenswarm.server.runtime.skill.skill_manager import (
     SkillRpcError,
 )
 
+# import_local 的源在 pytest 临时目录下；macOS 上该目录位于 /private/var，
+# 需绕过内置 /var 黑名单（与 test_skill_manager_path_safety.py 一致）。
+pytestmark = pytest.mark.usefixtures("allow_macos_pytest_temp_sources")
+
 
 def _skill_md(name: str, description: str = "demo skill") -> str:
     return f"---\nname: {name}\ndescription: {description}\n---\n# Body\n"

--- a/tests/unit_tests/gateway/test_message_handler_security_review_prompt.py
+++ b/tests/unit_tests/gateway/test_message_handler_security_review_prompt.py
@@ -79,8 +79,13 @@ def _add_origin_head(path: str, bare: str) -> None:
     subprocess.run([_GIT, "-C", path, "push", "-q", "origin", "HEAD"], check=True)
     # 先 fetch 建立 refs/remotes/origin/* ，再用显式分支名 set-head
     # （`set-head origin HEAD` 在某些 git 版本会静默不写 symref）。
+    # 分支名取仓库实际默认分支：宿主机 init.defaultBranch 可能为 main，
+    # 硬编码 master 会让 set-head 失败。
+    branch = subprocess.check_output(
+        [_GIT, "-C", path, "symbolic-ref", "--short", "HEAD"], text=True
+    ).strip()
     subprocess.run([_GIT, "-C", path, "fetch", "-q", "origin"], check=True)
-    subprocess.run([_GIT, "-C", path, "remote", "set-head", "origin", "master"], check=True)
+    subprocess.run([_GIT, "-C", path, "remote", "set-head", "origin", branch], check=True)
 
 
 def test_run_security_review_git_succeeds_when_origin_head_set(tmp_path):

--- a/tests/unit_tests/process_cli/test_repl.py
+++ b/tests/unit_tests/process_cli/test_repl.py
@@ -60,7 +60,8 @@ def test_invalid_choice_error_is_fully_chinese(capsys) -> None:
 
     error = capsys.readouterr().err
     assert "参数 --work-mode 的值无效" in error
-    assert "可选值：'code', 'work'" in error
+    # Python 3.13 起 argparse 的 choices 列表不再逐项加引号，两种格式都要接受
+    assert "可选值：'code', 'work'" in error or "可选值：code, work" in error
     assert "invalid choice" not in error
 
 


### PR DESCRIPTION
Paired: [GitHub #4689](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4689) ↔ [GitCode !5897](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5897)

## What changed & why

单测套件目前只在 "Linux + git 默认分支为 master + Python 3.11" 的组合下全绿。本 PR 修复三类环境下的可移植性问题，使外部贡献者按 docs/en/Contributing.md 的流程（`uv sync && uv run pytest tests/unit_tests/`）在更常见的环境也能跑通测试：

1. **git 默认分支为 main 的机器（3 个用例必挂）**
   `tests/unit_tests/gateway/test_message_handler_security_review_prompt.py` 的 `_add_origin_head` 硬编码 `git remote set-head origin master`，而 `_make_repo` 用 `git init` 未固定分支名。宿主机配置 `init.defaultBranch=main`（GitHub 官方推荐配置）时 set-head 以 exit 1 失败。现改为 `symbolic-ref --short HEAD` 动态取实际分支名。

2. **macOS 开发机（2 个用例必挂）**
   macOS 的 pytest 临时目录位于 `/private/var/folders/...`，命中 `import_local` 内置黑名单中的 `/var`，导致
   - `test_skills_import_local_token.py::test_import_local_overwrite_preserves_archive`
   - `test_skill_manager_team_skills_hub.py::test_handle_skills_team_skills_hub_pack_excludes_archive`

   两个文件补挂仓库既有的 `allow_macos_pytest_temp_sources` fixture（与 `test_skill_manager_path_safety.py`、`test_skill_toolkits.py` 做法一致）。

3. **Python 3.12/3.13（171 个测试文件无法收集）**
   pyproject 声明 `requires-python = ">=3.11,<3.14"`，但三方库 pysbd 的历史遗留转义序列在 3.12+ 触发 `SyntaxWarning: invalid escape sequence`，被 pytest.ini 的 `filterwarnings = error` 升级后，`uv sync && uv run pytest` 在 3.12/3.13 上直接报 171 个收集错误。pytest.ini 增加 `ignore:invalid escape sequence:SyntaxWarning`（按消息过滤，不放宽其他 SyntaxWarning）。

   另外 Python 3.13 起 argparse 的 choices 列表不再逐项加引号（`'code', 'work'` → `code, work`），`test_invalid_choice_error_is_fully_chinese` 的断言兼容两种格式。

## How to test

```bash
uv venv --python 3.11 && uv sync --group test
uv run pytest tests/unit_tests/agentserver/test_skills_import_local_token.py \
  tests/unit_tests/agentserver/test_skill_manager_team_skills_hub.py \
  tests/unit_tests/gateway/test_message_handler_security_review_prompt.py \
  tests/unit_tests/process_cli/test_repl.py
```

- 修复前（macOS + Apple Silicon + git 默认分支 main）：上述文件 5 个用例失败；Python 3.13 下全量收集报 171 errors
- 修复后：Python 3.11.7 / 3.13.x 上述文件 70 passed, 1 skipped；3.13 全量 6650 passed（剩余 5 个失败与本次改动无关，为需要前端构建产物/webview 等的用例）

不改变任何产品代码行为，仅测试与 pytest 配置。
