### PR TITLE
fix(web): handle macOS IME confirmation Enter

### DIFF
--- a/jiuwenswarm/channels/web/frontend/package.json
+++ b/jiuwenswarm/channels/web/frontend/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "test:frontend-platform": "tsc src/utils/frontendPlatform.ts --target ES2020 --module ES2020 --moduleResolution Bundler --rootDir src --outDir node_modules/.cache/frontend-platform --skipLibCheck --noEmitOnError && node --test tests/frontendPlatform.test.mjs",
+    "test:ime-composition": "tsc src/components/ChatPanel/imeComposition.ts --target ES2020 --module ES2020 --moduleResolution Bundler --rootDir src --outDir node_modules/.cache/ime-composition --skipLibCheck --noEmitOnError && node --test tests/imeComposition.test.mjs",
     "test:code-turn-diff-binding": "tsc src/features/code-mode/codeTurnDiffBinding.ts --target ES2020 --module ES2020 --moduleResolution Bundler --rootDir src --outDir node_modules/.cache/code-turn-diff-binding --skipLibCheck --noEmitOnError && node --test tests/codeTurnDiffBinding.test.mjs",
     "test:turn-change-state": "tsc src/features/code-mode/turnChangeState.ts --target ES2020 --module ES2020 --moduleResolution Bundler --rootDir src --outDir node_modules/.cache/turn-change-state --skipLibCheck --noEmitOnError && node --test tests/turnChangeState.test.mjs",
     "test:git-publish-state": "tsc src/features/code-mode/gitPublishState.ts --target ES2020 --module ES2020 --moduleResolution Bundler --rootDir src --outDir node_modules/.cache/git-publish-state --skipLibCheck --noEmitOnError && node --test tests/gitPublishState.test.mjs",

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/InputArea.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/InputArea.tsx
@@ -98,6 +98,7 @@ import { CodeBranchSelector } from '../../features/code-mode/CodeBranchSelector'
 import { generateUuidV4 } from '../../utils/uuid';
 import { createAgentManagementClient, getAgentAvatarUrl, type AgentCatalogItem } from '../../features/agentManagement';
 import { ContextUsageIndicator } from './ContextUsageIndicator';
+import { isImeCompositionKey } from './imeComposition';
 
 /** 输入栏下拉所需的最小技能数据结构（与 SkillPanel 中的 SkillItem 保持一致） */
 type InputAreaSkillItem = {
@@ -2106,7 +2107,7 @@ export const InputArea = forwardRef<InputAreaHandle, InputAreaProps>(function In
         }
 
         if ((e.key === 'Enter' || e.key === 'Tab') && !e.shiftKey) {
-          if (isComposingRef.current || e.nativeEvent.isComposing) return;
+          if (isImeCompositionKey(e.nativeEvent, isComposingRef.current)) return;
           e.preventDefault();
           const item = composerSuggestionItems[composerSuggestionIndex];
           if (item) {
@@ -2123,7 +2124,7 @@ export const InputArea = forwardRef<InputAreaHandle, InputAreaProps>(function In
       }
 
       if (e.key !== 'Enter' || e.shiftKey) return;
-      if (isComposingRef.current || e.nativeEvent.isComposing) return;
+      if (isImeCompositionKey(e.nativeEvent, isComposingRef.current)) return;
       e.preventDefault();
       handleSubmit();
     },

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/imeComposition.ts
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/imeComposition.ts
@@ -1,0 +1,13 @@
+export type ImeKeyboardEvent = Pick<KeyboardEvent, 'isComposing' | 'key' | 'keyCode'>;
+
+/**
+ * Detect a key event handled by an input method editor.
+ *
+ * Safari/WKWebView can dispatch compositionend before the Enter keydown that
+ * confirms an IME candidate. In that sequence isComposing is already false,
+ * while the legacy keyCode remains 229 (the IME processing key). Some engines
+ * expose the same state as key="Process" instead.
+ */
+export function isImeCompositionKey(event: ImeKeyboardEvent, compositionActive: boolean): boolean {
+  return compositionActive || event.isComposing || event.key === 'Process' || event.keyCode === 229;
+}

--- a/jiuwenswarm/channels/web/frontend/tests/imeComposition.test.mjs
+++ b/jiuwenswarm/channels/web/frontend/tests/imeComposition.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isImeCompositionKey } from '../node_modules/.cache/ime-composition/components/ChatPanel/imeComposition.js';
+
+const keyboardEvent = (overrides = {}) => ({
+  isComposing: false,
+  key: 'Enter',
+  keyCode: 13,
+  ...overrides,
+});
+
+test('does not treat a regular Enter as IME composition', () => {
+  assert.equal(isImeCompositionKey(keyboardEvent(), false), false);
+});
+
+test('detects the component composition state', () => {
+  assert.equal(isImeCompositionKey(keyboardEvent(), true), true);
+});
+
+test('detects the standard KeyboardEvent composition flag', () => {
+  assert.equal(isImeCompositionKey(keyboardEvent({ isComposing: true }), false), true);
+});
+
+test('detects engines that expose an IME key as Process', () => {
+  assert.equal(isImeCompositionKey(keyboardEvent({ key: 'Process' }), false), true);
+});
+
+test('detects Safari and WKWebView IME processing keyCode 229', () => {
+  assert.equal(isImeCompositionKey(keyboardEvent({ isComposing: false, key: 'Enter', keyCode: 229 }), false), true);
+});


### PR DESCRIPTION
Paired: [GitHub #4746](https://github.com/openJiuwen-ai/jiuwenswarm/pull/4746) ↔ [GitCode !5933](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/5933)

## Summary

- prevent macOS Safari/WKWebView IME confirmation keys from submitting chat messages
- centralize composition detection across the normal submit path and composer suggestion selection
- cover the standard composition state plus the `Process` key and legacy IME key code `229`

## Why

On macOS, Safari/WKWebView can dispatch `compositionend` before the `keydown` generated by pressing Enter to confirm a Chinese IME candidate. At that point both the component composition ref and `KeyboardEvent.isComposing` may already be false, so the existing handler submits the unfinished message.

The additional checks are limited to browser IME signals used by established editors and chat clients. This deliberately avoids user-agent detection, timers, arbitrary post-composition grace periods, or persistent suppression state, so the next ordinary Enter remains available for sending.

## Testing

Automated:

- `npm run test:ime-composition` — 5 tests passed
- `npm run build` — TypeScript and Vite production build passed
- Prettier check for the new test/helper files and `package.json` passed
- `git diff --check` passed

Manual verification on macOS desktop/WKWebView:

- [x] Enter while confirming a Chinese Pinyin candidate selects the candidate without sending
- [x] A second Enter after candidate confirmation sends the message normally
- [x] Shift+Enter still inserts a newline
- [x] Chinese IME Enter does not activate `/` or `@` composer suggestions
- [x] Selecting IME candidates with Space or number keys continues to work

Closes #4690

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4690
<!-- /bot1-related-issues -->
