### PR TITLE
fix(search): keep configured paid providers in sync across agents

### DIFF
--- a/jiuwenswarm/agents/harness/common/tools/mcp_toolkits.py
+++ b/jiuwenswarm/agents/harness/common/tools/mcp_toolkits.py
@@ -4,25 +4,46 @@
 
 from __future__ import annotations
 import os
+from weakref import WeakSet
 
 from openjiuwen.core.foundation.tool import Tool
+from openjiuwen.core.runner import Runner
 
 from jiuwenswarm.agents.harness.common.tools.command_tools import mcp_exec_command
 from jiuwenswarm.agents.harness.common.tools.trusted_search_tool_adapter import (
     mcp_free_search,
     mcp_paid_search,
+    refresh_paid_search_metadata,
 )
+from jiuwenswarm.agents.harness.common.tools.search_tools import configured_paid_search_providers
 from jiuwenswarm.agents.harness.common.tools.web_fetch_tools import mcp_fetch_webpage
+
+_SEARCH_ABILITY_MANAGERS = WeakSet()
+
+
+def track_mcp_search_tools(ability_manager) -> None:
+    """Keep live MCP subagents in the search-config reload fan-out."""
+    _SEARCH_ABILITY_MANAGERS.add(ability_manager)
+
+
+def refresh_mcp_paid_search_tools() -> None:
+    """Refresh provider choices and reconcile registration in live subagents."""
+    refresh_paid_search_metadata()
+    enabled = _has_paid_search_api_key()
+    managers = list(_SEARCH_ABILITY_MANAGERS)
+    if enabled and managers:
+        Runner.resource_mgr.add_tool(mcp_paid_search, skip_if_exists=True)
+    for manager in managers:
+        current = manager.get(mcp_paid_search.card.name)
+        if enabled and current is None:
+            manager.add(mcp_paid_search.card)
+        elif not enabled and current is not None:
+            manager.remove(mcp_paid_search.card.name)
 
 
 def _has_paid_search_api_key() -> bool:
     """Check if any paid search API key is configured."""
-    return any([
-        os.environ.get("BOCHA_API_KEY"),
-        os.environ.get("PERPLEXITY_API_KEY"),
-        os.environ.get("SERPER_API_KEY"),
-        os.environ.get("JINA_API_KEY"),
-    ])
+    return bool(configured_paid_search_providers())
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -42,6 +63,7 @@ def _is_free_search_enabled() -> bool:
 def get_mcp_tools() -> list[Tool]:
     """Return all MCP toolkit tools for registration in Runner."""
     tools = []
+    refresh_paid_search_metadata()
     if _has_paid_search_api_key():
         tools.append(mcp_paid_search)
     if _is_free_search_enabled():

--- a/jiuwenswarm/agents/harness/common/tools/multi_session_toolkits.py
+++ b/jiuwenswarm/agents/harness/common/tools/multi_session_toolkits.py
@@ -35,7 +35,7 @@ from pydantic import BaseModel
 
 from openjiuwen.core.foundation.tool import LocalFunction, Tool, ToolCard
 
-from jiuwenswarm.agents.harness.common.tools.mcp_toolkits import get_mcp_tools
+from jiuwenswarm.agents.harness.common.tools.mcp_toolkits import get_mcp_tools, track_mcp_search_tools
 from jiuwenswarm.runtime.context import get_current_agent_manager
 from jiuwenswarm.runtime.host_services import send_runtime_push
 
@@ -109,6 +109,7 @@ class MultiSessionToolkit:
         for mcp_tool in mcp_tools:
             Runner.resource_mgr.add_tool(mcp_tool)
             agent.ability_manager.add(mcp_tool.card)
+        track_mcp_search_tools(agent.ability_manager)
         logger.debug("[MultiSessionToolkit] get_sub_agent 完成 mcp_tools_count=%d", len(mcp_tools))
         return agent
 

--- a/jiuwenswarm/agents/harness/common/tools/search_tools.py
+++ b/jiuwenswarm/agents/harness/common/tools/search_tools.py
@@ -531,6 +531,15 @@ def _jina_search_sync(query: str, timeout_seconds: int) -> dict[str, Any]:
     return {"provider": "jina", "answer": (answer or "").strip(), "urls": urls}
 
 
+def configured_paid_search_providers() -> list[str]:
+    """Return providers with nonblank keys in the MCP fallback order."""
+    return [
+        provider
+        for provider in ("bocha", "perplexity", "serper", "jina")
+        if str(os.environ.get(f"{provider.upper()}_API_KEY", "") or "").strip()
+    ]
+
+
 async def run_paid_search_structured(
     query: str,
     provider: str = "auto",
@@ -553,32 +562,21 @@ async def run_paid_search_structured(
             query=query, max_results=max_results, timeout_seconds=timeout_seconds
         ),
     }
-    
-    available_providers = []
-    if os.environ.get("BOCHA_API_KEY"):
-        available_providers.append("bocha")
-    if os.environ.get("PERPLEXITY_API_KEY"):
-        available_providers.append("perplexity")
-    if os.environ.get("SERPER_API_KEY"):
-        available_providers.append("serper")
-    if os.environ.get("JINA_API_KEY"):
-        available_providers.append("jina")
-    
+    available_providers = configured_paid_search_providers()
+
     if not available_providers:
         raise RuntimeError("no paid search API keys configured.")
-    
-    if provider != "auto":
-        if provider not in available_providers:
-            raise RuntimeError(
-                f"{provider} API key not configured. "
-                f"Available providers: {', '.join(available_providers)}"
-            )
-        order = [provider]
-    else:
-        order = [p for p in ["bocha", "perplexity", "serper", "jina"] if p in available_providers]
+
+    if provider != "auto" and provider not in runners:
+        raise ValueError("provider must be auto or a configured search provider.")
+    # Queued calls can outlive a provider's configuration. Use a configured
+    # fallback without invoking a runner that is guaranteed to lack a key.
+    order = [provider] if provider in available_providers else available_providers
 
     errors: list[str] = []
     for name in order:
+        if name not in configured_paid_search_providers():
+            continue
         runner = runners.get(name)
         if runner is None:
             errors.append(f"{name}: provider runner unavailable")

--- a/jiuwenswarm/agents/harness/common/tools/trusted_search_tool_adapter.py
+++ b/jiuwenswarm/agents/harness/common/tools/trusted_search_tool_adapter.py
@@ -10,14 +10,17 @@ provider results to the optional one-shot trusted-search provenance lease.
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 
-from openjiuwen.core.foundation.tool import tool
+from openjiuwen.core.foundation.tool import LocalFunction, tool
+from openjiuwen.harness.prompts.tools import get_tool_description, get_tool_input_params
 
 from jiuwenswarm.agents.harness.common.rails.permissions.trusted_search_urls import (
     complete_trusted_search_producer,
 )
 from jiuwenswarm.agents.harness.common.tools.search_tools import (
     DEFAULT_SEARCH_MAX_RESULTS,
+    configured_paid_search_providers,
     normalize_search_max_results,
     render_free_search_result,
     render_paid_search_result,
@@ -68,11 +71,7 @@ async def mcp_free_search(
         )
 
 
-@tool(
-    name="mcp_paid_search",
-    description="Paid search via Bocha/Perplexity/SERPER/JINA. Support provider=auto|bocha|perplexity|serper|jina.",
-)
-async def mcp_paid_search(
+async def _run_paid_search(
     query: str,
     provider: str = "auto",
     max_results: int = DEFAULT_SEARCH_MAX_RESULTS,
@@ -86,7 +85,7 @@ async def mcp_paid_search(
             return "[ERROR]: query cannot be empty."
         provider = (provider or "auto").strip().lower()
         if provider not in {"auto", "bocha", "jina", "serper", "perplexity"}:
-            return "[ERROR]: provider must be one of auto|bocha|jina|serper|perplexity."
+            return "[ERROR]: provider must be auto or a configured search provider."
         max_results = normalize_search_max_results(max_results)
         timeout_seconds = max(10, min(timeout_seconds, 120))
         try:
@@ -114,5 +113,36 @@ async def mcp_paid_search(
             success=False,
         )
 
+
+class _ConfiguredPaidSearchTool(LocalFunction):
+    """Normalize queued provider choices before LocalFunction schema validation."""
+
+    async def invoke(self, inputs, **kwargs):
+        provider = str(inputs.get("provider", "auto") or "auto").strip().lower()
+        if provider in {"auto", "bocha", "perplexity", "serper", "jina"}:
+            if provider != "auto" and provider not in configured_paid_search_providers():
+                provider = "auto"
+            inputs = {**inputs, "provider": provider}
+        return await super().invoke(inputs, **kwargs)
+
+
+mcp_paid_search = _ConfiguredPaidSearchTool(
+    card=tool(
+        name="mcp_paid_search",
+        description=get_tool_description("paid_search", "en"),
+    )(_run_paid_search).card,
+    func=_run_paid_search,
+)
+
+
+def refresh_paid_search_metadata() -> None:
+    """Refresh the shared MCP card after environment configuration is loaded."""
+    mcp_paid_search.card.description = get_tool_description("paid_search", "en")
+    params = deepcopy(mcp_paid_search.card.input_params)
+    params["properties"]["provider"] = get_tool_input_params("paid_search", "en")["properties"]["provider"]
+    mcp_paid_search.card.input_params = params
+
+
+refresh_paid_search_metadata()
 
 __all__ = ["mcp_free_search", "mcp_paid_search"]

--- a/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
+++ b/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
@@ -127,6 +127,9 @@ logger = logging.getLogger(__name__)
 
 
 _WEB_CONFIG_RELOAD_CHANNEL_ID = "web"
+_SEARCH_RELOAD_ENV_KEYS = {
+    "BOCHA_API_KEY", "PERPLEXITY_API_KEY", "SERPER_API_KEY", "JINA_API_KEY",
+}
 _MODEL_RELOAD_ENV_KEYS = {
     "MODEL_PROVIDER",
     "MODEL_NAME",
@@ -188,6 +191,8 @@ class _ConfigChangeSet:
             scopes.add("model")
         if _MULTIMODAL_RELOAD_ENV_KEYS & set(self.env_updates):
             scopes.add("multimodal")
+        if _SEARCH_RELOAD_ENV_KEYS & set(self.env_updates):
+            scopes.add("search")
         for key in self.yaml_updated:
             key_text = str(key)
             if key_text == "skill_retrieval_index_recommendation_shown":

--- a/jiuwenswarm/server/agent_ws_server.py
+++ b/jiuwenswarm/server/agent_ws_server.py
@@ -9499,6 +9499,7 @@ class AgentWebSocketServer:
             agent_reload_scopes = {
                 "model",
                 "multimodal",
+                "search",
                 "team",
                 "permissions",
                 "agent_runtime",

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_code.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_code.py
@@ -47,7 +47,7 @@ from openjiuwen.harness.subagents.browser_agent import build_browser_agent_confi
 from openjiuwen.harness.subagents.code_agent import build_code_agent_config
 from openjiuwen.harness.subagents.explore_agent import build_explore_agent_config
 from openjiuwen.harness.subagents.plan_agent import build_plan_agent_config
-from openjiuwen.harness.tools import WebFetchWebpageTool, WebPaidSearchTool
+from openjiuwen.harness.tools import WebFetchWebpageTool, WebPaidSearchTool, is_paid_search_enabled
 from openjiuwen.harness.tools.worktree import WorktreeConfig, WorktreeRail
 
 from jiuwenswarm.server.runtime.agent_adapter.interface_deep import (
@@ -2327,10 +2327,7 @@ class JiuwenSwarmCodeAdapter(JiuWenSwarmDeepAdapter):
 
     def _build_paid_search_tool(self, agent_id: str) -> WebPaidSearchTool | None:
         """条件注册付费搜索工具：有任意一个付费 API Key 才注册."""
-        if not any(
-            os.environ.get(key)
-            for key in ("BOCHA_API_KEY", "PERPLEXITY_API_KEY", "SERPER_API_KEY", "JINA_API_KEY")
-        ):
+        if not is_paid_search_enabled():
             logger.info("[JiuwenSwarmCodeAdapter] web_paid_search skipped: no paid search API key")
             return None
         tool = WebPaidSearchTool(
@@ -2342,6 +2339,7 @@ class JiuwenSwarmCodeAdapter(JiuWenSwarmDeepAdapter):
 
     def _sync_paid_search_tool_for_runtime(self) -> None:
         """Sync paid search while respecting ``modes.code.tools``."""
+        self._invalidate_stale_paid_search_tool()
         configured_tools = (
             self._active_code_config()
             .get("modes", {})
@@ -2349,18 +2347,7 @@ class JiuwenSwarmCodeAdapter(JiuWenSwarmDeepAdapter):
             .get("tools")
             or []
         )
-        paid_search_env_keys = (
-            "BOCHA_API_KEY",
-            "PERPLEXITY_API_KEY",
-            "SERPER_API_KEY",
-            "JINA_API_KEY",
-        )
-        has_paid_search_key = False
-        for key in paid_search_env_keys:
-            if os.environ.get(key):
-                has_paid_search_key = True
-                break
-        enabled = "web_paid_search" in configured_tools and has_paid_search_key
+        enabled = "web_paid_search" in configured_tools and is_paid_search_enabled()
         agent_id = self._tool_owner_id()
         tools, self._paid_search_registered = self._sync_tool_group(
             current_tools=(

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -5129,8 +5129,24 @@ class JiuWenSwarmDeepAdapter:
             warn_label="generate_visual tool",
         )
 
+    def _invalidate_stale_paid_search_tool(self) -> None:
+        """Re-register paid search when its configured-provider metadata changes."""
+        if self._paid_search_tool is None or not self._paid_search_registered:
+            return
+        current = self._paid_search_tool.card
+        updated = WebPaidSearchTool(
+            language=self._resolve_runtime_language(), agent_id=self._tool_owner_id()
+        ).card
+        if current.description == updated.description and current.input_params == updated.input_params:
+            return
+        self._remove_registered_tools([self._paid_search_tool])
+        self._prune_tool_cards({current.name})
+        self._paid_search_tool = None
+        self._paid_search_registered = False
+
     def _sync_paid_search_tool_for_runtime(self) -> None:
         """Sync paid-search tool registration after config reload."""
+        self._invalidate_stale_paid_search_tool()
         # The owner id, not ``card.id``; see ``_sync_multimodal_tools_for_runtime``.
         agent_id = self._tool_owner_id()
         tools, self._paid_search_registered = self._sync_tool_group(
@@ -8542,6 +8558,12 @@ class JiuWenSwarmDeepAdapter:
         if self._is_session_scoped_adapter:
             return
         if not target_sid:
+            if not reload_scopes or "search" in reload_scopes:
+                # Refresh the small tool surface now, including running sessions;
+                # the full agent/model reload remains lazy at the request boundary.
+                for _, adapter in self._iter_session_adapters_for_reload(None):
+                    if adapter._instance is not None:
+                        adapter._sync_paid_search_tool_for_runtime()
             self._mark_session_adapters_stale_for_reload(
                 config_base,
                 env_overrides,

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -5144,6 +5144,11 @@ class JiuWenSwarmDeepAdapter:
         self._paid_search_tool = None
         self._paid_search_registered = False
 
+    def refresh_paid_search_tool_for_runtime(self) -> None:
+        """Refresh paid search on a live adapter without creating its runtime."""
+        if self._instance is not None:
+            self._sync_paid_search_tool_for_runtime()
+
     def _sync_paid_search_tool_for_runtime(self) -> None:
         """Sync paid-search tool registration after config reload."""
         self._invalidate_stale_paid_search_tool()
@@ -8562,8 +8567,7 @@ class JiuWenSwarmDeepAdapter:
                 # Refresh the small tool surface now, including running sessions;
                 # the full agent/model reload remains lazy at the request boundary.
                 for _, adapter in self._iter_session_adapters_for_reload(None):
-                    if adapter._instance is not None:
-                        adapter._sync_paid_search_tool_for_runtime()
+                    adapter.refresh_paid_search_tool_for_runtime()
             self._mark_session_adapters_stale_for_reload(
                 config_base,
                 env_overrides,

--- a/jiuwenswarm/server/runtime/agent_manager.py
+++ b/jiuwenswarm/server/runtime/agent_manager.py
@@ -1222,7 +1222,7 @@ class AgentManager:
         使用 ``self._reload_lock`` 串行化, 避免高频触发(如批量 MCP 增删)时多个
         reload 并发叠加, 同时重建大量 agent 实例导致内存暴涨被 OOM kill.
 
-        ``reload_scopes`` 含 ``"model"`` 或 ``"multimodal"`` 时, 配置属于所有
+        ``reload_scopes`` 含 ``"model"``、``"multimodal"`` 或 ``"search"`` 时, 配置属于所有
         channel 共享的全局配置段, 此时忽略 ``target_channel_id`` 的窄化,
         fan-out 到全部 channel。否则 web 保存后只有 web 通道被热更新,
         IM 长连接通道的 session adapter 会继续使用旧配置。
@@ -1238,16 +1238,29 @@ class AgentManager:
 
             target_channel = str(target_channel_id or "").strip() or None
             target_session = str(target_session_id or "").strip() or None
-            # 对话模型和多模态工具都是全局共享配置，必须广播到所有 channel。
+            # 对话模型、多模态和搜索工具都是全局共享配置，必须广播到所有 channel。
             scope_set = set(reload_scopes) if reload_scopes else set()
+            search_changed = any(
+                f"{provider}_API_KEY" in self._latest_env_overrides
+                for provider in ("BOCHA", "PERPLEXITY", "SERPER", "JINA")
+            )
+            # Older callers can omit scopes; keep their full-reload semantics.
+            if search_changed and scope_set:
+                scope_set.add("search")
             model_scope = "model" in scope_set
-            global_scope = bool(scope_set & {"model", "multimodal"})
+            global_scope = search_changed or bool(scope_set & {"model", "multimodal", "search"})
+            if not scope_set or "search" in scope_set:
+                from jiuwenswarm.agents.harness.common.tools.mcp_toolkits import refresh_mcp_paid_search_tools
+
+                refresh_mcp_paid_search_tools()
             effective_target_channel = None if global_scope else target_channel
+            if search_changed or "search" in scope_set:
+                target_session = None
             if target_channel and global_scope:
                 logger.info(
                     "[AgentManager] global config scopes=%s changed via channel=%s; "
                     "fan-out reload to all channels",
-                    sorted(scope_set & {"model", "multimodal"}),
+                    sorted(scope_set & {"model", "multimodal", "search"}),
                     target_channel,
                 )
             effective_config = config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "ruamel.yaml>=0.18.0,<0.20",
     "lark-oapi>=1.5.3,<2",
     "loguru>=0.7.3,<0.8",
-    "openjiuwen @ git+https://gitcode.com/openJiuwen/agent-core.git@0af325ebe9f891e53fa211dae3392a4aff9d923d",
+    "openjiuwen @ git+https://gitcode.com/openJiuwen/agent-core.git@14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5",
     "pgvector>=0.4.2,<0.5",
     "portalocker>=3.2.0,<4",
     "prompt-toolkit>=3.0,<4.0",
@@ -70,7 +70,7 @@ harmony = [
     "ruamel.yaml>=0.18.0",
     "lark-oapi>=1.5.3",
     "loguru>=0.7.3",
-    "openjiuwen @ git+https://gitcode.com/openJiuwen/agent-core.git@0af325ebe9f891e53fa211dae3392a4aff9d923d",
+    "openjiuwen @ git+https://gitcode.com/openJiuwen/agent-core.git@14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5",
     "pgvector>=0.4.2",
     "portalocker>=3.2.0",
     "aiosqlite>=0.22.1",
@@ -187,7 +187,7 @@ default-groups = ['dev']
 
 [tool.uv.sources]
 workswarm-tui = { path = "./packages/jiuwenswarm-tui" }  # build-config: tui-source
-openjiuwen = { git = "https://gitcode.com/openJiuwen/agent-core.git", rev = "0af325ebe9f891e53fa211dae3392a4aff9d923d" }
+openjiuwen = { git = "https://gitcode.com/openJiuwen/agent-core.git", rev = "14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5" }
 
 [dependency-groups]
 # Testing (keep in sync with optional-dependencies.test)

--- a/tests/unit_tests/agents/harness/test_product_shell_rules_powershell.py
+++ b/tests/unit_tests/agents/harness/test_product_shell_rules_powershell.py
@@ -114,7 +114,7 @@ def test_product_powershell_unlisted_cmdlets_follow_tool_allow() -> None:
 
 _PS_DELETE_ASK_CASES = (
     ("Remove-Item test", "shell_ask_remove_item"),
-    ("Remove-Item -Recurse -Force tmp", "shell_ask_remove_item"),
+    ("Remove-Item -Recurse -Force tmp", "shell_ps_recursive_or_forced_delete"),
     ("ri test.txt", "shell_ask_ri"),
     ("rmdir olddir", "shell_ask_rmdir"),
     ("erase temp.log", "shell_ask_erase"),

--- a/tests/unit_tests/agentserver/permissions/test_trusted_search_tool_adapter.py
+++ b/tests/unit_tests/agentserver/permissions/test_trusted_search_tool_adapter.py
@@ -87,7 +87,13 @@ def test_mcp_search_result_limit_has_no_permission_side_duplicate() -> None:
     assert "max(1, min(int(max_results)," not in production
 
 
-def test_mcp_toolkit_exports_the_unique_adapter_tool_objects() -> None:
+def test_mcp_toolkit_exports_the_unique_adapter_tool_objects(monkeypatch) -> None:
+    for provider in ("bocha", "perplexity", "serper", "jina"):
+        monkeypatch.setenv(f"{provider.upper()}_API_KEY", "")
+    monkeypatch.setenv("BOCHA_API_KEY", "test-key")
+    monkeypatch.setattr(mcp_paid_search.card, "input_params", mcp_paid_search.card.input_params.copy())
+    monkeypatch.setattr(mcp_paid_search.card, "description", mcp_paid_search.card.description)
+    trusted_search_tool_adapter.refresh_paid_search_metadata()
     assert mcp_free_search is trusted_search_tool_adapter.mcp_free_search
     assert mcp_paid_search is trusted_search_tool_adapter.mcp_paid_search
     assert mcp_free_search.card.name == "mcp_free_search"
@@ -109,8 +115,9 @@ def test_mcp_toolkit_exports_the_unique_adapter_tool_objects() -> None:
         "query": {"type": "string", "description": "query"},
         "provider": {
             "type": "string",
-            "description": "provider",
+            "description": "Available providers: auto|bocha. Prefer auto; it selects only configured providers.",
             "default": "auto",
+            "enum": ["auto", "bocha"],
         },
         "max_results": {
             "type": "integer",
@@ -248,4 +255,5 @@ def test_adapter_owns_the_only_decorated_mcp_search_functions() -> None:
         )
     }
 
-    assert decorated == {"mcp_free_search", "mcp_paid_search"}
+    assert decorated == {"mcp_free_search"}
+    assert isinstance(mcp_paid_search, trusted_search_tool_adapter._ConfiguredPaidSearchTool)

--- a/tests/unit_tests/agentserver/test_agent_reload_model_scope.py
+++ b/tests/unit_tests/agentserver/test_agent_reload_model_scope.py
@@ -13,6 +13,8 @@ channel 的 agent。
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from jiuwenswarm.server.runtime import agent_manager as agent_manager_module
@@ -89,8 +91,10 @@ async def test_model_scope_fans_out_to_all_channels_even_with_target_channel(mon
 
 
 @pytest.mark.asyncio
-async def test_multimodal_scope_fans_out_to_all_channels_even_with_target_channel(
+@pytest.mark.parametrize("scope", ["multimodal", "search"])
+async def test_global_tool_scope_fans_out_to_all_channels_even_with_target_channel(
     monkeypatch,
+    scope,
 ):
     web_agent = FakeAgent()
     xiaoyi_agent = FakeAgent()
@@ -103,7 +107,7 @@ async def test_multimodal_scope_fans_out_to_all_channels_even_with_target_channe
         {"models": {"vision": {}}},
         {"VISION_ENABLED": "true"},
         target_channel_id="web",
-        reload_scopes={"multimodal"},
+        reload_scopes={scope},
     )
 
     assert len(web_agent.reload_calls) == 1
@@ -133,6 +137,33 @@ async def test_non_model_scope_still_narrows_to_target_channel(monkeypatch):
     assert xiaoyi_agent.reload_calls == [], (
         "non-model scopes must still narrow to target_channel (no regression)"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scopes", [None, {"multimodal"}, {"search"}])
+@pytest.mark.parametrize("key", ["first-test-key", ""])
+async def test_search_key_changes_refresh_all_sessions_and_mcp_after_env_update(monkeypatch, scopes, key):
+    import os
+    from jiuwenswarm.agents.harness.common.tools import mcp_toolkits
+
+    monkeypatch.setenv("BOCHA_API_KEY", "old-test-key")
+    observed = []
+    refresh = MagicMock(side_effect=lambda: observed.append(os.environ.get("BOCHA_API_KEY")))
+    monkeypatch.setattr(mcp_toolkits, "refresh_mcp_paid_search_tools", refresh)
+    web_agent, im_agent = FakeAgent(), FakeAgent()
+    manager, _ = _build_manager(
+        monkeypatch, agents={"web": {"agent": web_agent}, "im": {"agent": im_agent}},
+    )
+    await manager.reload_agents_config(
+        {}, {"BOCHA_API_KEY": key}, target_channel_id="web",
+        target_session_id="one-session", reload_scopes=scopes,
+    )
+    assert observed == [key]
+    for agent in (web_agent, im_agent):
+        assert len(agent.reload_calls) == 1
+        kwargs = agent.reload_calls[0]["kwargs"]
+        assert "target_session_id" not in kwargs
+        assert kwargs.get("reload_scopes") == (scopes | {"search"} if scopes else None)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agentserver/test_agent_reload_scope.py
+++ b/tests/unit_tests/agentserver/test_agent_reload_scope.py
@@ -41,6 +41,7 @@ class FakeWebSocket:
 class FakeAgent:
     def __init__(self):
         self.reload_calls = []
+        self._instance = None
 
     async def reload_agent_config(self, *args, **kwargs):
         if args:
@@ -436,7 +437,8 @@ async def test_agent_reload_config_handler_warms_zen_cache_on_model_scope(monkey
 
 
 @pytest.mark.asyncio
-async def test_multimodal_reload_refreshes_agents_without_model_probes(monkeypatch):
+@pytest.mark.parametrize("scope", ["multimodal", "search"])
+async def test_tool_reload_refreshes_agents_without_model_probes(monkeypatch, scope):
     from jiuwenswarm.agents.harness import team as team_harness_module
     from jiuwenswarm.server.runtime import image_modality_warmup, opencode_zen
 
@@ -476,7 +478,7 @@ async def test_multimodal_reload_refreshes_agents_without_model_probes(monkeypat
             "config": {"models": {"vision": {}}},
             "env": {"VISION_ENABLED": "true"},
             "target_channel_id": "web",
-            "reload_scopes": ["multimodal"],
+            "reload_scopes": [scope],
         },
     )
 
@@ -488,7 +490,7 @@ async def test_multimodal_reload_refreshes_agents_without_model_probes(monkeypat
         {"models": {"vision": {}}},
         {"VISION_ENABLED": "true"},
         target_channel_id="web",
-        reload_scopes={"multimodal"},
+        reload_scopes={scope},
     )
     refresh_image_modality.assert_not_awaited()
     warm_zen.assert_not_awaited()

--- a/tests/unit_tests/agentserver/test_agent_reload_scope.py
+++ b/tests/unit_tests/agentserver/test_agent_reload_scope.py
@@ -63,6 +63,9 @@ class FakeAgent:
     def persist_skill_retrieval_session_profile(self) -> None:
         """Match the child adapter's public profile persistence hook."""
 
+    def refresh_paid_search_tool_for_runtime(self) -> None:
+        """Match the child adapter's public paid-search refresh hook."""
+
 
 class FailingReloadAgent(FakeAgent):
     async def reload_agent_config(self, *args, **kwargs):

--- a/tests/unit_tests/agentserver/test_multimodal_capability_hot_reload.py
+++ b/tests/unit_tests/agentserver/test_multimodal_capability_hot_reload.py
@@ -97,6 +97,40 @@ def test_multimodal_switch_hot_reload_registers_and_removes_vision_tools(
     assert native_config.enable_read_image_multimodal is None
 
 
+def test_multimodal_reload_preserves_video_and_visual_generation_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = JiuWenSwarmDeepAdapter()
+    adapter._video_gen_model_config = {"api_key": "test-key"}
+    adapter._visual_gen_model_config = {"api_key": "test-key"}
+    sync_groups = MagicMock(
+        side_effect=lambda **kwargs: (kwargs["current_tools"], kwargs["enabled"])
+    )
+    monkeypatch.setattr(adapter, "_sync_tool_group", sync_groups)
+    monkeypatch.setattr(adapter, "_iter_runtime_audio_tools", lambda _agent_id: [])
+
+    adapter._sync_multimodal_tools_for_runtime()
+
+    groups = {
+        call.kwargs["warn_label"]: call.kwargs
+        for call in sync_groups.call_args_list
+    }
+    assert [tool.card.name for tool in groups["generate_video tools"]["current_tools"]] == [
+        "generate_video", "check_video_status",
+    ]
+    assert [tool.card.name for tool in groups["generate_visual tool"]["current_tools"]] == [
+        "generate_visual",
+    ]
+    assert adapter._video_gen_tool_registered is True
+    assert adapter._visual_gen_tool_registered is True
+
+    adapter._video_gen_model_config = None
+    adapter._visual_gen_model_config = None
+    adapter._sync_multimodal_tools_for_runtime()
+    assert adapter._video_gen_tool_registered is False
+    assert adapter._visual_gen_tool_registered is False
+
+
 def test_native_image_auto_uses_probe_cache_independently_of_vision_tools(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/agentserver/test_paid_search_configuration.py
+++ b/tests/unit_tests/agentserver/test_paid_search_configuration.py
@@ -4,7 +4,7 @@
 
 from copy import deepcopy
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 from weakref import WeakSet
 
 import pytest
@@ -43,18 +43,18 @@ def test_reload_refreshes_provider_metadata_and_removes_disabled_tool(monkeypatc
     monkeypatch.setattr(interface_deep, "register_tool", lambda tool, owner: registered.update({tool.card.name: tool}))
     monkeypatch.setattr(interface_deep, "unregister_tool", lambda tool: registered.pop(tool.card.name, None))
 
-    adapter._sync_paid_search_tool_for_runtime()
+    adapter.refresh_paid_search_tool_for_runtime()
     assert adapter._paid_search_tool is None
     monkeypatch.setenv("BOCHA_API_KEY", "test-key")
-    adapter._sync_paid_search_tool_for_runtime()
+    adapter.refresh_paid_search_tool_for_runtime()
     first = adapter._paid_search_tool
     assert cards["paid_search"].input_params["properties"]["provider"]["enum"] == ["auto", "bocha"]
 
-    adapter._sync_paid_search_tool_for_runtime()
+    adapter.refresh_paid_search_tool_for_runtime()
     assert adapter._paid_search_tool is first
     monkeypatch.setenv("BOCHA_API_KEY", " \t ")
     monkeypatch.setenv("SERPER_API_KEY", "test-key")
-    adapter._sync_paid_search_tool_for_runtime()
+    adapter.refresh_paid_search_tool_for_runtime()
     assert adapter._paid_search_tool is not first
     assert adapter._paid_search_tool.card.id == first.card.id
     assert cards["paid_search"].input_params["properties"]["provider"]["enum"] == ["auto", "serper"]
@@ -63,21 +63,34 @@ def test_reload_refreshes_provider_metadata_and_removes_disabled_tool(monkeypatc
     assert registered["paid_search"] is adapter._paid_search_tool
 
     monkeypatch.setenv("SERPER_API_KEY", "")
-    adapter._sync_paid_search_tool_for_runtime()
+    adapter.refresh_paid_search_tool_for_runtime()
     assert not adapter._paid_search_registered
     assert adapter._paid_search_tool is None
     assert adapter._tool_cards == []
     assert cards == registered == {}
 
 
+@pytest.mark.parametrize("adapter_class", [JiuWenSwarmDeepAdapter, JiuwenSwarmCodeAdapter])
+def test_paid_search_refresh_skips_uninitialized_runtime(adapter_class):
+    adapter = object.__new__(adapter_class)
+    adapter._instance = None
+    adapter._sync_paid_search_tool_for_runtime = MagicMock()
+
+    adapter.refresh_paid_search_tool_for_runtime()
+
+    adapter._sync_paid_search_tool_for_runtime.assert_not_called()
+    assert adapter._instance is None
+
+
 def test_code_mode_with_paid_search_disabled_stays_disabled(monkeypatch):
     adapter = object.__new__(JiuwenSwarmCodeAdapter)
+    adapter._instance = object()
     adapter._paid_search_tool = None
     adapter._paid_search_registered = False
     adapter._active_code_config = lambda: {"modes": {"code": {"tools": []}}}
     adapter._tool_owner_id = lambda: "test-owner"
     monkeypatch.setenv("BOCHA_API_KEY", "test-key")
-    adapter._sync_paid_search_tool_for_runtime()
+    adapter.refresh_paid_search_tool_for_runtime()
     assert adapter._paid_search_tool is None
     assert not adapter._paid_search_registered
 
@@ -202,15 +215,36 @@ async def test_existing_mcp_agent_refreshes_model_tools_on_enable_change_and_dis
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("scopes", [None, {"search"}])
+@pytest.mark.parametrize("scopes", [None, set(), {"search"}, {"search", "model"}])
 async def test_search_reload_updates_active_sessions_before_lazy_full_reload(scopes):
     root = object.__new__(JiuWenSwarmDeepAdapter)
     root._is_session_scoped_adapter = False
-    live = SimpleNamespace(_instance=object(), _sync_paid_search_tool_for_runtime=MagicMock())
-    idle = SimpleNamespace(_instance=None, _sync_paid_search_tool_for_runtime=MagicMock())
-    root._session_adapters = {"live": live, "idle": idle}
-    root._mark_session_adapters_stale_for_reload = MagicMock()
+    calls = MagicMock()
+    root._session_adapters = {
+        "first": SimpleNamespace(refresh_paid_search_tool_for_runtime=calls.refresh_first),
+        "second": SimpleNamespace(refresh_paid_search_tool_for_runtime=calls.refresh_second),
+    }
+    root._mark_session_adapters_stale_for_reload = calls.mark_stale
     await root._fan_out_reload_to_session_adapters({}, {}, None, scopes)
-    live._sync_paid_search_tool_for_runtime.assert_called_once()
-    idle._sync_paid_search_tool_for_runtime.assert_not_called()
+    assert calls.mock_calls == [
+        call.refresh_first(),
+        call.refresh_second(),
+        call.mark_stale({}, {}, scopes),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scopes", [{"model"}, {"multimodal"}])
+async def test_unrelated_reload_does_not_refresh_session_paid_search(scopes):
+    root = object.__new__(JiuWenSwarmDeepAdapter)
+    root._is_session_scoped_adapter = False
+    refresh = MagicMock()
+    root._session_adapters = {
+        "session": SimpleNamespace(refresh_paid_search_tool_for_runtime=refresh),
+    }
+    root._mark_session_adapters_stale_for_reload = MagicMock()
+
+    await root._fan_out_reload_to_session_adapters({}, {}, None, scopes)
+
+    refresh.assert_not_called()
     root._mark_session_adapters_stale_for_reload.assert_called_once_with({}, {}, scopes)

--- a/tests/unit_tests/agentserver/test_paid_search_configuration.py
+++ b/tests/unit_tests/agentserver/test_paid_search_configuration.py
@@ -1,0 +1,216 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Configured-provider exposure for main-agent reload and MCP subagents."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from weakref import WeakSet
+
+import pytest
+
+from jiuwenswarm.agents.harness.common.tools import mcp_toolkits, search_tools
+from jiuwenswarm.agents.harness.common.tools.trusted_search_tool_adapter import mcp_paid_search
+from jiuwenswarm.server.runtime.agent_adapter import interface_deep
+from jiuwenswarm.server.runtime.agent_adapter.interface_code import JiuwenSwarmCodeAdapter
+from jiuwenswarm.server.runtime.agent_adapter.interface_deep import JiuWenSwarmDeepAdapter
+
+
+@pytest.fixture(autouse=True)
+def isolated_search_env(monkeypatch):
+    for provider in ("bocha", "perplexity", "serper", "jina"):
+        monkeypatch.setenv(f"{provider.upper()}_API_KEY", "")
+    monkeypatch.setattr(mcp_paid_search.card, "description", mcp_paid_search.card.description)
+    monkeypatch.setattr(mcp_paid_search.card, "input_params", deepcopy(mcp_paid_search.card.input_params))
+    monkeypatch.setattr(mcp_toolkits, "_SEARCH_ABILITY_MANAGERS", WeakSet())
+
+
+@pytest.mark.parametrize("adapter_class", [JiuWenSwarmDeepAdapter, JiuwenSwarmCodeAdapter])
+def test_reload_refreshes_provider_metadata_and_removes_disabled_tool(monkeypatch, adapter_class):
+    adapter = object.__new__(adapter_class)
+    adapter._paid_search_tool = None
+    adapter._paid_search_registered = False
+    adapter._tool_cards = []
+    cards = {}
+    registered = {}
+    adapter._instance = SimpleNamespace(ability_manager=SimpleNamespace(
+        add=lambda card: cards.update({card.name: card}),
+        remove=lambda name: cards.pop(name, None),
+    ))
+    adapter._tool_owner_id = lambda: "test-owner"
+    adapter._resolve_runtime_language = lambda: "en"
+    adapter._active_code_config = lambda: {"modes": {"code": {"tools": ["web_paid_search"]}}}
+    monkeypatch.setattr(interface_deep, "register_tool", lambda tool, owner: registered.update({tool.card.name: tool}))
+    monkeypatch.setattr(interface_deep, "unregister_tool", lambda tool: registered.pop(tool.card.name, None))
+
+    adapter._sync_paid_search_tool_for_runtime()
+    assert adapter._paid_search_tool is None
+    monkeypatch.setenv("BOCHA_API_KEY", "test-key")
+    adapter._sync_paid_search_tool_for_runtime()
+    first = adapter._paid_search_tool
+    assert cards["paid_search"].input_params["properties"]["provider"]["enum"] == ["auto", "bocha"]
+
+    adapter._sync_paid_search_tool_for_runtime()
+    assert adapter._paid_search_tool is first
+    monkeypatch.setenv("BOCHA_API_KEY", " \t ")
+    monkeypatch.setenv("SERPER_API_KEY", "test-key")
+    adapter._sync_paid_search_tool_for_runtime()
+    assert adapter._paid_search_tool is not first
+    assert adapter._paid_search_tool.card.id == first.card.id
+    assert cards["paid_search"].input_params["properties"]["provider"]["enum"] == ["auto", "serper"]
+    assert "bocha" not in cards["paid_search"].description.lower()
+    assert adapter._tool_cards == [cards["paid_search"]]
+    assert registered["paid_search"] is adapter._paid_search_tool
+
+    monkeypatch.setenv("SERPER_API_KEY", "")
+    adapter._sync_paid_search_tool_for_runtime()
+    assert not adapter._paid_search_registered
+    assert adapter._paid_search_tool is None
+    assert adapter._tool_cards == []
+    assert cards == registered == {}
+
+
+def test_code_mode_with_paid_search_disabled_stays_disabled(monkeypatch):
+    adapter = object.__new__(JiuwenSwarmCodeAdapter)
+    adapter._paid_search_tool = None
+    adapter._paid_search_registered = False
+    adapter._active_code_config = lambda: {"modes": {"code": {"tools": []}}}
+    adapter._tool_owner_id = lambda: "test-owner"
+    monkeypatch.setenv("BOCHA_API_KEY", "test-key")
+    adapter._sync_paid_search_tool_for_runtime()
+    assert adapter._paid_search_tool is None
+    assert not adapter._paid_search_registered
+
+
+def test_mcp_metadata_tracks_provider_configuration(monkeypatch):
+    assert mcp_paid_search not in mcp_toolkits.get_mcp_tools()
+    monkeypatch.setenv("BOCHA_API_KEY", "test-key")
+    assert mcp_paid_search in mcp_toolkits.get_mcp_tools()
+    assert mcp_paid_search.card.input_params["properties"]["provider"]["enum"] == ["auto", "bocha"]
+    assert "serper" not in mcp_paid_search.card.description.lower()
+    monkeypatch.setenv("BOCHA_API_KEY", " ")
+    monkeypatch.setenv("SERPER_API_KEY", "test-key")
+    assert mcp_paid_search in mcp_toolkits.get_mcp_tools()
+    assert mcp_paid_search.card.input_params["properties"]["provider"]["enum"] == ["auto", "serper"]
+    assert "bocha" not in mcp_paid_search.card.description.lower()
+    monkeypatch.setenv("SERPER_API_KEY", "")
+    assert mcp_paid_search not in mcp_toolkits.get_mcp_tools()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["bocha", "perplexity", "serper", "jina"])
+async def test_registered_mcp_provider_requests_use_rotated_key(monkeypatch, provider):
+    key_name = f"{provider.upper()}_API_KEY"
+    monkeypatch.setenv(key_name, "first-test-key")
+    tool = next(item for item in mcp_toolkits.get_mcp_tools() if item.card.name == "mcp_paid_search")
+    response = MagicMock()
+    response.json.return_value = {
+        "summary": "answer", "webPages": {"value": [{"url": "https://example.invalid/result"}]},
+        "choices": [{"message": {"content": "answer https://example.invalid/result"}}],
+        "citations": ["https://example.invalid/result"],
+        "organic": [{"link": "https://example.invalid/result"}],
+    }
+    request = MagicMock(return_value=response)
+    monkeypatch.setattr(search_tools, "_http_request", request)
+    for key in ("first-test-key", "rotated-test-key"):
+        monkeypatch.setenv(key_name, key)
+        result = await tool.invoke({"query": "test", "provider": provider})
+        assert f"Paid search provider: {provider}" in result
+        assert "https://example.invalid/result" in result
+        headers = request.call_args.kwargs["headers"]
+        if provider == "serper":
+            assert headers["X-API-KEY"] == key
+        else:
+            assert headers["Authorization"] == f"Bearer {key}"
+    assert request.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["auto", "serper"])
+async def test_mcp_dispatch_never_enters_unconfigured_runner(monkeypatch, provider):
+    monkeypatch.setenv("BOCHA_API_KEY", "test-key")
+    available = MagicMock(return_value={"answer": "answer", "urls": []})
+    unavailable = MagicMock(side_effect=AssertionError("Unconfigured provider was dispatched"))
+    monkeypatch.setattr(search_tools, "_bocha_search_sync", available)
+    for name in ("serper", "perplexity", "jina"):
+        monkeypatch.setattr(search_tools, f"_{name}_search_sync", unavailable)
+    used, answer, _ = await search_tools.run_paid_search_structured("test", provider=provider)
+    assert (used, answer) == ("bocha", "answer")
+    available.assert_called_once()
+    unavailable.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mcp_call_queued_before_key_change_uses_current_provider(monkeypatch):
+    monkeypatch.setenv("BOCHA_API_KEY", "test-key")
+    mcp_toolkits.get_mcp_tools()
+    monkeypatch.setenv("BOCHA_API_KEY", "")
+    monkeypatch.setenv("SERPER_API_KEY", "test-key")
+    mcp_toolkits.refresh_mcp_paid_search_tools()
+    available = MagicMock(return_value={"answer": "answer", "urls": []})
+    unavailable = MagicMock(side_effect=AssertionError("Removed provider was dispatched"))
+    monkeypatch.setattr(search_tools, "_serper_search_sync", available)
+    monkeypatch.setattr(search_tools, "_bocha_search_sync", unavailable)
+    result = await mcp_paid_search.invoke({"query": "test", "provider": "bocha"})
+    assert "Paid search provider: serper" in result
+    available.assert_called_once()
+    unavailable.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mcp_provider_filter_preserves_input_normalization_and_clamping(monkeypatch):
+    monkeypatch.setenv("BOCHA_API_KEY", "test-key")
+    mcp_toolkits.get_mcp_tools()
+    runner = MagicMock(return_value={"answer": "answer", "urls": []})
+    monkeypatch.setattr(search_tools, "_bocha_search_sync", runner)
+    result = await mcp_paid_search.invoke({
+        "query": " test ", "provider": " BOCHA ", "max_results": 99, "timeout_seconds": 1,
+    })
+    assert "Paid search provider: bocha" in result
+    runner.assert_called_once_with(query="test", max_results=20, timeout_seconds=10)
+
+
+@pytest.mark.asyncio
+async def test_mcp_no_keys_does_not_dispatch(monkeypatch):
+    runner = MagicMock(side_effect=AssertionError("No configured provider"))
+    for name in ("bocha", "perplexity", "serper", "jina"):
+        monkeypatch.setattr(search_tools, f"_{name}_search_sync", runner)
+    with pytest.raises(RuntimeError, match="no paid search API keys configured"):
+        await search_tools.run_paid_search_structured("test")
+    runner.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_mcp_agent_refreshes_model_tools_on_enable_change_and_disable(monkeypatch):
+    from openjiuwen.core.single_agent.ability_manager import AbilityManager
+
+    manager = AbilityManager()
+    mcp_toolkits.track_mcp_search_tools(manager)
+    resource_add = MagicMock()
+    monkeypatch.setattr(mcp_toolkits.Runner.resource_mgr, "add_tool", resource_add)
+    for provider in ("bocha", "serper"):
+        monkeypatch.setenv("BOCHA_API_KEY", "")
+        monkeypatch.setenv(f"{provider.upper()}_API_KEY", "test-key")
+        mcp_toolkits.refresh_mcp_paid_search_tools()
+        info = next(item for item in await manager.list_tool_info() if item.name == "mcp_paid_search")
+        assert info.parameters["properties"]["provider"]["enum"] == ["auto", provider]
+    monkeypatch.setenv("SERPER_API_KEY", "")
+    mcp_toolkits.refresh_mcp_paid_search_tools()
+    assert manager.get("mcp_paid_search") is None
+    assert not any(item.name == "mcp_paid_search" for item in await manager.list_tool_info())
+    assert resource_add.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scopes", [None, {"search"}])
+async def test_search_reload_updates_active_sessions_before_lazy_full_reload(scopes):
+    root = object.__new__(JiuWenSwarmDeepAdapter)
+    root._is_session_scoped_adapter = False
+    live = SimpleNamespace(_instance=object(), _sync_paid_search_tool_for_runtime=MagicMock())
+    idle = SimpleNamespace(_instance=None, _sync_paid_search_tool_for_runtime=MagicMock())
+    root._session_adapters = {"live": live, "idle": idle}
+    root._mark_session_adapters_stale_for_reload = MagicMock()
+    await root._fan_out_reload_to_session_adapters({}, {}, None, scopes)
+    live._sync_paid_search_tool_for_runtime.assert_called_once()
+    idle._sync_paid_search_tool_for_runtime.assert_not_called()
+    root._mark_session_adapters_stale_for_reload.assert_called_once_with({}, {}, scopes)

--- a/tests/unit_tests/gateway/test_app_web_handlers.py
+++ b/tests/unit_tests/gateway/test_app_web_handlers.py
@@ -1075,11 +1075,31 @@ async def test_config_save_handlers_respond_before_agent_reload_finishes(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_config_set_applies_scoped_reload_before_responding(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "params,keys,scopes",
+    [
+        ({"api_base": "https://example.com/one"}, {"API_BASE"}, ["model"]),
+        ({"bocha_api_key": "test-key"}, {"BOCHA_API_KEY"}, ["search"]),
+        ({"serper_api_key": ""}, {"SERPER_API_KEY"}, ["search"]),
+        (
+            {"bocha_api_key": "test-key", "vision_api_key": "test-vision-key"},
+            {"BOCHA_API_KEY", "VISION_API_KEY"},
+            ["multimodal", "search"],
+        ),
+    ],
+)
+async def test_config_set_applies_scoped_reload_before_responding(monkeypatch, tmp_path, params, keys, scopes):
     channel = FakeWebChannel()
     reload_started = asyncio.Event()
     release_first_reload = asyncio.Event()
     reload_calls: list[tuple[set[str], dict, dict]] = []
+
+    monkeypatch.setattr(
+        "jiuwenswarm.extensions.registry.ExtensionRegistry.get_instance",
+        lambda: SimpleNamespace(get_crypto_provider=lambda: None),
+    )
+    for key in keys:
+        monkeypatch.setenv(key, "")
 
     monkeypatch.setattr(
         "jiuwenswarm.gateway.channel_manager.web.app_web_handlers._ENV_FILE",
@@ -1106,19 +1126,20 @@ async def test_config_set_applies_scoped_reload_before_responding(monkeypatch, t
     task = asyncio.create_task(channel.methods["config.set"](
         object(),
         "req-1",
-        {"api_base": "https://example.com/one"},
+        params,
         "sess-1",
     ))
 
-    await asyncio.wait_for(reload_started.wait(), timeout=1)
-    assert channel.responses == []
+    try:
+        await asyncio.wait_for(reload_started.wait(), timeout=1)
+        assert channel.responses == []
+    finally:
+        release_first_reload.set()
+        await task
 
-    release_first_reload.set()
-    await task
-
-    assert reload_calls[0][0] == {"API_BASE"}
+    assert reload_calls[0][0] == keys
     assert reload_calls[0][2]["target_channel_id"] == "web"
-    assert reload_calls[0][2]["reload_scopes"] == ["model"]
+    assert reload_calls[0][2]["reload_scopes"] == scopes
     assert channel.responses[-1]["id"] == "req-1"
     assert channel.responses[-1]["ok"] is True
     assert channel.responses[-1]["payload"]["applied_without_restart"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -2679,7 +2679,7 @@ wheels = [
 [[package]]
 name = "openjiuwen"
 version = "0.1.17"
-source = { git = "https://gitcode.com/openJiuwen/agent-core.git?rev=0af325ebe9f891e53fa211dae3392a4aff9d923d#0af325ebe9f891e53fa211dae3392a4aff9d923d" }
+source = { git = "https://gitcode.com/openJiuwen/agent-core.git?rev=14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5#14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
@@ -5565,11 +5565,11 @@ requires-dist = [
     { name = "mutagen", specifier = ">=1.47.0,<2" },
     { name = "mutagen", marker = "extra == 'harmony'", specifier = ">=1.47.0" },
     { name = "numpy", specifier = ">=1.24.0,<3" },
-    { name = "openjiuwen", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=0af325ebe9f891e53fa211dae3392a4aff9d923d" },
-    { name = "openjiuwen", marker = "extra == 'harmony'", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=0af325ebe9f891e53fa211dae3392a4aff9d923d" },
-    { name = "openjiuwen", extras = ["claude"], marker = "extra == 'claude'", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=0af325ebe9f891e53fa211dae3392a4aff9d923d" },
-    { name = "openjiuwen", extras = ["codex"], marker = "extra == 'codex'", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=0af325ebe9f891e53fa211dae3392a4aff9d923d" },
-    { name = "openjiuwen", extras = ["postgres", "zmq"], marker = "extra == 'distribute'", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=0af325ebe9f891e53fa211dae3392a4aff9d923d" },
+    { name = "openjiuwen", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5" },
+    { name = "openjiuwen", marker = "extra == 'harmony'", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5" },
+    { name = "openjiuwen", extras = ["claude"], marker = "extra == 'claude'", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5" },
+    { name = "openjiuwen", extras = ["codex"], marker = "extra == 'codex'", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5" },
+    { name = "openjiuwen", extras = ["postgres", "zmq"], marker = "extra == 'distribute'", git = "https://gitcode.com/openJiuwen/agent-core.git?rev=14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5" },
     { name = "opentelemetry-api", specifier = ">=1.28.0,<2" },
     { name = "opentelemetry-api", marker = "extra == 'harmony'", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.28.0,<2" },


### PR DESCRIPTION
Paired: [GitHub #5446](https://github.com/openJiuwen-ai/jiuwenswarm/pull/5446) ↔ [GitCode !6404](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/6404)

Expose only configured providers to models and guard stale selections before MCP validation. Reload search tools across channels and active sessions, reconcile MCP registration, and preserve existing input normalization.

Add offline lifecycle and HTTP request regression coverage. The [SDK paid-search fix](https://github.com/openJiuwen-ai/agent-core/pull/1253) has now merged into official develop. Pin openjiuwen to official `openJiuwen/agent-core` revision `14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5`, with all pip/Harmony/uv declarations aligned.

## Conflict Resolution and Verification (2026-09-09)

- Rebased the original single fix commit onto official develop `bb88019c636eda727eb335901fe49cae3e0c2506`; no merge commit added.
- Preserve upstream video/visual generation hot-reload groups and this PR's paid-search metadata invalidation as separate methods.
- Regenerate `uv.lock` with the merged official SDK; no unrelated dependency upgrades.
- Add a regression test that enables and disables video/visual generation groups after the conflict resolution.
- Update the old CI PowerShell test's expected rule ID to the SDK's higher-priority built-in delete rule; the assertion requiring `PermissionLevel.ASK` is unchanged. No permission policy was relaxed.
- Test the actual SDK installed from its pinned official Git URL in an isolated directory, not the local editable SDK: **210 passed** across paid search, reload fan-out/scopes, trusted MCP adapters, gateway settings, multimodal reload, code spec reload and the former CI failure.
- `uv lock --check --offline` and `git diff --check`: passed. Ruff comparison against the official base: **0 new findings** (75 existing full-file findings on both sides).
- Latest head: `b09db100e6d5f9eb115d8c647b46977557eb1c80`. Remote CI must rerun for this head; previous-head results are not final verification.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind bug


**What does this PR do / why do we need it**:
* Need to describe clearly


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #5142 


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Need to describe clearly


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [x] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #5142
<!-- /bot1-related-issues -->
