### PR TITLE
test: use the pinned openjiuwen instead of sibling checkouts

### DIFF
--- a/tests/unit_tests/agentserver/test_deep_adapter_empty_run_guard.py
+++ b/tests/unit_tests/agentserver/test_deep_adapter_empty_run_guard.py
@@ -10,17 +10,8 @@ flagged.
 """
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
-from pathlib import Path
-import sys
 
 import pytest
-
-# The installed openjiuwen editable install may point at an older checkout;
-# prefer the checked-out agent-core next to this repo (same trick as
-# test_goal_runtime_adapter.py).
-_AGENT_CORE_ROOT = Path(__file__).resolve().parents[4] / "agent-core"
-if _AGENT_CORE_ROOT.is_dir() and str(_AGENT_CORE_ROOT) not in sys.path:
-    sys.path.insert(0, str(_AGENT_CORE_ROOT))
 
 from jiuwenswarm.common.schema.agent import AgentRequest
 from jiuwenswarm.server.runtime.agent_adapter.interface_deep import JiuWenSwarmDeepAdapter

--- a/tests/unit_tests/agentserver/test_goal_runtime_adapter.py
+++ b/tests/unit_tests/agentserver/test_goal_runtime_adapter.py
@@ -1,17 +1,9 @@
 """Tests for the Goal capability adapter used by JiuwenSwarm."""
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
-# Goal capability tests exercise the checked-out OpenJiuwen implementation,
-# not whichever released package happens to be installed in the test venv.
-_AGENT_CORE_ROOT = Path(__file__).resolve().parents[3].parent / "agent-core"
-if str(_AGENT_CORE_ROOT) not in sys.path:
-    sys.path.insert(0, str(_AGENT_CORE_ROOT))
 
 from openjiuwen.core.session.stream import OutputSchema
 from openjiuwen.harness.goal.schema import GoalOperationError, GoalRecord, GoalStatus

--- a/tests/unit_tests/test_dependency_provenance.py
+++ b/tests/unit_tests/test_dependency_provenance.py
@@ -1,0 +1,286 @@
+"""The tests must run against the dependency this project ships against.
+
+Both guards here exist because of one line that lived in
+``tests/unit_tests/agentserver/test_goal_runtime_adapter.py`` for seven weeks: it
+prepended a sibling ``../agent-core`` source checkout to ``sys.path`` at import
+time, so that a Goal surface not yet in the pinned release could be tested.
+
+It cost more than it bought. ``sys.path`` is process-wide and the entry outlives
+the module that added it; an interpreter started with multiprocessing's *spawn*
+start method inherits ``sys.path`` but not ``sys.modules``, so the child resolves
+every import from scratch and reaches the checkout first. A checkout older than
+the pin then kills the child during import, and the failure surfaces in whatever
+unrelated test spawned it -- as an order-dependent failure that passes when run
+alone. It also never achieved its own purpose: in a full run the package is
+already bound to site-packages before that module is collected.
+
+The rule these guards encode: a test may not silently substitute a different
+build of a dependency. Testing against something other than the pin is a
+decision that belongs in ``pyproject.toml``, where it is reviewed.
+"""
+
+from __future__ import annotations
+
+import ast
+import sysconfig
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / "tests"
+
+# The rule, and why it is a shape rather than a list of blessed files: an
+# expression built only out of ``__file__`` and its ancestors can be evaluated
+# without executing test code. Two files use that form today to import this
+# repository from source. The check resolves the expression for the file where
+# it occurs and accepts it only if the result remains inside ``_REPO_ROOT``.
+# This is a literal ``sys.path`` hygiene check, not an attempt to recognize every
+# alias or deliberately obscured mutation. Unsupported expressions fail closed;
+# ``/`` joins are accepted only when the complete resolved path stays in the repo.
+
+
+def test_the_openjiuwen_under_test_is_the_installed_one() -> None:
+    """The property the pin exists to give: what the tests import is what ships.
+
+    Asserted on the package rather than on ``sys.path`` because that is the fact
+    that matters -- a stray entry is harmless until something resolves through it.
+    """
+    import openjiuwen
+
+    origin = Path(openjiuwen.__file__).resolve()
+    installed_roots = {
+        Path(p).resolve()
+        for p in (
+            sysconfig.get_paths().get("purelib"),
+            sysconfig.get_paths().get("platlib"),
+        )
+        if p
+    }
+    assert any(root in origin.parents for root in installed_roots), (
+        f"openjiuwen resolved to {origin}, outside the installed environment "
+        f"{sorted(installed_roots)}. Something put another build ahead of the "
+        "pinned release; testing against it makes a green run meaningless. "
+        "If openjiuwen was deliberately installed editable (for example, "
+        "`uv pip install -e ../agent-core`), restore the project pin with "
+        "`uv sync` before running or pushing these tests."
+    )
+
+
+def _is_literal_sys_path(node: ast.AST) -> bool:
+    """Return whether *node* is the literal expression ``sys.path``."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "path"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "sys"
+    )
+
+
+def _is_literal_sys_path_target(node: ast.AST) -> bool:
+    """Also recognize writes through an index or slice of ``sys.path``."""
+    return _is_literal_sys_path(node.value if isinstance(node, ast.Subscript) else node)
+
+
+def _sys_path_writes(tree: ast.AST) -> list[ast.AST]:
+    """Find direct calls, rebindings and item/slice writes to literal ``sys.path``."""
+    found: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("insert", "append", "extend")
+            and _is_literal_sys_path(node.func.value)
+        ):
+            found.append(node)
+            continue
+        if isinstance(node, ast.Assign) and any(
+            _is_literal_sys_path_target(target) for target in node.targets
+        ):
+            found.append(node)
+            continue
+        if isinstance(
+            node, (ast.AnnAssign, ast.AugAssign)
+        ) and _is_literal_sys_path_target(node.target):
+            found.append(node)
+    return sorted(found, key=lambda node: node.lineno)
+
+
+def _sys_path_call_arguments(call: ast.Call) -> list[ast.AST] | None:
+    """Return path expressions for a supported call, or ``None`` if ambiguous."""
+    if call.keywords or not isinstance(call.func, ast.Attribute):
+        return None
+    method = call.func.attr
+    if method == "insert" and len(call.args) == 2:
+        return [call.args[1]]
+    if method == "append" and len(call.args) == 1:
+        return [call.args[0]]
+    if method == "extend" and len(call.args) == 1:
+        values = call.args[0]
+        if isinstance(values, (ast.List, ast.Tuple, ast.Set)):
+            return list(values.elts)
+    return None
+
+
+def _evaluate_local_path(node: ast.AST, source_path: Path) -> Path | str:
+    """Evaluate the small path-expression subset allowed in ``sys.path`` writes."""
+    if isinstance(node, ast.Name) and node.id == "__file__":
+        return source_path
+
+    if isinstance(node, ast.Call):
+        if node.keywords:
+            raise ValueError("unsupported call")
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id in ("Path", "str")
+            and len(node.args) == 1
+        ):
+            value = _evaluate_local_path(node.args[0], source_path)
+            return Path(value) if node.func.id == "Path" else str(value)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "resolve"
+            and not node.args
+        ):
+            return Path(_evaluate_local_path(node.func.value, source_path)).resolve()
+        raise ValueError("unsupported call")
+
+    if isinstance(node, ast.Attribute) and node.attr == "parent":
+        return Path(_evaluate_local_path(node.value, source_path)).parent
+
+    if (
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Div)
+        and isinstance(node.right, ast.Constant)
+        and isinstance(node.right.value, str)
+    ):
+        return Path(_evaluate_local_path(node.left, source_path)) / node.right.value
+
+    if isinstance(node, ast.Subscript):
+        value = node.value
+        index = node.slice
+        if (
+            isinstance(value, ast.Attribute)
+            and value.attr == "parents"
+            and isinstance(index, ast.Constant)
+            and isinstance(index.value, int)
+            and index.value >= 0
+        ):
+            base = Path(_evaluate_local_path(value.value, source_path))
+            return base.parents[index.value]
+
+    raise ValueError("unsupported path expression")
+
+
+def _names_a_path_inside_repo(node: ast.AST, source_path: Path) -> bool:
+    """Return whether a restricted path expression resolves inside this repo."""
+    return _path_location(node, source_path) == "inside"
+
+
+def _path_location(node: ast.AST, source_path: Path) -> str:
+    """Classify a path expression for actionable failure messages."""
+    try:
+        candidate = Path(_evaluate_local_path(node, source_path)).resolve()
+    except (IndexError, TypeError, ValueError):
+        return "unsupported"
+    if candidate == _REPO_ROOT or _REPO_ROOT in candidate.parents:
+        return "inside"
+    return "outside"
+
+
+def test_sys_path_write_scanner_covers_direct_mutation_forms() -> None:
+    tree = ast.parse(
+        """
+sys.path.insert(0, candidate)
+sys.path.append(candidate)
+sys.path.extend([candidate])
+sys.path = [candidate] + sys.path
+sys.path[:0] = [candidate]
+sys.path += [candidate]
+"""
+    )
+    assert [node.lineno for node in _sys_path_writes(tree)] == [2, 3, 4, 5, 6, 7]
+
+
+def test_local_path_evaluator_accepts_only_resolved_repo_paths() -> None:
+    source_path = _TESTS_ROOT / "unit_tests" / "example.py"
+    inside = ast.parse('Path(__file__).resolve().parents[2] / "src"', mode="eval").body
+    outside = ast.parse(
+        'Path(__file__).resolve().parents[3] / "agent-core"', mode="eval"
+    ).body
+    assert _names_a_path_inside_repo(inside, source_path)
+    assert not _names_a_path_inside_repo(outside, source_path)
+    assert _path_location(inside, source_path) == "inside"
+    assert _path_location(outside, source_path) == "outside"
+    assert _path_location(ast.Name(id="candidate"), source_path) == "unsupported"
+
+
+def test_extend_arguments_are_checked_individually() -> None:
+    tree = ast.parse(
+        "sys.path.extend([str(Path(__file__).resolve().parents[2]), "
+        'str(Path(__file__).resolve().parents[2] / "src")])'
+    )
+    call = _sys_path_writes(tree)[0]
+    assert isinstance(call, ast.Call)
+    arguments = _sys_path_call_arguments(call)
+    assert arguments is not None
+    source_path = _TESTS_ROOT / "unit_tests" / "example.py"
+    assert all(_names_a_path_inside_repo(arg, source_path) for arg in arguments)
+
+
+def test_no_test_module_puts_another_build_on_sys_path() -> None:
+    """Caught where it is written, not where it detonates.
+
+    The runtime guard above only fires if the substituted package is the one that
+    wins the import race, and the spawn failure it caused fired in a file that had
+    nothing to do with the cause. A static check names the line.
+    """
+    outside_repo: list[str] = []
+    unsupported: list[str] = []
+    for path in sorted(_TESTS_ROOT.rglob("*.py")):
+        relative = path.relative_to(_TESTS_ROOT)
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:  # not this guard's business
+            continue
+        if "sys.path" not in source:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:  # syntax validation belongs to Python/pytest
+            continue
+        for write in _sys_path_writes(tree):
+            location = f"{relative}:{write.lineno}"
+            if not isinstance(write, ast.Call):
+                unsupported.append(location)
+                continue
+            arguments = _sys_path_call_arguments(write)
+            if arguments is None:
+                unsupported.append(location)
+                continue
+            locations = {_path_location(argument, path) for argument in arguments}
+            if locations <= {"inside"}:
+                continue
+            if "outside" in locations:
+                outside_repo.append(location)
+            else:
+                unsupported.append(location)
+
+    failures: list[str] = []
+    if outside_repo:
+        failures.append(
+            "these test modules put paths outside the repository on sys.path: "
+            + ", ".join(outside_repo)
+            + ". Change the dependency pin in pyproject.toml instead."
+        )
+    if unsupported:
+        failures.append(
+            "these test modules modify sys.path in a form this guard cannot "
+            "statically verify: "
+            + ", ".join(unsupported)
+            + ". Use a literal sys.path.insert/append/extend call with a "
+            "Path(__file__) expression that resolves inside the repository."
+        )
+    assert not failures, (
+        " ".join(failures)
+        + " sys.path is process-wide; a spawned child inherits it and resolves "
+        "imports from scratch."
+    )


### PR DESCRIPTION
Paired: [GitHub #5474](https://github.com/openJiuwen-ai/jiuwenswarm/pull/5474) ↔ [GitCode !6418](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/6418)

Fixes #5473.

Based on `upstream/develop` @ `3b00611e8`; commit `fbb54e0c7`.

## Problem

Two unit-test modules prepend a sibling `../agent-core` checkout to
`sys.path[0]` during collection:

- `tests/unit_tests/agentserver/test_goal_runtime_adapter.py`
- `tests/unit_tests/agentserver/test_deep_adapter_empty_run_guard.py`

That process-global entry leaks into interpreters created through
`multiprocessing.spawn`. A child inherits `sys.path` but imports its modules
afresh, so it can resolve `openjiuwen` from an arbitrary local checkout rather
than the revision pinned in `pyproject.toml`.

With an older sibling checkout, the child importing
`test_trace_store.py` dies because that checkout lacks
`openjiuwen.core.kv_cache`. The parent then times out waiting for the child's
`ready` event. Latest `develop` reproduces this deterministically when the
polluting modules are collected first; the same trace-store test passes alone.

The path substitutions also do not reliably achieve their stated purpose. If
the regular `openjiuwen` package is already imported, its `__path__` remains
bound to the installed package. If the checkout wins, the tests validate a tree
that JiuwenSwarm does not ship.

## Change

- Remove both sibling-checkout `sys.path` blocks.
- Import the required Goal surface directly from the pinned dependency. Import
  failures remain failures instead of silently changing the dependency under test.
- Add dependency-provenance regression guards:
  - the imported `openjiuwen` must resolve inside the installed environment;
  - direct test-side `sys.path` calls and assignments are rejected unless a
    supported path expression provably resolves inside this repository.

The repository-boundary check evaluates the expression for the source file
instead of assuming that every `parents[n]` remains inside the repository. It
supports common in-repo `/ "child"` joins and `extend([...])`, gives distinct
diagnostics for external and unsupported expressions, and scans only files that
contain the literal `sys.path`. Its own focused tests cover these rules. A test
environment that deliberately installs `openjiuwen` editable still fails the
provenance invariant, with an actionable `uv sync` recovery hint.

```text
 tests/unit_tests/agentserver/test_deep_adapter_empty_run_guard.py |   9 --
 tests/unit_tests/agentserver/test_goal_runtime_adapter.py         |   8 --
 tests/unit_tests/test_dependency_provenance.py                    | 286 +++++++++++++++++++++
 3 files changed, 286 insertions(+), 17 deletions(-)
```

The current pinned dependency is:

```
openjiuwen @ git+https://gitcode.com/openJiuwen/agent-core.git@14a7fe2d0a2bf0cf2a25abd90f05f5ae6a9bf2d5
```

## Testing

Python 3.11.16, Linux, `openjiuwen 0.1.17`.

Targeted before/after command:

```bash
python -m pytest -p no:cacheprovider --no-cov \
  tests/unit_tests/agentserver/test_goal_runtime_adapter.py \
  tests/unit_tests/agentserver/test_deep_adapter_empty_run_guard.py \
  tests/unit_tests/observability/test_trace_store.py::test_gateway_reader_sees_committed_wal_from_writer_process
```

| | latest `develop` @ `3b00611e8` | this commit |
|---|---:|---:|
| collected | 42 | 42 |
| Goal adapter | 37 passed | 37 passed |
| empty-run guard | 4 passed | 4 passed |
| spawned WAL reader | failed | passed |
| summary | 1 failed, 41 passed | 42 passed |
| duration | 17.21s | 6.93s |

Additional checks:

```text
pytest tests/unit_tests/test_dependency_provenance.py -q
5 passed in 0.07s

ruff check <three changed test files>
All checks passed!

pytest tests/unit_tests/agentserver tests/unit_tests/observability \
  tests/unit_tests/test_dependency_provenance.py
4200 passed, 3 skipped in 101.80s
```

The targeted command is the controlled comparison: same interpreter, pinned
dependency, sibling checkout, test selection and collection order; only the
patch differs.

## Screenshots

### Before — latest upstream

![before](https://raw.githubusercontent.com/agtai/jiuwenswarm/issue-assets-syspath-pollution/2026-09-07-syspath-before.png)

### After — fixed branch

![after](https://raw.githubusercontent.com/agtai/jiuwenswarm/issue-assets-syspath-pollution/2026-09-07-syspath-after.png)

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #5473
<!-- /bot1-related-issues -->
