### PR TITLE
fix(cron): resolve environment model names before storing

### DIFF
--- a/jiuwenswarm/runtime/cron/models.py
+++ b/jiuwenswarm/runtime/cron/models.py
@@ -209,7 +209,9 @@ def validate_cron_model(raw: Any) -> str | None:
     """Validate model name/alias against configured models. Returns canonical model_name or raises.
 
     If the input is an alias, resolves to the underlying ``model_client_config.model_name``
-    so the stored value is always a key AgentServer ``_model_cache`` can look up.
+    (including environment placeholders) so the stored value is always a key
+    AgentServer ``_model_cache`` can look up. An explicitly configured name that
+    resolves to empty is rejected instead of being persisted.
 
     Opencode Zen free models are in-memory only, so a configured-model miss
     also checks the live free-model cache.  A cache failure never blocks the
@@ -220,13 +222,26 @@ def validate_cron_model(raw: Any) -> str | None:
     value = str(raw).strip()
     if not value:
         return None
-    from jiuwenswarm.common.config import get_model_config, get_model_names
+    from jiuwenswarm.common.config import (
+        get_model_config,
+        get_model_names,
+        resolve_env_vars,
+    )
 
     entry = get_model_config(value)
     if entry is not None:
         mcc = entry.get("model_client_config") or {}
-        canonical = (mcc.get("model_name") or "").strip()
-        return canonical if canonical else value
+        configured_name = mcc.get("model_name")
+        if not configured_name:
+            return value
+        canonical = str(resolve_env_vars(configured_name) or "").strip()
+        if not canonical:
+            raise ValueError(
+                f"Configured model {value!r} has a model_client_config.model_name "
+                f"that resolves to an empty value ({configured_name!r}). Set the "
+                "referenced environment variable or configure a concrete model_name."
+            )
+        return canonical
 
     try:
         from jiuwenswarm.server.runtime.opencode_zen import (

--- a/tests/unit_tests/gateway/test_cron_model_validation.py
+++ b/tests/unit_tests/gateway/test_cron_model_validation.py
@@ -37,7 +37,22 @@ def _user_model_entry() -> dict:
     }
 
 
-def _zen_free_entry(model_id: str = "deepseek-v4-flash-free", alias: str = "DeepSeek V4 Flash") -> dict:
+def _environment_model_entry(model_name: str = "${MODEL_NAME}") -> dict:
+    return {
+        "model_client_config": {
+            "api_base": "${API_BASE}",
+            "api_key": "${API_KEY}",
+            "model_name": model_name,
+            "client_provider": "${MODEL_PROVIDER}",
+        },
+        "is_default": True,
+        "alias": "默认模型",
+    }
+
+
+def _zen_free_entry(
+    model_id: str = "deepseek-v4-flash-free", alias: str = "DeepSeek V4 Flash"
+) -> dict:
     return {
         "model_client_config": {
             "api_base": "https://opencode.ai/zen/v1",
@@ -56,7 +71,9 @@ def test_validate_cron_model_none_or_empty(monkeypatch: pytest.MonkeyPatch) -> N
     assert validate_cron_model("   ") is None
 
 
-def test_validate_cron_model_resolves_user_model(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validate_cron_model_resolves_user_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def fake_get_model_config(name: str, index: int | None = None) -> dict | None:
         # 模拟 config.py 的真实语义：model_name 或 alias 命中都返回条目
         if name in ("my-model", "我的模型"):
@@ -67,10 +84,73 @@ def test_validate_cron_model_resolves_user_model(monkeypatch: pytest.MonkeyPatch
         "jiuwenswarm.common.config.get_model_config",
         fake_get_model_config,
     )
-    monkeypatch.setattr("jiuwenswarm.common.config.get_model_names", lambda: ["我的模型"])
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_model_names", lambda: ["我的模型"]
+    )
     assert validate_cron_model("my-model") == "my-model"
     # alias 也解析为 canonical model_name
     assert validate_cron_model("我的模型") == "my-model"
+
+
+def test_validate_cron_model_resolves_environment_model_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_NAME", "deployed-model")
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config_raw",
+        lambda: {"models": {"defaults": [_environment_model_entry()]}},
+    )
+
+    assert validate_cron_model("deployed-model") == "deployed-model"
+    assert validate_cron_model("默认模型") == "deployed-model"
+
+
+def test_validate_cron_model_uses_environment_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MODEL_NAME", raising=False)
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config_raw",
+        lambda: {
+            "models": {
+                "defaults": [_environment_model_entry("${MODEL_NAME:-fallback-model}")]
+            }
+        },
+    )
+
+    assert validate_cron_model("fallback-model") == "fallback-model"
+    assert validate_cron_model("默认模型") == "fallback-model"
+
+
+def test_validate_cron_model_rejects_empty_environment_model_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MODEL_NAME", raising=False)
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config_raw",
+        lambda: {"models": {"defaults": [_environment_model_entry()]}},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Configured model '默认模型'.*resolves to an empty value.*MODEL_NAME",
+    ):
+        validate_cron_model("默认模型")
+
+
+def test_validate_cron_model_rejects_whitespace_only_model_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_config_raw",
+        lambda: {"models": {"defaults": [_environment_model_entry("   ")]}},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Configured model '默认模型'.*resolves to an empty value",
+    ):
+        validate_cron_model("默认模型")
 
 
 def test_validate_cron_model_accepts_zen_free_model_id(


### PR DESCRIPTION
Paired: [GitHub #5490](https://github.com/openJiuwen-ai/jiuwenswarm/pull/5490) ↔ [GitCode !6429](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/6429)

Fixes #5489.

Based on `upstream/develop` @ `3b00611e8`; head `4444228c`.

## Problem

`validate_cron_model()` resolves an input name or alias through
`get_model_config()`, but previously returned the matched entry's raw
`model_client_config.model_name`. For the shipped configuration shape, that raw
value can be `${MODEL_NAME}`.

The cron create/update paths then store the placeholder even though AgentServer
builds its model cache from resolved configuration. The write succeeds and the
failure appears later at dispatch, when `${MODEL_NAME}` cannot be found as a
cache key.

The validator is shared by the gateway cron controller, agent cron tools, and
session-model inheritance, so the fix belongs at this boundary rather than in an
individual caller.

## Change

- Resolve a matched entry's configured `model_name` with `resolve_env_vars()`
  before returning it.
- Raise an actionable `ValueError` when an explicitly configured name resolves
  to empty, preventing an invalid pin from being persisted.
- Preserve the existing compatibility fallback when a matched entry has no
  `model_name` field.
- Add regression coverage using the shipped environment-placeholder shape,
  including alias lookup, environment defaults, unset variables, and a
  whitespace-only configured name.

## Behavior

| configured `model_name` | environment | result |
|---|---|---|
| `my-model` | n/a | `my-model` |
| `${MODEL_NAME}` | `MODEL_NAME=deployed-model` | `deployed-model` |
| `${MODEL_NAME:-fallback-model}` | unset | `fallback-model` |
| `${MODEL_NAME}` | unset | actionable `ValueError` |
| `"   "` | n/a | actionable `ValueError` (upstream fell back to the input value) |

## Before — latest upstream

With the shipped `${MODEL_NAME}` config shape, alias `default-model`, and
`MODEL_NAME=deployed-model`, upstream stores a key that the resolved AgentServer
cache cannot contain:

```text
[BEFORE] upstream/develop @ 3b00611e8
configured model_name : ${MODEL_NAME}
MODEL_NAME            : deployed-model
validator stored      : '${MODEL_NAME}'
AgentServer cache key : 'deployed-model'
dispatch lookup       : False
Traceback (most recent call last):
  File "<string>", line 15, in <module>
RuntimeError: dispatch cannot resolve model key '${MODEL_NAME}'
```

![before: placeholder is stored and dispatch cannot resolve it](https://raw.githubusercontent.com/agtai/jiuwenswarm/issue-assets-cron-model-env-resolution/docs/assets/images/cron/2026-09-09-cron-model-before.png)

## After — this fix

The same reproduction now stores the resolved cache key and dispatch succeeds:

```text
[AFTER] fix commit @ 9c7a13d00
configured model_name : ${MODEL_NAME}
MODEL_NAME            : deployed-model
validator stored      : 'deployed-model'
AgentServer cache key : 'deployed-model'
dispatch lookup       : True
PASS: stored name resolves to the live cache key
```

With `MODEL_NAME` unset, validation now fails before persistence:

```text
[AFTER: UNSET VARIABLE GUARD]
configured model_name : ${MODEL_NAME}
MODEL_NAME            : <unset>
rejected before write : ValueError
Configured model 'default-model' has a model_client_config.model_name that
resolves to an empty value ('${MODEL_NAME}'). Set the referenced environment
variable or configure a concrete model_name.
PASS: invalid placeholder was not persisted
```

![after: resolved cache key and fail-fast guard](https://raw.githubusercontent.com/agtai/jiuwenswarm/issue-assets-cron-model-env-resolution/docs/assets/images/cron/2026-09-09-cron-model-after.png)

## Diff

```text
 jiuwenswarm/runtime/cron/models.py                 | 23 +++++-
 tests/unit_tests/gateway/test_cron_model_validation.py | 86 +++++++++++++++++++++-
 2 files changed, 102 insertions(+), 7 deletions(-)
```

## Testing

Focused validator suite:

```text
10 passed
```

Validator plus gateway controller create/update, project binding, and session
model inheritance coverage:

```text
24 passed in 3.86s
```

Static checks:

```text
ruff check <changed files>
All checks passed!

ruff format --check <changed files>
2 files already formatted

git diff --check
clean
```

## Compatibility and risk

- No storage schema or API shape changes.
- Literal names and aliases still resolve as before.
- A missing `model_name` key or the empty string `""` retains the prior `value`
  fallback.
- A whitespace-only value such as `"   "` now raises instead of falling back to
  the input value. This is intentional: it is an explicitly configured but blank
  canonical name and cannot be a valid cache key.
- An explicit environment-backed name that resolves to empty becomes a
  synchronous validation error; persisting that value previously guaranteed a
  later lookup failure.
- `ValueError` is already the validator's failure type for an unknown model, so
  this introduces no new exception class at the three gateway controller call
  sites. It moves a guaranteed dispatch-time failure into the validation
  boundary that attempted the write, where the configuration error is
  actionable.
- The existing Opencode Zen free-model fallback is unchanged.

The patch is intentionally confined to the shared validator and focused tests;
it does not modify model-cache construction or add caller-specific workarounds.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #5489
<!-- /bot1-related-issues -->
