### PR TITLE
docs: clarify Windows exe vs pip CLI entry points

### DIFF
--- a/docs/en/InstallGuide.md
+++ b/docs/en/InstallGuide.md
@@ -55,6 +55,8 @@ curl -L --fail -o JiuwenSwarm-<version>.dmg \
 
 On first launch the app creates `~/.jiuwenswarm/`. Then follow [Post-start verification](#3-post-start-verification) to finish model configuration.
 
+> ⚠️ **Desktop-installer users should not run `jiuwenswarm-init` / `jiuwenswarm-start`:** those CLI entry points belong to [Option 2: pip install](#option-2-pip-install). After installing the `.exe` / `.dmg`, start the app from the desktop shortcut or Start menu (the Windows installer already initializes the workspace). Running those commands in a terminal will fail with “not recognized as an internal or external command”.
+
 > Match the version to the actual download link on the Release page. For desktop auto-update behavior (Windows and macOS), see [Desktop auto-update design](WindowsAutoUpdateDesign.md).
 
 ---
@@ -129,6 +131,8 @@ pip install jiuwenswarm==0.2.4b3
 ```
 
 #### 2. First launch
+
+> Applies to **pip / source installs only**. If you installed via the desktop `.exe` / `.dmg`, go back to [Option 1](#option-1-desktop-installer-dmg--exe) and launch from the GUI.
 
 ```bash
 # Initialize JiuwenSwarm (first run)

--- a/docs/zh/安装指南.md
+++ b/docs/zh/安装指南.md
@@ -55,6 +55,8 @@ curl -L --fail -o JiuwenSwarm-<version>.dmg \
 
 首次启动后，系统会创建配置目录 `~/.jiuwenswarm/`，之后请参考 [启动后验证](#3-启动后验证) 完成模型配置。
 
+> ⚠️ **桌面安装包用户请勿执行 `jiuwenswarm-init` / `jiuwenswarm-start`**：这两条命令属于下方 [方式二：pip 安装](#方式二pip-安装)，`.exe` / `.dmg` 安装后请通过桌面快捷方式或开始菜单启动应用（Windows 安装程序已自动初始化工作区）。在终端执行上述命令会报「不是内部或外部命令」。
+
 > 版本号以 Release 页面实际下载链接为准。Windows 与 macOS 桌面端的自动更新方案见 [桌面端自动更新设计](windows自动更新设计.md)。
 
 ---
@@ -129,6 +131,8 @@ pip install jiuwenswarm==0.2.4b3
 ```
 
 #### 2. 首次启动
+
+> 仅适用于 **pip / 源码安装**。若你使用的是桌面 `.exe` / `.dmg` 安装包，请回到 [方式一](#方式一桌面安装包dmg--exe) 通过 GUI 启动。
 
 ```bash
 # 初始化 JiuwenSwarm（首次启动）


### PR DESCRIPTION
Paired: [GitHub #5526](https://github.com/openJiuwen-ai/jiuwenswarm/pull/5526) ↔ [GitCode !6680](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/6680)

## Summary
- Document that desktop `.exe` / `.dmg` users must launch from the GUI — not `jiuwenswarm-init` / `jiuwenswarm-start`.
- Mark those CLI commands as **pip / source installs only** in EN + ZH install guides.

Fixes #4560

## Test plan
- [ ] Read Option 1 (desktop) warning in `docs/en/InstallGuide.md` and `docs/zh/安装指南.md`
- [ ] Confirm Option 2 “First launch” notes that CLI entry points are pip/source-only
- [ ] Anchors/links to Option 1 / Option 2 still resolve

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #4560
<!-- /bot1-related-issues -->
