### PR TITLE
fix(ask-user): nest options items inside anyOf for Gemini

### DIFF
--- a/jiuwenswarm/agents/harness/common/rails/ask_user_rail.py
+++ b/jiuwenswarm/agents/harness/common/rails/ask_user_rail.py
@@ -88,16 +88,41 @@ _QUESTIONS_ITEM_SCHEMA: dict[str, Any] = {
         },
         "options": {
             "description": "Available choices for this question (2-4 items).",
-            # Moonshot/Kimi 的 flavored JSON Schema 校验器要求：parent schema 里
-            # 不得同时存在 type 与 anyOf，type 必须写进 anyOf 的每个分支
-            # （报错 "type should be defined in anyOf items instead of the parent
-            # schema"）。语义不变：数组元素由 items 约束（object + required label），
-            # 数量由 anyOf 约束（0 个，或 2-4 个）。
+            # Moonshot/Kimi: parent must not mix type+anyOf; put type on each branch.
+            # Gemini/OpenRouter: each anyOf array branch must declare its own items
+            # (parent-level items is ignored / rejected as "items: missing field").
             "anyOf": [
-                {"type": "array", "maxItems": 0},
-                {"type": "array", "minItems": 2, "maxItems": 4},
-            ],
-            "items": {
+                {"type": "array", "maxItems": 0, "items": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Display text for this option (1-5 words).",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Explanation of what this option means.",
+                    },
+                    "preview": {
+                        "type": "string",
+                        "description": (
+                            "Optional preview content rendered beside this option when "
+                            "comparing concrete artifacts the user should visually compare "
+                            "(e.g. ASCII mockups, code snippets). Markdown is supported; "
+                            "use fenced code blocks for monospace mockups so alignment is "
+                            "preserved. Only rendered for single-select questions; ignored "
+                            "for multi-select."
+                        ),
+                    },
+                },
+                "required": ["label"],
+            }},
+                {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 4,
+                    "items": {
                 "type": "object",
                 "properties": {
                     "label": {
@@ -123,6 +148,8 @@ _QUESTIONS_ITEM_SCHEMA: dict[str, Any] = {
                 },
                 "required": ["label"],
             },
+                },
+            ],
         },
         "multi_select": {
             "type": "boolean",

--- a/tests/system_tests/test_structured_ask_user.py
+++ b/tests/system_tests/test_structured_ask_user.py
@@ -144,13 +144,15 @@ class TestStructuredAskUserToolSchema:
         options_schema = props["options"]
         # Moonshot/Kimi flavored schema：type 必须落在 anyOf 分支内，父级不得
         # 同置 type；数量约束（0 个或 2-4 个）由两个分支各自声明。
-        assert options_schema["anyOf"] == [
-            {"type": "array", "maxItems": 0},
-            {"type": "array", "minItems": 2, "maxItems": 4},
-        ]
-        option_schema = options_schema["items"]
-        assert option_schema["required"] == ["label"]
-        assert option_schema["properties"]["label"]["minLength"] == 1
+        assert "items" not in options_schema  # Gemini rejects parent-level items with anyOf
+        assert len(options_schema["anyOf"]) == 2
+        empty_branch, choice_branch = options_schema["anyOf"]
+        assert empty_branch["type"] == "array" and empty_branch["maxItems"] == 0
+        assert choice_branch["minItems"] == 2 and choice_branch["maxItems"] == 4
+        for branch in options_schema["anyOf"]:
+            option_schema = branch["items"]
+            assert option_schema["required"] == ["label"]
+            assert option_schema["properties"]["label"]["minLength"] == 1
 
     @staticmethod
     def test_tool_card_name_is_ask_user():


### PR DESCRIPTION
Paired: [GitHub #5528](https://github.com/openJiuwen-ai/jiuwenswarm/pull/5528) ↔ [GitCode !6681](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/6681)

## Summary
- Move `items` into each `anyOf` branch of `ask_user` `options` schema.
- Keeps Kimi-compatible anyOf (no parent `type`) while satisfying Gemini/OpenRouter which requires `items` on each array branch.

Fixes #5514

## Test plan
- [ ] `tests/system_tests/test_structured_ask_user.py` schema assertions pass
- [ ] Tool schema no longer has parent-level `options.items`
- [ ] Manual: Gemini via OpenRouter no longer returns `items: missing field` on ask_user

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #5514
<!-- /bot1-related-issues -->
