### PR TITLE
fix(cron): resolve env placeholders in validate_cron_model canonical name

### DIFF
--- a/jiuwenswarm/runtime/cron/models.py
+++ b/jiuwenswarm/runtime/cron/models.py
@@ -220,13 +220,26 @@ def validate_cron_model(raw: Any) -> str | None:
     value = str(raw).strip()
     if not value:
         return None
-    from jiuwenswarm.common.config import get_model_config, get_model_names
+    from jiuwenswarm.common.config import (
+        get_model_config,
+        get_model_names,
+        resolve_env_vars,
+    )
 
     entry = get_model_config(value)
     if entry is not None:
         mcc = entry.get("model_client_config") or {}
-        canonical = (mcc.get("model_name") or "").strip()
-        return canonical if canonical else value
+        configured_name = mcc.get("model_name")
+        if not configured_name:
+            return value
+        canonical = str(resolve_env_vars(configured_name) or "").strip()
+        if not canonical:
+            raise ValueError(
+                f"Configured model {value!r} has a model_client_config.model_name "
+                f"that resolves to an empty value ({configured_name!r}). Set the "
+                "referenced environment variable or configure a concrete model_name."
+            )
+        return canonical
 
     try:
         from jiuwenswarm.server.runtime.opencode_zen import (

--- a/tests/unit_tests/gateway/test_cron_model_validation.py
+++ b/tests/unit_tests/gateway/test_cron_model_validation.py
@@ -73,6 +73,85 @@ def test_validate_cron_model_resolves_user_model(monkeypatch: pytest.MonkeyPatch
     assert validate_cron_model("我的模型") == "my-model"
 
 
+def _shipped_env_entry() -> dict:
+    """Mirror the shipped config shape: model_name via a ${MODEL_NAME} placeholder."""
+    return {
+        "model_client_config": {
+            "api_base": "https://api.example.com/v1",
+            "api_key": "sk-test",
+            "model_name": "${MODEL_NAME}",
+            "client_provider": "OpenAI",
+        },
+        "is_default": True,
+        "alias": "default-model",
+    }
+
+
+def _patch_shipped_env_config(monkeypatch: pytest.MonkeyPatch, entry: dict) -> None:
+    """Fake get_model_config with the real matching semantics (resolve-then-compare)."""
+    from jiuwenswarm.common.config import resolve_env_vars
+
+    def fake_get_model_config(name: str, index: int | None = None) -> dict | None:
+        mcc = entry.get("model_client_config") or {}
+        if resolve_env_vars(str(mcc.get("model_name") or "")) == name:
+            return entry
+        alias = entry.get("alias") or ""
+        if alias and resolve_env_vars(str(alias)) == name:
+            return entry
+        return None
+
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_model_config",
+        fake_get_model_config,
+    )
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.get_model_names", lambda: [entry.get("alias", "")]
+    )
+
+
+def test_validate_cron_model_resolves_env_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """${MODEL_NAME} entries must store the resolved cache key, not the placeholder."""
+    monkeypatch.setenv("MODEL_NAME", "deployed-model")
+    _patch_shipped_env_config(monkeypatch, _shipped_env_entry())
+    # Both the alias and the resolved name map to the live AgentServer cache key.
+    assert validate_cron_model("default-model") == "deployed-model"
+    assert validate_cron_model("deployed-model") == "deployed-model"
+
+
+def test_validate_cron_model_honors_env_default_syntax(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """${VAR:-default} falls back to the default when the variable is unset."""
+    monkeypatch.delenv("MODEL_NAME", raising=False)
+    entry = _shipped_env_entry()
+    entry["model_client_config"]["model_name"] = "${MODEL_NAME:-fallback-model}"
+    _patch_shipped_env_config(monkeypatch, entry)
+    assert validate_cron_model("default-model") == "fallback-model"
+
+
+def test_validate_cron_model_rejects_unset_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare placeholder resolving to empty must fail fast before persistence."""
+    monkeypatch.delenv("MODEL_NAME", raising=False)
+    _patch_shipped_env_config(monkeypatch, _shipped_env_entry())
+    with pytest.raises(ValueError, match="resolves to an empty value"):
+        validate_cron_model("default-model")
+
+
+def test_validate_cron_model_rejects_whitespace_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whitespace-only configured name is not a valid canonical cache key."""
+    entry = _shipped_env_entry()
+    entry["model_client_config"]["model_name"] = "   "
+    _patch_shipped_env_config(monkeypatch, entry)
+    with pytest.raises(ValueError, match="resolves to an empty value"):
+        validate_cron_model("default-model")
+
+
 def test_validate_cron_model_accepts_zen_free_model_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Paired: [GitHub #5537](https://github.com/openJiuwen-ai/jiuwenswarm/pull/5537) ↔ [GitCode !6524](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/6524)

Fixes #5489

## Root cause

`validate_cron_model()` promises to return the canonical model name that
AgentServer can use as a model-cache key, but it split lookup and return
semantics: `get_model_config()` matches the input against the
**environment-resolved** model name/alias, while the validator then returned
`model_client_config.model_name` **verbatim** from the raw entry. With the
shipped configuration shape (`model_name: ${MODEL_NAME}`), creating a cron job
by alias persisted the literal string `${MODEL_NAME}`. Creation succeeded, but
dispatch later failed to find that key in the resolved model cache — a
write-time defect surfacing as a dispatch-time failure.

## Changes

- `jiuwenswarm/runtime/cron/models.py:208-249` — `validate_cron_model()` now
  resolves the configured `model_client_config.model_name` with the existing
  `resolve_env_vars()` helper before returning it, so the stored value is the
  live AgentServer cache key. An explicitly configured name that resolves to
  empty (unset bare placeholder, whitespace-only) now raises an actionable
  `ValueError` before any caller can persist it. Missing/empty key keeps the
  previous compatibility fallback (`return value`); literal names, aliases,
  and the Opencode Zen path are unchanged.
- `tests/unit_tests/gateway/test_cron_model_validation.py:76-152` — four new
  regression tests using the shipped `${MODEL_NAME}` config shape: alias and
  resolved name both return the resolved canonical name; `${VAR:-default}`
  fallback honored; unset bare placeholder and whitespace-only names raise
  before persistence.

## Test evidence

- New tests mirror the issue's acceptance criteria one-to-one; existing
  literal-name / alias / Zen / unknown-model tests are untouched and keep
  passing by construction (their code paths are unchanged).
- Full `pytest` could not run locally: the pinned `openjiwen` dependency is
  git-hosted and uninstallable in this environment (offline `uv sync` timed
  out fetching it), and `jiuwenswarm.common.config` imports it transitively.
  Instead I ran a standalone harness executing the **real**
  `validate_cron_model` plus the **real** `resolve_env_vars` source with a
  stubbed config loader reproducing the real resolve-then-compare matching:
  11/11 checks passed (alias/name resolution, `:-` default, unset-reject,
  whitespace-reject, missing-key fallback, literals, None/blank, unknown).
- `py_compile` passes on both changed files.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #5489
<!-- /bot1-related-issues -->
