### PR TITLE
fix(tests): drop sibling agent-core sys.path shims, add dependency-provenance guards

### DIFF
--- a/tests/unit_tests/agentserver/test_deep_adapter_empty_run_guard.py
+++ b/tests/unit_tests/agentserver/test_deep_adapter_empty_run_guard.py
@@ -10,17 +10,8 @@ flagged.
 """
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
-from pathlib import Path
-import sys
 
 import pytest
-
-# The installed openjiuwen editable install may point at an older checkout;
-# prefer the checked-out agent-core next to this repo (same trick as
-# test_goal_runtime_adapter.py).
-_AGENT_CORE_ROOT = Path(__file__).resolve().parents[4] / "agent-core"
-if _AGENT_CORE_ROOT.is_dir() and str(_AGENT_CORE_ROOT) not in sys.path:
-    sys.path.insert(0, str(_AGENT_CORE_ROOT))
 
 from jiuwenswarm.common.schema.agent import AgentRequest
 from jiuwenswarm.server.runtime.agent_adapter.interface_deep import JiuWenSwarmDeepAdapter

--- a/tests/unit_tests/agentserver/test_goal_runtime_adapter.py
+++ b/tests/unit_tests/agentserver/test_goal_runtime_adapter.py
@@ -1,17 +1,9 @@
 """Tests for the Goal capability adapter used by JiuwenSwarm."""
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
-# Goal capability tests exercise the checked-out OpenJiuwen implementation,
-# not whichever released package happens to be installed in the test venv.
-_AGENT_CORE_ROOT = Path(__file__).resolve().parents[3].parent / "agent-core"
-if str(_AGENT_CORE_ROOT) not in sys.path:
-    sys.path.insert(0, str(_AGENT_CORE_ROOT))
 
 from openjiuwen.core.session.stream import OutputSchema
 from openjiuwen.harness.goal.schema import GoalOperationError, GoalRecord, GoalStatus

--- a/tests/unit_tests/test_dependency_provenance.py
+++ b/tests/unit_tests/test_dependency_provenance.py
@@ -1,0 +1,243 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Dependency-provenance guards (issue #5473).
+
+Two unit-test modules used to prepend a sibling ``agent-core`` checkout to
+``sys.path`` at import time. The entries outlived the importing module, and
+interpreters started through ``multiprocessing.spawn`` re-resolved
+``openjiuwen`` from that arbitrary checkout, breaking unrelated tests
+depending on collection order.
+
+Guards:
+
+1. The imported ``openjiuwen`` package must resolve to the installed
+   environment, never to a sibling source checkout.
+2. No test module may mutate ``sys.path`` with a path that does not provably
+   resolve inside this repository.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in (here.parent, *here.parents):
+        if (parent / "pyproject.toml").is_file():
+            return parent
+    raise AssertionError(f"cannot locate repository root from {__file__}")
+
+
+def test_openjiuwen_resolves_to_installed_environment() -> None:
+    """The pinned dependency wins; a sibling checkout must not shadow it."""
+    import openjiuwen
+
+    package_file = Path(getattr(openjiuwen, "__file__", "") or "")
+    assert package_file.suffix or package_file.name, "openjiuwen has no __file__"
+    resolved = package_file.resolve()
+    repo_root = _repo_root()
+    sibling_checkout = repo_root.parent / "agent-core"
+    assert sibling_checkout not in resolved.parents, (
+        f"openjiuwen resolves to sibling checkout {resolved}; "
+        "test another revision via an explicit pyproject.toml pin instead"
+    )
+    assert repo_root not in resolved.parents, (
+        f"openjiuwen resolves inside this repository ({resolved}); "
+        "tests must exercise the installed dependency"
+    )
+
+
+class _Unevaluatable(Exception):
+    """Raised when a path expression cannot be resolved statically."""
+
+
+def _eval_test_path(node: ast.AST, test_file: Path) -> Path:
+    """Statically evaluate a ``__file__``-rooted path expression.
+
+    Supports the shapes used for legitimate in-repo insertions:
+    ``Path(__file__)``, ``.resolve()``, ``.parent``, ``.parents[N]``,
+    ``/ "segment"`` and ``str(...)``. Anything else is rejected so a new
+    dynamic entry cannot slip past the guard unnoticed.
+    """
+    if isinstance(node, ast.Call):
+        func = node.func
+        if (
+            isinstance(func, ast.Name)
+            and func.id in {"str", "Path"}
+            and len(node.args) == 1
+            and not node.keywords
+        ):
+            return _eval_test_path(node.args[0], test_file)
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "resolve"
+            and not node.args
+            and not node.keywords
+        ):
+            return _eval_test_path(func.value, test_file).resolve()
+        raise _Unevaluatable(f"unsupported call: {ast.dump(node)}")
+    if isinstance(node, ast.Name):
+        if node.id == "__file__":
+            return test_file
+        raise _Unevaluatable(f"unsupported name: {node.id}")
+    if isinstance(node, ast.Attribute) and node.attr == "parent":
+        return _eval_test_path(node.value, test_file).parent
+    if (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "parents"
+    ):
+        index = node.slice
+        if isinstance(index, ast.Constant) and isinstance(index.value, int):
+            return _eval_test_path(node.value.value, test_file).parents[index.value]
+        raise _Unevaluatable(f"unsupported parents index: {ast.dump(node)}")
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        left = _eval_test_path(node.left, test_file)
+        right = node.right
+        if isinstance(right, ast.Constant) and isinstance(right.value, str):
+            return left / right.value
+        raise _Unevaluatable(f"unsupported path segment: {ast.dump(node)}")
+    raise _Unevaluatable(f"unsupported expression: {ast.dump(node)}")
+
+
+def _sys_path_mutations(tree: ast.AST) -> list[ast.AST]:
+    """Collect ``sys.path`` mutations where ``sys`` is the stdlib module."""
+    bound: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "sys":
+                    bound.add(alias.asname or "sys")
+        elif isinstance(node, ast.ImportFrom) and node.module == "sys":
+            bound.update(alias.asname or alias.name for alias in node.names)
+    if not bound:
+        return []
+    hits: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            receiver = node.func.value
+            if (
+                isinstance(receiver, ast.Attribute)
+                and receiver.attr == "path"
+                and isinstance(receiver.value, ast.Name)
+                and receiver.value.id in bound
+                and node.func.attr in {"insert", "append", "extend"}
+            ):
+                hits.append(node)
+        elif isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            targets = (
+                node.targets if isinstance(node, ast.Assign) else [node.target]
+            )
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and target.attr == "path"
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id in bound
+                ):
+                    hits.append(node)
+    return hits
+
+
+def _check_test_file(path: Path, repo_root: Path) -> list[str]:
+    """Return violation messages for out-of-repo ``sys.path`` mutations."""
+    violations: list[str] = []
+    try:
+        # utf-8-sig: some test modules carry a BOM.
+        tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+    except SyntaxError as exc:
+        return [f"{path.relative_to(repo_root)}: unparseable ({exc})"]
+    for node in _sys_path_mutations(tree):
+        lineno = getattr(node, "lineno", "?")
+        where = f"{path.relative_to(repo_root)}:{lineno}"
+        args = node.args if isinstance(node, ast.Call) else []
+        if not args:
+            violations.append(f"{where}: sys.path assignment is not allowed in tests")
+            continue
+        try:
+            resolved = _eval_test_path(args[-1], path)
+        except _Unevaluatable:
+            violations.append(
+                f"{where}: sys.path entry is not statically provable "
+                "to resolve inside the repository"
+            )
+            continue
+        if repo_root not in (resolved, *resolved.parents):
+            violations.append(f"{where}: sys.path entry escapes repository -> {resolved}")
+    return violations
+
+
+def test_no_test_side_sys_path_escapes_repo() -> None:
+    """Every ``tests/`` sys.path entry must provably resolve inside the repo."""
+    repo_root = _repo_root()
+    violations: list[str] = []
+    for path in sorted((repo_root / "tests").rglob("*.py")):
+        violations.extend(_check_test_file(path, repo_root))
+    assert not violations, (
+        "test-side sys.path entries escaping the repository:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_sys_path_guard_rejects_sibling_checkout() -> None:
+    """The guard itself flags the removed ``agent-core`` pattern."""
+    repo_root = Path("/repo").resolve()
+    test_file = repo_root / "tests" / "unit_tests" / "test_example.py"
+    bad = ast.parse(
+        "import sys\n"
+        "from pathlib import Path\n"
+        '_R = Path(__file__).resolve().parents[3].parent / "agent-core"\n'
+        "sys.path.insert(0, str(_R))\n"
+    )
+    # A dynamic name cannot be proven to resolve in-repo, so it is flagged.
+    mutations = _sys_path_mutations(bad)
+    assert len(mutations) == 1
+    flagged = False
+    try:
+        _eval_test_path(mutations[0].args[-1], test_file)
+    except _Unevaluatable:
+        flagged = True
+    assert flagged, "dynamic sibling-checkout entry must not be provable"
+
+    good = ast.parse(
+        "import sys\n"
+        "from pathlib import Path\n"
+        "sys.path.insert(0, str(Path(__file__).resolve().parents[2]))\n"
+    )
+    good_mutations = _sys_path_mutations(good)
+    assert len(good_mutations) == 1
+    resolved = _eval_test_path(good_mutations[0].args[-1], test_file)
+    assert repo_root in (resolved, *resolved.parents)
+
+
+def test_no_agent_core_backed_sys_path_entries() -> None:
+    """No ``sys.path`` mutation may be backed by a sibling agent-core checkout.
+
+    Unlike the pure substring check this stays green for the guard itself:
+    only mutations whose own source segment references ``agent-core`` fail.
+    """
+    repo_root = _repo_root()
+    offenders = []
+    for path in sorted((repo_root / "tests").rglob("*.py")):
+        # utf-8-sig: some test modules carry a BOM.
+        source = path.read_text(encoding="utf-8-sig")
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        for node in _sys_path_mutations(tree):
+            segment = ast.get_source_segment(source, node) or ""
+            if "agent-core" in segment.replace("_", "-"):
+                lineno = getattr(node, "lineno", "?")
+                offenders.append(f"{path.relative_to(repo_root)}:{lineno}")
+    assert not offenders, (
+        "test modules still backing sys.path with a sibling agent-core "
+        f"checkout: {offenders}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(f"run with pytest: {Path(__file__).name}")


### PR DESCRIPTION
Paired: [GitHub #5628](https://github.com/openJiuwen-ai/jiuwenswarm/pull/5628) ↔ [GitCode !6527](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/6527)

Fixes #5473

## Root cause

Two unit-test modules prepended a sibling `agent-core` source checkout to
`sys.path[0]` at import time. The entries outlive the importing module for the
rest of the pytest session, and interpreters started via
`multiprocessing.get_context("spawn")` inherit `sys.path` without the parent's
imported module table — so a fresh child re-resolves `openjiuwen` from that
arbitrary checkout instead of the revision pinned in `pyproject.toml`. With an
older sibling checkout present this deterministically breaks
`tests/unit_tests/observability/test_trace_store.py::test_gateway_reader_sees_committed_wal_from_writer_process`
with `ModuleNotFoundError: No module named 'openjiuwen.core.kv_cache'`
(a collection-order dependency, not a flake). It also means a green run can
certify a local checkout users never install.

## Changes

- `tests/unit_tests/agentserver/test_goal_runtime_adapter.py:1-18` — deleted
  the `_AGENT_CORE_ROOT` / `sys.path.insert(0, ...)` block (8 lines); the
  required APIs are now imported directly from the pinned `openjiuwen`
  (`:8-10`). No `ImportError` fallback: a missing/broken API must fail loudly.
- `tests/unit_tests/agentserver/test_deep_adapter_empty_run_guard.py:11-17` —
  deleted the sibling-checkout `sys.path` block (9 lines); direct imports only.
- `tests/unit_tests/test_dependency_provenance.py:34,173,185,216` — new
  dependency-provenance guards: (1) the imported `openjiuwen` must resolve to
  the installed environment, never a sibling checkout; (2) every `tests/`
  `sys.path` mutation must statically prove it resolves inside this repo;
  (3) the guard flags the removed `agent-core` pattern; (4) no `sys.path`
  mutation may reference an `agent-core` backing checkout.

## Test evidence

- Full `pytest` could not run locally: the pinned `openjiuwen` dependency is
  git-hosted and uninstallable in this environment, and the venv has no
  `pytest` installed — so this is honestly partial verification.
- Ran the new guard module's real logic with a stdlib-only driver (module
  loaded from file, test functions invoked directly): all 3 runnable guards
  PASS — `test_no_test_side_sys_path_escapes_repo`,
  `test_sys_path_guard_rejects_sibling_checkout` (proves the guard flags the
  removed pattern), `test_no_agent_core_backed_sys_path_entries`.
- `test_openjiuwen_resolves_to_installed_environment` SKIPPED locally
  (`No module named 'openjiuwen'`); it will execute in CI where the pinned
  dependency is installed.
- `py_compile` passes on all three touched files.
- Remaining `sys.path` mutations under `tests/` resolve in-repo
  (`tests/system_tests/conftest.py:16`, `tests/auth/test_common.py:7`) or
  target a non-stdlib `runtime.sys` object, so the new repo-wide scan stays
  green.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #5473
<!-- /bot1-related-issues -->
