### PR TITLE
fix(ask-user): give each options anyOf branch its own items for Gemini

### DIFF
--- a/jiuwenswarm/agents/harness/common/rails/ask_user_rail.py
+++ b/jiuwenswarm/agents/harness/common/rails/ask_user_rail.py
@@ -74,6 +74,36 @@ def _is_saved_pending_tool_call(
 # Extended input schema
 # ---------------------------------------------------------------------------
 
+# Shared schema for one selectable option. Referenced from the parent `items`
+# and from every `anyOf` branch below so the copies cannot drift apart.
+_OPTION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "label": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Display text for this option (1-5 words).",
+        },
+        "description": {
+            "type": "string",
+            "description": "Explanation of what this option means.",
+        },
+        "preview": {
+            "type": "string",
+            "description": (
+                "Optional preview content rendered beside this option when "
+                "comparing concrete artifacts the user should visually compare "
+                "(e.g. ASCII mockups, code snippets). Markdown is supported; "
+                "use fenced code blocks for monospace mockups so alignment is "
+                "preserved. Only rendered for single-select questions; ignored "
+                "for multi-select."
+            ),
+        },
+    },
+    "required": ["label"],
+}
+
+
 _QUESTIONS_ITEM_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -93,36 +123,21 @@ _QUESTIONS_ITEM_SCHEMA: dict[str, Any] = {
             # （报错 "type should be defined in anyOf items instead of the parent
             # schema"）。语义不变：数组元素由 items 约束（object + required label），
             # 数量由 anyOf 约束（0 个，或 2-4 个）。
+            # Google Gemini（经 OpenRouter，issue #5514）则进一步要求：声明了
+            # `"type": "array"` 的每个 anyOf 分支必须自带 `items`
+            # （报错 "...options.any_of[i].items: missing field"），因此每个分支
+            # 都复用同一份 _OPTION_SCHEMA；parent 级 items 为兼容其他 provider 保留，
+            # 三处引用同一 dict，不会漂移。
             "anyOf": [
-                {"type": "array", "maxItems": 0},
-                {"type": "array", "minItems": 2, "maxItems": 4},
-            ],
-            "items": {
-                "type": "object",
-                "properties": {
-                    "label": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "Display text for this option (1-5 words).",
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Explanation of what this option means.",
-                    },
-                    "preview": {
-                        "type": "string",
-                        "description": (
-                            "Optional preview content rendered beside this option when "
-                            "comparing concrete artifacts the user should visually compare "
-                            "(e.g. ASCII mockups, code snippets). Markdown is supported; "
-                            "use fenced code blocks for monospace mockups so alignment is "
-                            "preserved. Only rendered for single-select questions; ignored "
-                            "for multi-select."
-                        ),
-                    },
+                {"type": "array", "maxItems": 0, "items": _OPTION_SCHEMA},
+                {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 4,
+                    "items": _OPTION_SCHEMA,
                 },
-                "required": ["label"],
-            },
+            ],
+            "items": _OPTION_SCHEMA,
         },
         "multi_select": {
             "type": "boolean",

--- a/tests/system_tests/test_structured_ask_user.py
+++ b/tests/system_tests/test_structured_ask_user.py
@@ -144,13 +144,24 @@ class TestStructuredAskUserToolSchema:
         options_schema = props["options"]
         # Moonshot/Kimi flavored schema：type 必须落在 anyOf 分支内，父级不得
         # 同置 type；数量约束（0 个或 2-4 个）由两个分支各自声明。
-        assert options_schema["anyOf"] == [
-            {"type": "array", "maxItems": 0},
-            {"type": "array", "minItems": 2, "maxItems": 4},
+        # Gemini（issue #5514）还要求每个 array 分支自带 items，否则报
+        # "...options.any_of[i].items: missing field"。
+        assert "type" not in options_schema
+        branches = options_schema["anyOf"]
+        assert [
+            (b.get("type"), b.get("minItems"), b.get("maxItems")) for b in branches
+        ] == [
+            ("array", None, 0),
+            ("array", 2, 4),
         ]
+        for branch in branches:
+            assert branch["items"]["type"] == "object"
+            assert branch["items"]["required"] == ["label"]
         option_schema = options_schema["items"]
         assert option_schema["required"] == ["label"]
         assert option_schema["properties"]["label"]["minLength"] == 1
+        # 三处引用同一 schema dict，避免漂移。
+        assert all(branch["items"] is option_schema for branch in branches)
 
     @staticmethod
     def test_tool_card_name_is_ask_user():


### PR DESCRIPTION
Paired: [GitHub #5629](https://github.com/openJiuwen-ai/jiuwenswarm/pull/5629) ↔ [GitCode !6525](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/6525)

Fixes #5514

## Root cause

The `ask_user` tool's `questions[].options` schema put `"type": "array"` into
each `anyOf` branch (to satisfy Moonshot/Kimi's validator, which rejects a
parent-level `type` next to `anyOf`) but left `items` only on the parent
schema. Google Gemini (via OpenRouter) requires every `anyOf` branch that
declares an array type to carry its own `items`, so every `ask_user` tool
declaration is rejected with:

```text
...properties[questions].items.properties[options].any_of[0].items: missing field.
...properties[questions].items.properties[options].any_of[1].items: missing field.
```

— surfacing as `BadRequestError: 400 ... INVALID_ARGUMENT` on Gemini 3.8 Flash.

## Changes

- `jiuwenswarm/agents/harness/common/rails/ask_user_rail.py:79` — extracted
  the option-object schema (object + `required: [label]`) into a shared
  `_OPTION_SCHEMA` dict.
- `jiuwenswarm/agents/harness/common/rails/ask_user_rail.py:131-140` — each
  `anyOf` branch (`maxItems: 0` and `minItems: 2, maxItems: 4`) now carries
  `"items": _OPTION_SCHEMA`, fixing the Gemini rejection. The parent-level
  `"items"` is kept (same shared dict) for providers that validate against
  the parent, and the parent still carries no `"type"`, preserving the Kimi
  constraint. Both `EXTENDED_INPUT_PARAMS_EN/CN` share the schema, so one
  change covers both languages.
- `tests/system_tests/test_structured_ask_user.py:129` —
  `test_questions_item_schema_structure` now asserts: no parent-level `type`,
  both branches are arrays with the `(0)` / `(2-4)` cardinality, every branch
  carries object `items` requiring `label`, and all three references are the
  identical dict (`is`) so they cannot drift.

## Test evidence

- Full `pytest` could not run locally: the pinned `openjiuwen` dependency is
  git-hosted and uninstallable in this environment (no `pytest` in the venv
  either) — so this is honestly partial verification; the updated system test
  will execute in CI.
- Ran a stdlib-only schema check (AST `literal_eval` of the module dicts):
  fixed tree PASS — 2 array branches each carry identical `items`, no parent
  `type`; the `HEAD` version was confirmed to fail exactly as the issue
  reports (branches without `items` → Gemini `any_of[0]/any_of[1].items:
  missing field`).
- `py_compile` passes on both touched files.
- Grepped the repo for other copies of this schema (frontend `anyOf` /
  `maxItems`, other `items` builders): the tool schema is defined in exactly
  one place, so no other file needs the same fix.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #5514
<!-- /bot1-related-issues -->
